### PR TITLE
Display build version in UI title using __APP_VERSION__ from package.json

### DIFF
--- a/src/web/components/Layout.tsx
+++ b/src/web/components/Layout.tsx
@@ -5,14 +5,23 @@ import type { PropsWithChildren } from "@kitajs/html";
  */
 interface LayoutProps extends PropsWithChildren {
   title: string;
+  /** Optional version string to display next to the title. */
+  version?: string;
 }
+
+// Expose the build-time version constant for type safety
+declare const __APP_VERSION__: string | undefined;
 
 /**
  * Base HTML layout component for all pages.
  * Includes common head elements, header, and scripts.
- * @param props - Component props including title and children.
+ * @param props - Component props including title, version, and children.
  */
-const Layout = ({ title, children }: LayoutProps) => (
+const Layout = ({
+  title,
+  version = __APP_VERSION__,
+  children,
+}: LayoutProps) => (
   <html lang="en">
     <head>
       <meta charset="UTF-8" />
@@ -52,6 +61,15 @@ const Layout = ({ title, children }: LayoutProps) => (
         <header class="mb-4">
           <h1 class="text-3xl font-bold text-gray-900 dark:text-white">
             <a href="/">MCP Docs</a>
+            {version ? (
+              <span
+                safe
+                class="ml-2 text-base font-normal text-gray-500 dark:text-gray-400 align-baseline"
+                title={`Version ${version}`}
+              >
+                v{version}
+              </span>
+            ) : null}
           </h1>
         </header>
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,13 @@
 import { defineConfig } from "vitest/config";
 import path from 'path';
-import packageJson from './package.json'; // Import package.json to read dependencies
+import packageJson from "./package.json" assert { type: "json" };
 
 export default defineConfig({
   plugins: [
   ],
+  define: {
+    __APP_VERSION__: JSON.stringify(packageJson.version),
+  },
   resolve: {
     // Keep existing resolve extensions
     extensions: [".ts", ".tsx", ".js", ".jsx", ".json"],

--- a/vite.config.web.ts
+++ b/vite.config.web.ts
@@ -1,11 +1,15 @@
 import { defineConfig } from "vite";
 import path from "node:path";
 import tailwindcss from '@tailwindcss/vite'
+import packageJson from "./package.json" assert { type: "json" };
 
 // Vite configuration specifically for building frontend assets (CSS, JS)
 export default defineConfig({
   // No need for dts plugin for frontend assets
   plugins: [tailwindcss()],
+  define: {
+    __APP_VERSION__: JSON.stringify(packageJson.version),
+  },
   resolve: {
     // Keep existing resolve extensions
     extensions: [".ts", ".tsx", ".js", ".jsx", ".json"],


### PR DESCRIPTION
### Summary

- Injects __APP_VERSION__ at build time in both vite configs
- Layout component shows version next to title, aligned baseline
- Improves traceability and user awareness of deployed version

This PR adds the build version to the UI title, making it visible to users and maintainers.