### PR TITLE
Fix: Load SQLite vector extension before applying migrations

### DIFF
--- a/src/store/DocumentStore.ts
+++ b/src/store/DocumentStore.ts
@@ -242,30 +242,30 @@ export class DocumentStore {
     return `"${escapedQuotes}"`;
   }
 
-  /**
-   * Initializes database connection and ensures readiness
-   */
-  async initialize(): Promise<void> {
-    try {
-      // 1. Apply migrations (must happen after connection, before schema/statements)
-      applyMigrations(this.db);
+/**
+ * Initializes database connection and ensures readiness
+ */
+async initialize(): Promise<void> {
+  try {
+    // 1. Load extensions first (moved before migrations)
+    sqliteVec.load(this.db);
 
-      // 2. Load extensions
-      sqliteVec.load(this.db);
+    // 2. Apply migrations (after extensions are loaded)
+    applyMigrations(this.db);
 
-      // 3. Initialize prepared statements (Schema creation is now handled by migrations)
-      this.prepareStatements();
+    // 3. Initialize prepared statements
+    this.prepareStatements();
 
-      // 4. Initialize embeddings client (await to catch errors)
-      await this.initializeEmbeddings();
-    } catch (error) {
-      // Re-throw StoreError directly, wrap others in ConnectionError
-      if (error instanceof StoreError) {
-        throw error;
-      }
-      throw new ConnectionError("Failed to initialize database connection", error);
+    // 4. Initialize embeddings client (await to catch errors)
+    await this.initializeEmbeddings();
+  } catch (error) {
+    // Re-throw StoreError directly, wrap others in ConnectionError
+    if (error instanceof StoreError) {
+      throw error;
     }
+    throw new ConnectionError("Failed to initialize database connection", error);
   }
+}
 
   /**
    * Gracefully closes database connections


### PR DESCRIPTION
## Issue Description
Fixes #82: When running the MCP server in Docker, it fails during startup with the error:
"Failed to apply migration: 000-initial-schema.sql - SqliteError: no such module: vec0"

This happens because the migration script tries to use the `vec0` SQLite module before it's loaded.

## Solution
Reordered the initialization sequence in `DocumentStore.initialize()` to load the SQLite vector extension before applying migrations, ensuring the `vec0` module is available when needed by the migration scripts.

## Changes Made
- Modified the `initialize()` method in `DocumentStore` class to load SQLite extensions before running migrations

## Testing Done
- Verified the server starts correctly without the "no such module: vec0" error
- Confirmed that document storage and retrieval functionality works as expected
![image](https://github.com/user-attachments/assets/0f28c2dd-4153-4f6e-add5-8cecb9d4e2e9)