### PR TITLE
chore: switch release workflow to manual trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main # Trigger on pushes to the main branch
+  workflow_dispatch: # Allows manual triggering
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -471,13 +471,14 @@ This project uses [semantic-release](https://github.com/semantic-release/semanti
 **How it works:**
 
 1.  **Commit Messages:** All commits merged into the `main` branch **must** follow the Conventional Commits specification.
-2.  **Automation:** The "Release" GitHub Actions workflow automatically runs `semantic-release` on pushes to `main`.
+2.  **Manual Trigger:** The "Release" GitHub Actions workflow can be triggered manually from the Actions tab when you're ready to create a new release.
 3.  **`semantic-release` Actions:** Determines version, updates `CHANGELOG.md` & `package.json`, commits, tags, publishes to npm, and creates a GitHub Release.
 
 **What you need to do:**
 
 - Use Conventional Commits.
-- Merge to `main`.
+- Merge changes to `main`.
+- Trigger a release manually when ready from the Actions tab in GitHub.
 
 **Automation handles:** Changelog, version bumps, tags, npm publish, GitHub releases.
 


### PR DESCRIPTION
This change modifies our release workflow to be manually triggered instead of automatically running on every merge to main. This allows us to batch multiple PRs together before creating a new release.

Changes:
- Renamed publish.yml to release.yml for consistency
- Changed workflow trigger from push to workflow_dispatch
- Updated README.md to reflect manual release process

This gives us more control over when releases are created, allowing us to merge multiple PRs before deciding to create a new release.