### PR TITLE
feat(docker): use system Chromium instead of Playwright's bundled browser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,14 @@ COPY db            db
 # Install production dependencies only
 RUN npm ci --omit=dev
 
-# Install Playwright browsers (only if needed for runtime)
-RUN npx playwright install --no-shell --with-deps chromium
+# Install system Chromium and required dependencies
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends chromium \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/*
+
+# Set Playwright to use system Chromium
+ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
 
 # Copy built files from builder
 COPY --from=builder /app/dist ./dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,13 @@ RUN npm ci --omit=dev
 RUN apt-get update \
   && apt-get install -y --no-install-recommends chromium \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* /tmp/*
+  && rm -rf /var/lib/apt/lists/* /tmp/* \
+  && CHROMIUM_PATH=$(command -v chromium || command -v chromium-browser) \
+  && if [ -z "$CHROMIUM_PATH" ]; then echo "Chromium executable not found!" && exit 1; fi \
+  && if [ "$CHROMIUM_PATH" != "/usr/bin/chromium" ]; then echo "Unexpected Chromium path: $CHROMIUM_PATH" && exit 1; fi \
+  && echo "Chromium installed at $CHROMIUM_PATH"
 
-# Set Playwright to use system Chromium
+# Set Playwright to use system Chromium (hardcoded path, as ENV cannot use shell vars)
 ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
 
 # Copy built files from builder

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,9 +30,17 @@ import { getProjectRoot } from "./utils/paths";
 import { startWebServer, stopWebServer } from "./web/web";
 
 /**
- * Ensures that the Playwright browsers are installed.
+ * Ensures that the Playwright browsers are installed, unless a system Chromium path is set.
  */
 function ensurePlaywrightBrowsersInstalled(): void {
+  // If PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH is set, skip install
+  const chromiumEnvPath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+  if (chromiumEnvPath && existsSync(chromiumEnvPath)) {
+    logger.debug(
+      `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH is set to '${chromiumEnvPath}', skipping Playwright browser install.`,
+    );
+    return;
+  }
   try {
     // Dynamically require Playwright and check for Chromium browser
     // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/src/scraper/middleware/HtmlPlaywrightMiddleware.ts
+++ b/src/scraper/middleware/HtmlPlaywrightMiddleware.ts
@@ -23,10 +23,15 @@ export class HtmlPlaywrightMiddleware implements ContentProcessorMiddleware {
   private async ensureBrowser(): Promise<Browser> {
     if (!this.browser || !this.browser.isConnected()) {
       const launchArgs = process.env.PLAYWRIGHT_LAUNCH_ARGS?.split(" ") ?? [];
+      const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH || undefined;
       logger.debug(
         `Launching new Playwright browser instance (Chromium) with args: ${launchArgs.join(" ") || "none"}...`,
       );
-      this.browser = await chromium.launch({ channel: "chromium", args: launchArgs });
+      this.browser = await chromium.launch({
+        channel: "chromium",
+        args: launchArgs,
+        executablePath: executablePath,
+      });
       this.browser.on("disconnected", () => {
         logger.debug("Playwright browser instance disconnected.");
         this.browser = null;


### PR DESCRIPTION
Closes #124. This PR reduces the Docker image size by installing system Chromium via apt-get and configuring Playwright to use it via the PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH environment variable. The HtmlPlaywrightMiddleware now explicitly uses this path if set. This avoids downloading Playwright's own browser build and ensures a smaller, more efficient image.