### PR TITLE
chore(ci): install Playwright browsers only when needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,9 @@ jobs:
         run: npm ci
 
       - name: Install Playwright browsers
-        # FIXME: Why is this needed? Where does the version conflict come from?
-        run: ln -s /home/runner/.cache/ms-playwright/chromium-1161 /home/runner/.cache/ms-playwright/chromium-1169
+        run: npx playwright install --no-shell --with-deps chromium
 
       - name: Run tests
-        # run: npm run test
         run: npx vitest run
 
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,9 @@ COPY db            db
 
 # Install production dependencies only
 RUN npm ci --omit=dev
-# FIXME: Why is this needed? Where does the version conflict come from?
-RUN ln -s /root/.cache/ms-playwright/chromium-1161 /root/.cache/ms-playwright/chromium-1169
+
+# Install Playwright browsers (only if needed for runtime)
+RUN npx playwright install --no-shell --with-deps chromium
 
 # Copy built files from builder
 COPY --from=builder /app/dist ./dist

--- a/README.md
+++ b/README.md
@@ -403,6 +403,12 @@ This section covers running the server/CLI directly from the source code for dev
 
 ### Running from Source
 
+> **Note:** Playwright browsers are not installed automatically during `npm install`. If you need to run tests or use features that require Playwright, run:
+>
+> ```bash
+> npx playwright install --no-shell --with-deps chromium
+> ```
+
 This provides an isolated environment and exposes the server via HTTP endpoints.
 
 This method is useful for contributing to the project or running un-published versions.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:coverage": "vitest run --coverage",
     "lint": "biome check .",
     "format": "biome format . --write",
-    "postinstall": "npx playwright install --no-shell --with-deps chromium"
+    "postinstall": "echo 'Skipping Playwright browser install. See README.md for details.'"
   },
   "dependencies": {
     "@fastify/formbody": "^8.0.2",


### PR DESCRIPTION
- Install Playwright browsers only in test job and Docker build
- Remove unconditional install from postinstall script
- Add README note for local devs

This reduces CI/CD time and avoids unnecessary installs.