### PR TITLE
fix(store): batch embedding creation to avoid token limit errors (closes #93)

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -36,3 +36,8 @@ export const FETCHER_BASE_DELAY = 1000;
 export const SPLITTER_MIN_CHUNK_SIZE = 500;
 export const SPLITTER_PREFERRED_CHUNK_SIZE = 1500;
 export const SPLITTER_MAX_CHUNK_SIZE = 5000;
+
+/**
+ * Maximum number of documents to process in a single batch for embeddings.
+ */
+export const EMBEDDING_BATCH_SIZE = 300;


### PR DESCRIPTION
This PR introduces a batch limit for embedding creation in DocumentStore to prevent token limit errors when processing large numbers of documents. The batch size is configurable via EMBEDDING_BATCH_SIZE in src/utils/config.ts. Closes #93.