### PR TITLE
chore(docs): restructure README and ARCHITECTURE for clarity

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -304,6 +304,18 @@ This separation of concerns improves the modularity, maintainability, and testab
 - Formats results as MCP responses
 - Provides progress feedback through MCP protocol (Note: Currently reports job start via message, detailed progress TBD)
 
+The MCP server exposes the following tools:
+
+- `scrape_docs`: Starts a scraping job.
+- `search_docs`: Searches the indexed documentation.
+- `list_libraries`: Lists all indexed libraries.
+- `find_version`: Finds the best matching version for a library.
+- `remove_docs`: Removes indexed documents.
+- `fetch_url`: Fetches a single URL and converts to Markdown.
+- `list_jobs`: Lists active/completed jobs.
+- `get_job_info`: Retrieves the status and progress of a specific job.
+- `cancel_job`: Attempts to cancel a running or queued job.
+
 ### Progress Reporting
 
 The project uses a unified progress reporting system via callbacks managed by the `PipelineManager`. This design:
@@ -397,6 +409,24 @@ import { functionToMock } from "./dependency";
 ```
 
 This structure ensures that mocks are set up correctly before the modules that depend on them are imported and used in your tests.
+
+## Releasing
+
+This project uses [semantic-release](https://github.com/semantic-release/semantic-release) and [Conventional Commits](https://www.conventionalcommits.org/) to automate the release process.
+
+**How it works:**
+
+1.  **Commit Messages:** All commits merged into the `main` branch **must** follow the Conventional Commits specification.
+2.  **Manual Trigger:** The "Release" GitHub Actions workflow can be triggered manually from the Actions tab when you're ready to create a new release.
+3.  **`semantic-release` Actions:** Determines version, updates `CHANGELOG.md` & `package.json`, commits, tags, publishes to npm, and creates a GitHub Release.
+
+**What you need to do:**
+
+- Use Conventional Commits.
+- Merge changes to `main`.
+- Trigger a release manually when ready from the Actions tab in GitHub.
+
+**Automation handles:** Changelog, version bumps, tags, npm publish, GitHub releases.
 
 ## Future Considerations
 

--- a/README.md
+++ b/README.md
@@ -1,81 +1,50 @@
-# docs-mcp-server MCP Server
+# Docs MCP Server: Enhance Your AI Coding Assistant
 
-A MCP server for fetching and searching 3rd party package documentation.
+AI coding assistants often struggle with outdated documentation, leading to incorrect suggestions or hallucinated code examples. Verifying AI responses against specific library versions can be time-consuming and inefficient.
+
+The **Docs MCP Server** addresses these challenges by providing a personal, always-current knowledge base for your AI assistant. It acts as a bridge, connecting your LLM directly to the **latest official documentation** from thousands of software libraries.
+
+By grounding AI responses in accurate, version-aware context, the Docs MCP Server enables you to receive concise and relevant integration details and code snippets, improving the reliability and efficiency of LLM-assisted development.
+
+It's **free**, **open-source**, runs **locally** for privacy, and integrates seamlessly with your workflow via the Model Context Protocol (MCP).
+
+## Why Use the Docs MCP Server?
+
+LLM-assisted coding promises speed and efficiency, but often falls short due to:
+
+- 🌀 **Stale Knowledge:** LLMs train on snapshots of the internet, quickly falling behind new library releases and API changes.
+- 👻 **Code Hallucinations:** AI can invent plausible-looking code that is syntactically correct but functionally wrong or uses non-existent APIs.
+- ❓ **Version Ambiguity:** Generic answers rarely account for the specific version dependencies in _your_ project, leading to subtle bugs.
+- ⏳ **Verification Overhead:** Developers spend valuable time double-checking AI suggestions against official documentation.
+
+**The Docs MCP Server tackles these problems head-on by:**
+
+- ✅ **Providing Always Up-to-Date Context:** It fetches and indexes documentation _directly_ from official sources (websites, GitHub, npm, PyPI, local files) on demand.
+- 🎯 **Delivering Version-Specific Answers:** Search queries can target exact library versions, ensuring the information aligns with your project's dependencies.
+- 💡 **Reducing Hallucinations:** By grounding the LLM in real documentation, it provides accurate examples and integration details.
+- ⚡ **Boosting Productivity:** Get trustworthy answers faster, integrated directly into your AI assistant workflow.
 
 ## ✨ Key Features
 
-- 🌐 **Versatile Scraping:** Fetch documentation from diverse sources like websites, GitHub, npm, PyPI, or local files.
-- 🧠 **Intelligent Processing:** Automatically split content semantically and generate embeddings using your choice of models (OpenAI, Google Gemini, Azure OpenAI, AWS Bedrock, Ollama, and more).
-- 💾 **Optimized Storage:** Leverage SQLite with `sqlite-vec` for efficient vector storage and FTS5 for robust full-text search.
-- 🔍 **Powerful Hybrid Search:** Combine vector similarity and full-text search across different library versions for highly relevant results.
-- ⚙️ **Asynchronous Job Handling:** Manage scraping and indexing tasks efficiently with a background job queue and MCP/CLI tools.
-- 🐳 **Simple Deployment:** Get up and running quickly using Docker or npx.
-
-## Overview
-
-This project provides a Model Context Protocol (MCP) server designed to scrape, process, index, and search documentation for various software libraries and packages. It fetches content from specified URLs, splits it into meaningful chunks using semantic splitting techniques, generates vector embeddings using OpenAI, and stores the data in an SQLite database. The server utilizes `sqlite-vec` for efficient vector similarity search and FTS5 for full-text search capabilities, combining them for hybrid search results. It supports versioning, allowing documentation for different library versions (including unversioned content) to be stored and queried distinctly.
-
-The server exposes MCP tools for:
-
-- Starting a scraping job (`scrape_docs`): Returns a `jobId` immediately.
-- Checking job status (`get_job_status`): Retrieves the current status and progress of a specific job.
-- Listing active/completed jobs (`list_jobs`): Shows recent and ongoing jobs.
-- Cancelling a job (`cancel_job`): Attempts to stop a running or queued job.
-- Searching documentation (`search_docs`).
-- Listing indexed libraries (`list_libraries`).
-- Finding appropriate versions (`find_version`).
-- Removing indexed documents (`remove_docs`).
-- Fetching single URLs (`fetch_url`): Fetches a URL and returns its content as Markdown.
-
-## Configuration
-
-The following environment variables are supported to configure the embedding model behavior:
-
-### Embedding Model Configuration
-
-- `DOCS_MCP_EMBEDDING_MODEL`: **Optional.** Format: `provider:model_name` or just `model_name` (defaults to `text-embedding-3-small`). Supported providers and their required environment variables:
-
-  - `openai` (default): Uses OpenAI's embedding models
-
-    - `OPENAI_API_KEY`: **Required.** Your OpenAI API key
-    - `OPENAI_ORG_ID`: **Optional.** Your OpenAI Organization ID
-    - `OPENAI_API_BASE`: **Optional.** Custom base URL for OpenAI-compatible APIs (e.g., Ollama, Azure OpenAI)
-
-  - `vertex`: Uses Google Cloud Vertex AI embeddings
-
-    - `GOOGLE_APPLICATION_CREDENTIALS`: **Required.** Path to service account JSON key file
-
-  - `gemini`: Uses Google Generative AI (Gemini) embeddings
-
-    - `GOOGLE_API_KEY`: **Required.** Your Google API key
-
-  - `aws`: Uses AWS Bedrock embeddings
-
-    - `AWS_ACCESS_KEY_ID`: **Required.** AWS access key
-    - `AWS_SECRET_ACCESS_KEY`: **Required.** AWS secret key
-    - `AWS_REGION` or `BEDROCK_AWS_REGION`: **Required.** AWS region for Bedrock
-
-  - `microsoft`: Uses Azure OpenAI embeddings
-    - `AZURE_OPENAI_API_KEY`: **Required.** Azure OpenAI API key
-    - `AZURE_OPENAI_API_INSTANCE_NAME`: **Required.** Azure instance name
-    - `AZURE_OPENAI_API_DEPLOYMENT_NAME`: **Required.** Azure deployment name
-    - `AZURE_OPENAI_API_VERSION`: **Required.** Azure API version
-
-### Vector Dimensions
-
-The database schema uses a fixed dimension of 1536 for embedding vectors. Only models that produce vectors with dimension ≤ 1536 are supported, except for certain providers (like Gemini) that support dimension reduction.
-
-For OpenAI-compatible APIs (like Ollama), use the `openai` provider with `OPENAI_API_BASE` pointing to your endpoint.
-
-These variables can be set regardless of how you run the server (Docker, npx, or from source).
+- **Up-to-Date Knowledge:** Fetches the latest documentation directly from the source.
+- **Version-Aware Search:** Get answers relevant to specific library versions (e.g., `react@18.2.0` vs `react@17.0.0`).
+- **Accurate Snippets:** Reduces AI hallucinations by using context from official docs.
+- **Broad Source Compatibility:** Scrapes websites, GitHub repos, package manager sites (npm, PyPI), and even local file directories.
+- **Intelligent Processing:** Automatically chunks documentation semantically and generates embeddings.
+- **Flexible Embedding Models:** Supports OpenAI (incl. compatible APIs like Ollama), Google Gemini/Vertex AI, Azure OpenAI, AWS Bedrock, and more.
+- **Powerful Hybrid Search:** Combines vector similarity with full-text search for relevance.
+- **Local & Private:** Runs entirely on your machine, keeping your data and queries private.
+- **Free & Open Source:** Built for the community, by the community.
+- **Simple Deployment:** Easy setup via Docker or `npx`.
+- **Seamless Integration:** Works with MCP-compatible clients (like Claude, Cline, Roo).
 
 ## Running the MCP Server
 
-There are two ways to run the docs-mcp-server:
+Get up and running quickly!
 
-### Option 1: Using Docker (Recommended)
+### Option 1: Using Docker
 
-This is the recommended approach for most users. It's easy, straightforward, and doesn't require Node.js to be installed.
+This approach is easy, straightforward, and doesn't require Node.js to be installed.
 
 1. **Ensure Docker is installed and running.**
 2. **Configure your MCP settings:**
@@ -176,7 +145,7 @@ docker run -i --rm \
 
 ### Option 2: Using npx
 
-This approach is recommended when you need local file access (e.g., indexing documentation from your local file system). While this can also be achieved by mounting paths into a Docker container, using npx is simpler but requires a Node.js installation.
+This approach is useful when you need local file access (e.g., indexing documentation from your local file system). While this can also be achieved by mounting paths into a Docker container, using npx is simpler but requires a Node.js installation.
 
 1. **Ensure Node.js is installed.**
 2. **Configure your MCP settings:**
@@ -208,6 +177,8 @@ This approach is recommended when you need local file access (e.g., indexing doc
 
 You can use the CLI to manage documentation directly, either via Docker or npx. **Important: Use the same method (Docker or npx) for both the server and CLI to ensure access to the same indexed documentation.**
 
+Here's how to invoke the CLI:
+
 ### Using Docker CLI
 
 If you're running the server with Docker, use Docker for the CLI as well:
@@ -232,9 +203,60 @@ npx -y --package=@arabold/docs-mcp-server docs-cli <command> [options]
 
 The npx approach will use the default data directory on your system (typically in your home directory), ensuring consistency between server and CLI.
 
-(See "CLI Command Reference" below for available commands and options.)
+The main commands available are:
 
-### CLI Command Reference
+- `scrape`: Scrapes and indexes documentation from a URL.
+- `search`: Searches the indexed documentation.
+- `list`: Lists all indexed libraries.
+- `remove`: Removes indexed documentation.
+- `fetch-url`: Fetches a single URL and converts to Markdown.
+- `find-version`: Finds the best matching version for a library.
+
+See the [CLI Command Reference](#cli-command-reference) below for detailed command usage.
+
+## Configuration
+
+The following environment variables are supported to configure the embedding model behavior:
+
+### Embedding Model Configuration
+
+- `DOCS_MCP_EMBEDDING_MODEL`: **Optional.** Format: `provider:model_name` or just `model_name` (defaults to `text-embedding-3-small`). Supported providers and their required environment variables:
+
+  - `openai` (default): Uses OpenAI's embedding models
+
+    - `OPENAI_API_KEY`: **Required.** Your OpenAI API key
+    - `OPENAI_ORG_ID`: **Optional.** Your OpenAI Organization ID
+    - `OPENAI_API_BASE`: **Optional.** Custom base URL for OpenAI-compatible APIs (e.g., Ollama, Azure OpenAI)
+
+  - `vertex`: Uses Google Cloud Vertex AI embeddings
+
+    - `GOOGLE_APPLICATION_CREDENTIALS`: **Required.** Path to service account JSON key file
+
+  - `gemini`: Uses Google Generative AI (Gemini) embeddings
+
+    - `GOOGLE_API_KEY`: **Required.** Your Google API key
+
+  - `aws`: Uses AWS Bedrock embeddings
+
+    - `AWS_ACCESS_KEY_ID`: **Required.** AWS access key
+    - `AWS_SECRET_ACCESS_KEY`: **Required.** AWS secret key
+    - `AWS_REGION` or `BEDROCK_AWS_REGION`: **Required.** AWS region for Bedrock
+
+  - `microsoft`: Uses Azure OpenAI embeddings
+    - `AZURE_OPENAI_API_KEY`: **Required.** Azure OpenAI API key
+    - `AZURE_OPENAI_API_INSTANCE_NAME`: **Required.** Azure instance name
+    - `AZURE_OPENAI_API_DEPLOYMENT_NAME`: **Required.** Azure deployment name
+    - `AZURE_OPENAI_API_VERSION`: **Required.** Azure API version
+
+### Vector Dimensions
+
+The database schema uses a fixed dimension of 1536 for embedding vectors. Only models that produce vectors with dimension ≤ 1536 are supported, except for certain providers (like Gemini) that support dimension reduction.
+
+For OpenAI-compatible APIs (like Ollama), use the `openai` provider with `OPENAI_API_BASE` pointing to your endpoint.
+
+These variables can be set regardless of how you run the server (Docker, npx, or from source).
+
+## CLI Command Reference
 
 The `docs-cli` provides commands for managing the documentation index. Access it either via Docker (`docker run -v docs-mcp-data:/data ghcr.io/arabold/docs-mcp-server:latest docs-cli ...`) or `npx` (`npx -y --package=@arabold/docs-mcp-server docs-cli ...`).
 
@@ -390,39 +412,6 @@ This section covers running the server/CLI directly from the source code for dev
 
 This provides an isolated environment and exposes the server via HTTP endpoints.
 
-1.  **Clone the repository:**
-    ```bash
-    git clone https://github.com/arabold/docs-mcp-server.git # Replace with actual URL if different
-    cd docs-mcp-server
-    ```
-2.  **Create `.env` file:**
-    Copy the example and add your OpenAI key (see "Environment Setup" below).
-    ```bash
-    cp .env.example .env
-    # Edit .env and add your OPENAI_API_KEY
-    ```
-3.  **Build the Docker image:**
-    ```bash
-    docker build -t docs-mcp-server .
-    ```
-4.  **Run the Docker container:**
-
-    ```bash
-    # Option 1: Using a named volume (recommended)
-    # Docker automatically creates the volume 'docs-mcp-data' if it doesn't exist on first run.
-    docker run -i --env-file .env -v docs-mcp-data:/data --name docs-mcp-server docs-mcp-server
-
-    # Option 2: Mapping to a host directory
-    # docker run -i --env-file .env -v /path/on/your/host:/data --name docs-mcp-server docs-mcp-server
-    ```
-
-    - `-i`: Keep STDIN open even if not attached. This is crucial for interacting with the server over stdio.
-    - `--env-file .env`: Loads environment variables (like `OPENAI_API_KEY`) from your local `.env` file.
-    - `-v docs-mcp-data:/data` or `-v /path/on/your/host:/data`: **Crucial for persistence.** This mounts a Docker named volume (Docker creates `docs-mcp-data` automatically if needed) or a host directory to the `/data` directory inside the container. The `/data` directory is where the server stores its `documents.db` file (as configured by `DOCS_MCP_STORE_PATH` in the Dockerfile). This ensures your indexed documentation persists even if the container is stopped or removed.
-    - `--name docs-mcp-server`: Assigns a convenient name to the container.
-
-    The server inside the container now runs directly using Node.js and communicates over **stdio**.
-
 This method is useful for contributing to the project or running un-published versions.
 
 1.  **Clone the repository:**
@@ -479,7 +468,7 @@ This method is useful for contributing to the project or running un-published ve
    # DOCS_MCP_STORE_PATH=/path/to/your/desired/storage/directory
    ```
 
