### PR TITLE
fix(embeddings): handle colon in model name parsing (#89)

### DIFF
--- a/src/store/embeddings/EmbeddingFactory.ts
+++ b/src/store/embeddings/EmbeddingFactory.ts
@@ -58,7 +58,8 @@ export class ModelConfigurationError extends Error {
  */
 export function createEmbeddingModel(providerAndModel: string): Embeddings {
   // Parse provider and model name
-  const [providerOrModel, modelName] = providerAndModel.split(":");
+  const [providerOrModel, ...modelNameParts] = providerAndModel.split(":");
+  const modelName = modelNameParts.join(":");
   const provider = modelName ? (providerOrModel as EmbeddingProvider) : "openai";
   const model = modelName || providerOrModel;
 


### PR DESCRIPTION
This PR fixes an issue where model names containing a colon (`:`) were not parsed correctly in the embedding model factory. Now, the model name is properly reconstructed if it contains colons. Closes #89.