### PR TITLE
chore(mcpServer): improve no-results message for search tool

### DIFF
--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -133,7 +133,9 @@ ${r.content}\n`,
         );
 
         if (formattedResults.length === 0) {
-          return createResponse(`No results found for '${query}' in ${library}.`);
+          return createResponse(
+            `No results found for '${query}' in ${library}. Try to use a different or more general query.`,
+          );
         }
         return createResponse(
           `Search results for '${query}' in ${library}:


### PR DESCRIPTION
Improves the message shown when no search results are found, suggesting to use a different or more general query.

Closes #76.