### PR TITLE
feat(scraper/playwright): improve Playwright page loading reliability and test robustness (#116)

### DIFF
--- a/src/scraper/middleware/HtmlPlaywrightMiddleware.test.ts
+++ b/src/scraper/middleware/HtmlPlaywrightMiddleware.test.ts
@@ -159,16 +159,21 @@ describe("HtmlPlaywrightMiddleware", () => {
     const context = createPipelineTestContext(initialHtml, urlWithCreds);
     const next = vi.fn();
 
-    // Spy on Playwright's browser/page
+    // Spy on Playwright's browser/context/page
     const pageSpy = {
       route: vi.fn().mockResolvedValue(undefined),
       unroute: vi.fn().mockResolvedValue(undefined),
       goto: vi.fn().mockResolvedValue(undefined),
+      waitForSelector: vi.fn().mockResolvedValue(undefined), // <-- Add this line
       content: vi.fn().mockResolvedValue(initialHtml),
       close: vi.fn().mockResolvedValue(undefined),
     } as unknown as MockedObject<Page>;
-    const browserSpy = {
+    const contextSpy = {
       newPage: vi.fn().mockResolvedValue(pageSpy),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    const browserSpy = {
+      newContext: vi.fn().mockResolvedValue(contextSpy),
       isConnected: vi.fn().mockReturnValue(true),
       on: vi.fn(),
       close: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary

This PR improves the reliability of Playwright-based page loading in the web scraper middleware and tightens the associated unit tests.

### Key changes:
- Waits for the `body` selector after navigation to ensure the DOM is ready before extracting content, making scraping more robust for both authenticated and non-authenticated sites.
- Updates tests to mock `waitForSelector` and assert that no errors are added to `context.errors` in the credentialed URL scenario.

### Motivation
- Fixes navigation/content extraction issues seen on some authenticated sites.
- Ensures tests are robust and reflect real middleware behavior.

Refs #116

---

**Files changed:**
- `src/scraper/middleware/HtmlPlaywrightMiddleware.ts`
- `src/scraper/middleware/HtmlPlaywrightMiddleware.test.ts`

Please review and merge if all looks good!