### PR TITLE
fix(store): wrap migrations in immediate transaction with retries

### DIFF
--- a/src/store/applyMigrations.ts
+++ b/src/store/applyMigrations.ts
@@ -41,8 +41,8 @@ function getAppliedMigrations(db: Database): Set<string> {
  * @param db The better-sqlite3 database instance.
  * @throws {StoreError} If any migration fails.
  */
-export function applyMigrations(db: Database): void {
-  try {
+export async function applyMigrations(db: Database): Promise<void> {
+  const overallTransaction = db.transaction(() => {
     logger.debug("Applying database migrations...");
     ensureMigrationsTable(db);
     const appliedMigrations = getAppliedMigrations(db);
@@ -63,23 +63,20 @@ export function applyMigrations(db: Database): void {
         const filePath = path.join(MIGRATIONS_DIR, filename);
         const sql = fs.readFileSync(filePath, "utf8");
 
-        // Run migration within a transaction
-        const transaction = db.transaction(() => {
+        // Execute migration and record it directly within the overall transaction
+        // The nested transaction is removed.
+        try {
           db.exec(sql);
           const insertStmt = db.prepare(
             `INSERT INTO ${MIGRATIONS_TABLE} (id) VALUES (?)`,
           );
           insertStmt.run(filename);
-        });
-
-        try {
-          transaction();
           logger.debug(`Successfully applied migration: ${filename}`);
           appliedCount++;
         } catch (error) {
-          logger.error(`Failed to apply migration: ${filename} - ${error}`);
-          // Let the transaction implicitly rollback on error
-          throw new StoreError(`Migration failed: ${filename} - ${error}`);
+          logger.error(`❌ Failed to apply migration: ${filename} - ${error}`);
+          // Re-throw to ensure the overall transaction rolls back
+          throw new StoreError(`Migration failed: ${filename}`, error);
         }
       }
     }
@@ -89,11 +86,41 @@ export function applyMigrations(db: Database): void {
     } else {
       logger.debug("Database schema is up to date.");
     }
-  } catch (error) {
-    // Ensure StoreError is thrown for consistent handling
-    if (error instanceof StoreError) {
-      throw error;
+  });
+
+  let retries = 0;
+  const MAX_MIGRATION_RETRIES = 5;
+  const MIGRATION_RETRY_DELAY_MS = 300;
+
+  while (true) {
+    try {
+      // Start a single IMMEDIATE transaction for the entire migration process
+      overallTransaction.immediate(); // Execute the encompassing transaction
+      logger.debug(
+        "Migrations applied successfully or schema up to date after potential retries.",
+      );
+      break; // Success
+    } catch (error) {
+      // biome-ignore lint/suspicious/noExplicitAny: error can be any
+      if ((error as any)?.code === "SQLITE_BUSY" && retries < MAX_MIGRATION_RETRIES) {
+        retries++;
+        logger.warn(
+          `⚠️ Migrations busy (SQLITE_BUSY), retrying attempt ${retries}/${MAX_MIGRATION_RETRIES} in ${MIGRATION_RETRY_DELAY_MS}ms...`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, MIGRATION_RETRY_DELAY_MS));
+      } else {
+        // biome-ignore lint/suspicious/noExplicitAny: error can be any
+        if ((error as any)?.code === "SQLITE_BUSY") {
+          logger.error(
+            `❌ Migrations still busy after ${MAX_MIGRATION_RETRIES} retries. Giving up: ${error}`,
+          );
+        }
+        // Ensure StoreError is thrown for consistent handling
+        if (error instanceof StoreError) {
+          throw error;
+        }
+        throw new StoreError("Failed during migration process", error);
+      }
     }
-    throw new StoreError("Failed during migration process", error);
   }
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -41,3 +41,13 @@ export const SPLITTER_MAX_CHUNK_SIZE = 5000;
  * Maximum number of documents to process in a single batch for embeddings.
  */
 export const EMBEDDING_BATCH_SIZE = 100;
+
+/**
+ * Maximum number of retries for database migrations if busy.
+ */
+export const MIGRATION_MAX_RETRIES = 5;
+
+/**
+ * Delay in milliseconds between migration retry attempts.
+ */
+export const MIGRATION_RETRY_DELAY_MS = 300;


### PR DESCRIPTION
Resolves #108 by ensuring the entire migration process, including reading the current migration state, is wrapped in an IMMEDIATE database transaction. This provides atomicity and helps prevent race conditions if multiple application instances attempt to run migrations simultaneously.

Also implements an async retry mechanism for SQLITE_BUSY errors, allowing the migration to attempt acquiring a database lock multiple times with a delay.