### PR TITLE
feat: increase default maxPages and centralize configuration constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ docs-cli scrape <library> <url> [options]
 - `-v, --version <string>`: The specific version to associate with the scraped documents.
   - Accepts full versions (`1.2.3`), pre-release versions (`1.2.3-beta.1`), or partial versions (`1`, `1.2` which are expanded to `1.0.0`, `1.2.0`).
   - If omitted, the documentation is indexed as **unversioned**.
-- `-p, --max-pages <number>`: Maximum pages to scrape (default: 100).
+- `-p, --max-pages <number>`: Maximum pages to scrape (default: 1000).
 - `-d, --max-depth <number>`: Maximum navigation depth (default: 3).
 - `-c, --max-concurrency <number>`: Maximum concurrent requests (default: 3).
 - `--ignore-errors`: Ignore errors during scraping (default: true).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 import "dotenv/config";
 import { Command } from "commander";
 import packageJson from "../package.json";
+import { DEFAULT_MAX_CONCURRENCY, DEFAULT_MAX_DEPTH, DEFAULT_MAX_PAGES } from "./config";
 import { PipelineManager } from "./pipeline/PipelineManager";
 import { FileFetcher, HttpFetcher } from "./scraper/fetcher";
 import { HtmlProcessor } from "./scraper/processor";
@@ -63,9 +64,21 @@ async function main() {
       .command("scrape <library> <url>") // Remove <version> as positional
       .description("Scrape and index documentation from a URL")
       .option("-v, --version <string>", "Version of the library (optional)") // Add optional version flag
-      .option("-p, --max-pages <number>", "Maximum pages to scrape", "100")
-      .option("-d, --max-depth <number>", "Maximum navigation depth", "3")
-      .option("-c, --max-concurrency <number>", "Maximum concurrent page requests", "3")
+      .option(
+        "-p, --max-pages <number>",
+        "Maximum pages to scrape",
+        DEFAULT_MAX_PAGES.toString(),
+      )
+      .option(
+        "-d, --max-depth <number>",
+        "Maximum navigation depth",
+        DEFAULT_MAX_DEPTH.toString(),
+      )
+      .option(
+        "-c, --max-concurrency <number>",
+        "Maximum concurrent page requests",
+        DEFAULT_MAX_CONCURRENCY.toString(),
+      )
       .option("--ignore-errors", "Ignore errors during scraping", true)
       .option(
         "--scope <scope>",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,12 @@
+/**
+ * Default configuration values for the scraping pipeline
+ */
+
+/** Maximum number of pages to scrape in a single job */
+export const DEFAULT_MAX_PAGES = 1000;
+
+/** Maximum navigation depth when crawling links */
+export const DEFAULT_MAX_DEPTH = 3;
+
+/** Maximum number of concurrent page requests */
+export const DEFAULT_MAX_CONCURRENCY = 3;

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -3,6 +3,7 @@ import "dotenv/config";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import { DEFAULT_MAX_DEPTH, DEFAULT_MAX_PAGES } from "../config";
 import { PipelineManager } from "../pipeline/PipelineManager";
 import { PipelineJobStatus } from "../pipeline/types";
 import { FileFetcher, HttpFetcher } from "../scraper/fetcher";
@@ -82,9 +83,13 @@ export async function startServer() {
         maxPages: z
           .number()
           .optional()
-          .default(100)
-          .describe("Maximum number of pages to scrape"),
-        maxDepth: z.number().optional().default(3).describe("Maximum navigation depth"),
+          .default(DEFAULT_MAX_PAGES)
+          .describe(`Maximum number of pages to scrape (default: ${DEFAULT_MAX_PAGES})`),
+        maxDepth: z
+          .number()
+          .optional()
+          .default(DEFAULT_MAX_DEPTH)
+          .describe(`Maximum navigation depth (default: ${DEFAULT_MAX_DEPTH})`),
         scope: z
           .enum(["subpages", "hostname", "domain"])
           .optional()

--- a/src/tools/ScrapeTool.test.ts
+++ b/src/tools/ScrapeTool.test.ts
@@ -141,6 +141,7 @@ describe("ScrapeTool", () => {
         followRedirects: true, // Default value
         maxPages: 50, // Overridden
         maxDepth: 2, // Overridden
+        maxConcurrency: 5, // Test override
         ignoreErrors: false, // Overridden
       },
     );

--- a/src/tools/ScrapeTool.ts
+++ b/src/tools/ScrapeTool.ts
@@ -1,12 +1,9 @@
 import * as semver from "semver";
+import { DEFAULT_MAX_CONCURRENCY, DEFAULT_MAX_DEPTH, DEFAULT_MAX_PAGES } from "../config";
 import type { PipelineManager } from "../pipeline/PipelineManager";
 import type { DocumentManagementService } from "../store/DocumentManagementService";
 import type { ProgressResponse } from "../types"; // Keep for options interface, though onProgress is removed from internal logic
 import { logger } from "../utils/logger";
-
-// Default values for scraping configuration
-const DEFAULT_MAX_PAGES = 1000;
-const DEFAULT_MAX_DEPTH = 3;
 
 export interface ScrapeToolOptions {
   library: string;
@@ -121,7 +118,7 @@ export class ScrapeTool {
       followRedirects: scraperOptions?.followRedirects ?? true,
       maxPages: scraperOptions?.maxPages ?? DEFAULT_MAX_PAGES,
       maxDepth: scraperOptions?.maxDepth ?? DEFAULT_MAX_DEPTH,
-      // maxConcurrency is handled by the manager itself now
+      maxConcurrency: scraperOptions?.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
       ignoreErrors: scraperOptions?.ignoreErrors ?? true,
     });
 

--- a/src/tools/ScrapeTool.ts
+++ b/src/tools/ScrapeTool.ts
@@ -4,6 +4,10 @@ import type { DocumentManagementService } from "../store/DocumentManagementServi
 import type { ProgressResponse } from "../types"; // Keep for options interface, though onProgress is removed from internal logic
 import { logger } from "../utils/logger";
 
+// Default values for scraping configuration
+const DEFAULT_MAX_PAGES = 1000;
+const DEFAULT_MAX_DEPTH = 3;
+
 export interface ScrapeToolOptions {
   library: string;
   version?: string | null; // Make version optional
@@ -115,8 +119,8 @@ export class ScrapeTool {
       version: internalVersion,
       scope: scraperOptions?.scope ?? "subpages",
       followRedirects: scraperOptions?.followRedirects ?? true,
-      maxPages: scraperOptions?.maxPages ?? 100,
-      maxDepth: scraperOptions?.maxDepth ?? 3,
+      maxPages: scraperOptions?.maxPages ?? DEFAULT_MAX_PAGES,
+      maxDepth: scraperOptions?.maxDepth ?? DEFAULT_MAX_DEPTH,
       // maxConcurrency is handled by the manager itself now
       ignoreErrors: scraperOptions?.ignoreErrors ?? true,
     });


### PR DESCRIPTION
This PR increases the default value for `maxPages` from 100 to 1000 to improve the out-of-the-box experience for users scraping larger documentation sites.

### Changes

- Create `config.ts` with shared configuration constants:
  ```typescript
  export const DEFAULT_MAX_PAGES = 1000;
  export const DEFAULT_MAX_DEPTH = 3;
  export const DEFAULT_MAX_CONCURRENCY = 3;
  ```
- Use these constants consistently across:
  - CLI configuration
  - ScrapeTool implementation
  - MCP server tool schema
- Update parameter descriptions to include default values
- Add proper documentation for these values in the README
- Fixed potential issue with maxConcurrency handling in ScrapeTool

Closes #43