-### Debugging (from Source)
+### Testing (from Source)
 
 Since MCP servers communicate over stdio when run directly via Node.js, debugging can be challenging. We recommend using the [MCP Inspector](https://github.com/modelcontextprotocol/inspector), which is available as a package script after building:
 
@@ -488,24 +477,6 @@ npx @modelcontextprotocol/inspector node dist/server.js
 ```
 
 The Inspector will provide a URL to access debugging tools in your browser.
-
-### Releasing
-
-This project uses [semantic-release](https://github.com/semantic-release/semantic-release) and [Conventional Commits](https://www.conventionalcommits.org/) to automate the release process.
-
-**How it works:**
-
-1.  **Commit Messages:** All commits merged into the `main` branch **must** follow the Conventional Commits specification.
-2.  **Manual Trigger:** The "Release" GitHub Actions workflow can be triggered manually from the Actions tab when you're ready to create a new release.
-3.  **`semantic-release` Actions:** Determines version, updates `CHANGELOG.md` & `package.json`, commits, tags, publishes to npm, and creates a GitHub Release.
-
-**What you need to do:**
-
-- Use Conventional Commits.
-- Merge changes to `main`.
-- Trigger a release manually when ready from the Actions tab in GitHub.
-
-**Automation handles:** Changelog, version bumps, tags, npm publish, GitHub releases.
 
 ### Architecture
 


### PR DESCRIPTION
This PR restructures the README.md and ARCHITECTURE.md files for improved clarity for new users. Key changes include:

- Moved 'Running the MCP Server' section up in README.md.
- Adjusted wording for Docker/npx neutrality in README.md.
- Added a high-level 'Using the CLI' section with invocation examples and command overview in README.md.
- Renamed 'Debugging' to 'Testing' in README.md.
- Moved 'Releasing' section from README.md to ARCHITECTURE.md.
- Added a list of MCP tool names to ARCHITECTURE.md.
- Simplified the development setup instructions in README.md.