### PR TITLE
Update DocumentStore.ts

### DIFF
--- a/src/store/DocumentStore.ts
+++ b/src/store/DocumentStore.ts
@@ -242,30 +242,30 @@ export class DocumentStore {
     return `"${escapedQuotes}"`;
   }
 
-  /**
-   * Initializes database connection and ensures readiness
-   */
-  async initialize(): Promise<void> {
-    try {
-      // 1. Apply migrations (must happen after connection, before schema/statements)
-      applyMigrations(this.db);
+/**
+ * Initializes database connection and ensures readiness
+ */
+async initialize(): Promise<void> {
+  try {
+    // 1. Load extensions first (moved before migrations)
+    sqliteVec.load(this.db);
 
-      // 2. Load extensions
-      sqliteVec.load(this.db);
+    // 2. Apply migrations (after extensions are loaded)
+    applyMigrations(this.db);
 
-      // 3. Initialize prepared statements (Schema creation is now handled by migrations)
-      this.prepareStatements();
+    // 3. Initialize prepared statements
+    this.prepareStatements();
 
-      // 4. Initialize embeddings client (await to catch errors)
-      await this.initializeEmbeddings();
-    } catch (error) {
-      // Re-throw StoreError directly, wrap others in ConnectionError
-      if (error instanceof StoreError) {
-        throw error;
-      }
-      throw new ConnectionError("Failed to initialize database connection", error);
+    // 4. Initialize embeddings client (await to catch errors)
+    await this.initializeEmbeddings();
+  } catch (error) {
+    // Re-throw StoreError directly, wrap others in ConnectionError
+    if (error instanceof StoreError) {
+      throw error;
     }
+    throw new ConnectionError("Failed to initialize database connection", error);
   }
+}
 
   /**
    * Gracefully closes database connections


### PR DESCRIPTION
fix: Load SQLite vector extension before migrations

This commit resolves the "no such module: vec0" error by reordering the 
initialization process in DocumentStore. The SQLite vector extension is now
loaded before applying migrations, ensuring the vec0 module is available
when referenced in migration scripts.

The error occurred because the 000-initial-schema.sql migration was trying
to use the vec0 module before it was loaded. By changing the initialization
sequence, we ensure proper extension availability during the migration process.