### PR TITLE
fix(scraper): replace domcontentloaded with load event in Playwright

### DIFF
--- a/src/scraper/middleware/components/HtmlPlaywrightMiddleware.ts
+++ b/src/scraper/middleware/components/HtmlPlaywrightMiddleware.ts
@@ -86,7 +86,7 @@ export class HtmlPlaywrightMiddleware implements ContentProcessorMiddleware {
       // Use 'domcontentloaded' as scripts might need the initial DOM structure
       // Use 'networkidle' if waiting for async data fetches is critical, but slower.
       await page.goto(context.source, {
-        waitUntil: "domcontentloaded",
+        waitUntil: "load",
       });
 
       // Optionally, add a small delay or wait for a specific element if needed


### PR DESCRIPTION
This PR addresses issue #62 by changing the Playwright wait condition from `domcontentloaded` to `load`.

Fixes #62