### PR TITLE
fix: silence JSDOM virtual console output

### DIFF
--- a/src/scraper/middleware/components/HtmlDomParserMiddleware.ts
+++ b/src/scraper/middleware/components/HtmlDomParserMiddleware.ts
@@ -1,4 +1,5 @@
-import { type DOMWindow, JSDOM } from "jsdom";
+import type { DOMWindow } from "jsdom";
+import { createJSDOM } from "../../../utils/dom";
 import { logger } from "../../../utils/logger";
 import type { ContentProcessingContext, ContentProcessorMiddleware } from "../types";
 
@@ -26,7 +27,8 @@ export class HtmlDomParserMiddleware implements ContentProcessorMiddleware {
     let domWindow: DOMWindow | undefined;
     try {
       logger.debug(`Parsing HTML content from ${context.source}`);
-      domWindow = new JSDOM(htmlString, {
+      // Use createJSDOM factory
+      domWindow = createJSDOM(htmlString, {
         url: context.source, // Provide the source URL to JSDOM
         // Consider adding other JSDOM options if needed, e.g., runScripts: "dangerously"
       }).window;

--- a/src/scraper/middleware/components/HtmlJsExecutorMiddleware.ts
+++ b/src/scraper/middleware/components/HtmlJsExecutorMiddleware.ts
@@ -1,4 +1,4 @@
-import { JSDOM } from "jsdom";
+import { createJSDOM } from "../../../utils/dom"; // Replace JSDOM import with createJSDOM
 import { logger } from "../../../utils/logger";
 import type { FetchOptions, RawContent } from "../../fetcher/types";
 import { executeJsInSandbox } from "../../utils/sandbox";
@@ -145,7 +145,8 @@ export class HtmlJsExecutorMiddleware implements ContentProcessorMiddleware {
       context.content = result.finalHtml;
 
       // Optionally, update the DOM object as well for potential custom middleware use
-      context.dom = new JSDOM(result.finalHtml, {
+      // Use createJSDOM factory
+      context.dom = createJSDOM(result.finalHtml, {
         url: context.source,
       }).window;
 

--- a/src/scraper/middleware/components/HtmlMetadataExtractorMiddleware.test.ts
+++ b/src/scraper/middleware/components/HtmlMetadataExtractorMiddleware.test.ts
@@ -39,7 +39,7 @@ const createMockContext = (
     options: { ...createMockScraperOptions(source), ...options },
   };
   if (htmlContent && contentType.startsWith("text/html")) {
-    context.dom = new JSDOM(htmlContent).window;
+    context.dom = new JSDOM(htmlContent, { url: source }).window;
   }
   return context;
 };

--- a/src/scraper/middleware/components/HtmlPlaywrightMiddleware.ts
+++ b/src/scraper/middleware/components/HtmlPlaywrightMiddleware.ts
@@ -1,5 +1,5 @@
-import { JSDOM } from "jsdom";
 import { type Browser, type Page, chromium } from "playwright";
+import { createJSDOM } from "../../../utils/dom";
 import { logger } from "../../../utils/logger";
 import type { ContentProcessingContext, ContentProcessorMiddleware } from "../types";
 
@@ -113,7 +113,9 @@ export class HtmlPlaywrightMiddleware implements ContentProcessorMiddleware {
 
       try {
         logger.debug(`Parsing Playwright-rendered HTML with JSDOM for ${context.source}`);
-        const domWindow = new JSDOM(renderedHtml, {
+        // Remove manual VirtualConsole setup
+        // Use createJSDOM factory
+        const domWindow = createJSDOM(renderedHtml, {
           url: context.source, // Provide the source URL to JSDOM
         }).window;
 

--- a/src/scraper/utils/sandbox.ts
+++ b/src/scraper/utils/sandbox.ts
@@ -1,5 +1,6 @@
 import { createContext, runInContext } from "node:vm";
-import { type DOMWindow, JSDOM } from "jsdom";
+import type { JSDOM } from "jsdom";
+import { createJSDOM } from "../../utils/dom";
 import { logger } from "../../utils/logger";
 
 /**
@@ -44,8 +45,8 @@ export async function executeJsInSandbox(
 
   try {
     logger.debug(`Creating JSDOM sandbox for ${url}`);
-    // Create JSDOM instance *without* running scripts immediately
-    jsdom = new JSDOM(html, {
+    // Create JSDOM instance using the factory, which includes default virtualConsole
+    jsdom = createJSDOM(html, {
       url,
       runScripts: "outside-only", // We'll run scripts manually in the VM
       pretendToBeVisual: true, // Helps with some scripts expecting a visual environment

--- a/src/splitter/SemanticMarkdownSplitter.ts
+++ b/src/splitter/SemanticMarkdownSplitter.ts
@@ -5,6 +5,7 @@ import remarkHtml from "remark-html";
 import remarkParse from "remark-parse";
 import TurndownService from "turndown";
 import { unified } from "unified";
+import { createJSDOM } from "../utils/dom";
 import { logger } from "../utils/logger";
 import { fullTrim } from "../utils/string";
 import { ContentSplitterError, MinimumChunkSizeError } from "./errors";
@@ -335,7 +336,8 @@ export class SemanticMarkdownSplitter implements DocumentSplitter {
    * Parse HTML
    */
   private async parseHtml(html: string): Promise<Document> {
-    const { window } = new JSDOM(html);
+    // Use createJSDOM which includes default options like virtualConsole
+    const { window } = createJSDOM(html);
     return window.document;
   }
 }

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,0 +1,29 @@
+import { JSDOM, VirtualConsole } from "jsdom";
+import type { ConstructorOptions } from "jsdom";
+
+/**
+ * Creates a JSDOM instance with a pre-configured virtual console to suppress console noise.
+ * This utility simplifies the setup of JSDOM by providing a standard configuration.
+ *
+ * @param html - The HTML content to parse.
+ * @param options - Optional JSDOM configuration options. These will be merged with the default virtual console setup.
+ * @returns A JSDOM instance.
+ */
+export function createJSDOM(html: string, options?: ConstructorOptions): JSDOM {
+  const virtualConsole = new VirtualConsole();
+  // Suppress console output from JSDOM by default
+  virtualConsole.on("error", () => {});
+  virtualConsole.on("warn", () => {});
+  virtualConsole.on("info", () => {});
+  virtualConsole.on("debug", () => {});
+  virtualConsole.on("log", () => {}); // Also suppress regular logs
+
+  const defaultOptions: ConstructorOptions = {
+    virtualConsole,
+  };
+
+  // Merge provided options with defaults, letting provided options override
+  const finalOptions: ConstructorOptions = { ...defaultOptions, ...options };
+
+  return new JSDOM(html, finalOptions);
+}


### PR DESCRIPTION
Replaces direct JSDOM instantiation with a factory function that configures a silent virtual console by default.

Fixes #53