### PR TITLE
feat(ci): publish multi-arch Docker images (x86_64/amd64 and arm64) for Mac Silicon support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64 # Build for both x86_64 and arm64 (Mac Silicon)
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Once the Docs MCP Server is running, you can use the Web Interface to **add new 
 
 ## Alternative: Using Docker
 
+> **Note:** The published Docker images now support both x86_64 (amd64) and Mac Silicon (arm64) platforms.
+
 This approach is easy, straightforward, and doesn't require cloning the repository.
 
 1. **Ensure Docker is installed and running.**


### PR DESCRIPTION
Closes #127

- The release workflow now builds and pushes Docker images for both linux/amd64 and linux/arm64 platforms using Docker Buildx.
- Updated README to note support for both Intel and Apple Silicon Macs.

This enables native Docker usage on both Intel and Apple Silicon Macs via the published images.