### PR TITLE
Improve link resolution and redirect handling

### DIFF
--- a/src/scraper/fetcher/HttpFetcher.test.ts
+++ b/src/scraper/fetcher/HttpFetcher.test.ts
@@ -554,5 +554,24 @@ describe("HttpFetcher", () => {
         statusCode: 301,
       });
     });
+
+    it("should expose final redirect URL as source (canonical trailing slash + query)", async () => {
+      const fetcher = new HttpFetcher();
+      const original = "https://learn.microsoft.com/en-us/azure/bot-service";
+      const finalUrl = `${original}/?view=azure-bot-service-4.0`;
+
+      // Simulate axios response object after redirects (follow-redirects style)
+      mockedAxios.get.mockResolvedValue({
+        data: Buffer.from("<html><body>OK</body></html>", "utf-8"),
+        headers: { "content-type": "text/html" },
+        request: { res: { responseUrl: finalUrl } },
+        config: { url: finalUrl },
+      });
+
+      const result = await fetcher.fetch(original);
+
+      // Expected to FAIL before implementation change (currently returns original)
+      expect(result.source).toBe(finalUrl);
+    });
   });
 });

--- a/src/scraper/fetcher/HttpFetcher.ts
+++ b/src/scraper/fetcher/HttpFetcher.ts
@@ -83,12 +83,22 @@ export class HttpFetcher implements ContentFetcher {
           content = Buffer.from(response.data);
         }
 
+        // Determine the final effective URL after redirects (if any)
+        const finalUrl =
+          // Node follow-redirects style
+          response.request?.res?.responseUrl ||
+          // Some adapters may expose directly
+          response.request?.responseUrl ||
+          // Fallback to axios recorded config URL
+          response.config?.url ||
+          source;
+
         return {
           content,
           mimeType,
           charset,
           encoding: contentEncoding,
-          source: source,
+          source: finalUrl,
         } satisfies RawContent;
       } catch (error: unknown) {
         const axiosError = error as AxiosError;

--- a/src/scraper/middleware/HtmlLinkExtractorMiddleware.ts
+++ b/src/scraper/middleware/HtmlLinkExtractorMiddleware.ts
@@ -24,15 +24,60 @@ export class HtmlLinkExtractorMiddleware implements ContentProcessorMiddleware {
     }
 
     try {
+      // Determine effective document base (first <base href> if present)
+      let docBase = context.source;
+      try {
+        const baseEl = $("base[href]").first();
+        const rawBase = baseEl.attr("href");
+        if (rawBase && rawBase.trim() !== "") {
+          try {
+            const trimmed = rawBase.trim();
+            // Attempt to resolve candidate base against the document source.
+            const candidate = new URL(trimmed, context.source);
+            // Heuristic validation:
+            // Accept if:
+            //  - Starts with a valid scheme (e.g. https:, data:, etc.) OR
+            //  - Protocol-relative (//...) OR
+            //  - Root-relative (/...) OR
+            //  - Dot-relative (./ or ../...) OR
+            //  - Otherwise a plain relative path segment WITHOUT a suspicious leading colon
+            //
+            // Reject (fallback to original page URL) if the first character is a colon or
+            // there is a colon before any slash that does NOT form a valid scheme.
+            const hasScheme = /^[a-zA-Z][a-zA-Z0-9+.+-]*:/.test(trimmed);
+            const protocolRelative = trimmed.startsWith("//");
+            const firstSlash = trimmed.indexOf("/");
+            const firstColon = trimmed.indexOf(":");
+            const colonBeforeSlash =
+              firstColon !== -1 && (firstSlash === -1 || firstColon < firstSlash);
+            const suspiciousColon = colonBeforeSlash && !hasScheme && !protocolRelative;
+            if (suspiciousColon || trimmed.startsWith(":")) {
+              logger.debug(
+                `Ignoring suspicious <base href> value (colon misuse): ${rawBase}`,
+              );
+            } else {
+              // Accept candidate (valid scheme, protocol/root/dot relative, or plain relative segment)
+              docBase = candidate.href;
+            }
+          } catch {
+            logger.debug(`Ignoring invalid <base href> value: ${rawBase}`);
+          }
+        }
+      } catch {
+        // Ignore base parsing errors
+      }
+
       const linkElements = $("a[href]");
-      logger.debug(`Found ${linkElements.length} potential links in ${context.source}`);
+      logger.debug(
+        `Found ${linkElements.length} potential links in ${context.source} (base=${docBase})`,
+      );
 
       const extractedLinks: string[] = [];
       linkElements.each((_index, element) => {
         const href = $(element).attr("href");
         if (href && href.trim() !== "") {
           try {
-            const urlObj = new URL(href, context.source);
+            const urlObj = new URL(href, docBase);
             if (!["http:", "https:", "file:"].includes(urlObj.protocol)) {
               logger.debug(`Ignoring link with invalid protocol: ${href}`);
               return;

--- a/src/scraper/strategies/BaseScraperStrategy.ts
+++ b/src/scraper/strategies/BaseScraperStrategy.ts
@@ -26,6 +26,7 @@ export abstract class BaseScraperStrategy implements ScraperStrategy {
   protected pageCount = 0;
   protected totalDiscovered = 0; // Track total URLs discovered (unlimited)
   protected effectiveTotal = 0; // Track effective total (limited by maxPages)
+  protected canonicalBaseUrl?: URL; // Final URL after initial redirect (depth 0)
 
   abstract canHandle(url: string): boolean;
 
@@ -42,7 +43,7 @@ export abstract class BaseScraperStrategy implements ScraperStrategy {
   protected shouldProcessUrl(url: string, options: ScraperOptions): boolean {
     if (options.scope) {
       try {
-        const base = new URL(options.url);
+        const base = this.canonicalBaseUrl ?? new URL(options.url);
         const target = new URL(url);
         if (!isInScope(base, target, options.scope)) return false;
       } catch {
@@ -65,6 +66,7 @@ export abstract class BaseScraperStrategy implements ScraperStrategy {
   ): Promise<{
     document?: Document;
     links?: string[];
+    finalUrl?: string; // Effective fetched URL (post-redirect)
   }>;
 
   // Removed getProcessor method as processing is now handled by strategies using middleware pipelines
@@ -92,6 +94,28 @@ export abstract class BaseScraperStrategy implements ScraperStrategy {
         try {
           // Pass signal to processItem
           const result = await this.processItem(item, options, undefined, signal);
+          // If this is the root (depth 0) and we have a finalUrl differing from original, set canonicalBaseUrl
+          if (item.depth === 0 && !this.canonicalBaseUrl && result?.finalUrl) {
+            try {
+              const finalUrlStr = result.finalUrl as string;
+              const original = new URL(options.url);
+              const finalUrlObj = new URL(finalUrlStr);
+              if (
+                finalUrlObj.href !== original.href &&
+                (finalUrlObj.protocol === "http:" || finalUrlObj.protocol === "https:")
+              ) {
+                this.canonicalBaseUrl = finalUrlObj;
+                logger.info(
+                  `ℹ️  Updated scope base after redirect: ${original.href} -> ${finalUrlObj.href}`,
+                );
+              } else {
+                this.canonicalBaseUrl = original;
+              }
+            } catch {
+              // Ignore canonical base errors
+              this.canonicalBaseUrl = new URL(options.url);
+            }
+          }
 
           if (result.document) {
             this.pageCount++;
@@ -174,7 +198,8 @@ export abstract class BaseScraperStrategy implements ScraperStrategy {
     this.totalDiscovered = 1; // Start with the initial URL (unlimited counter)
     this.effectiveTotal = 1; // Start with the initial URL (limited counter)
 
-    const baseUrl = new URL(options.url);
+    this.canonicalBaseUrl = new URL(options.url);
+    let baseUrl = this.canonicalBaseUrl;
     const queue = [{ url: options.url, depth: 0 } satisfies QueueItem];
 
     // Track values we've seen (either queued or visited)
@@ -205,6 +230,8 @@ export abstract class BaseScraperStrategy implements ScraperStrategy {
 
       const batch = queue.splice(0, batchSize);
       // Pass signal to processBatch
+      // Always use latest canonical base (may have been updated after first fetch)
+      baseUrl = this.canonicalBaseUrl ?? baseUrl;
       const newUrls = await this.processBatch(
         batch,
         baseUrl,

--- a/src/scraper/utils/scope.ts
+++ b/src/scraper/utils/scope.ts
@@ -2,6 +2,24 @@
 import type { URL } from "node:url";
 
 /**
+ * Compute the effective base directory for scope=subpages.
+ * Rules:
+ * - If path ends with '/', treat as directory (keep as-is)
+ * - Else if last segment contains a dot, treat as file and use its parent directory
+ * - Else treat the path as a directory name (append '/')
+ */
+export function computeBaseDirectory(pathname: string): string {
+  if (pathname === "") return "/";
+  if (pathname.endsWith("/")) return pathname;
+  const lastSegment = pathname.split("/").pop() || "";
+  const looksLikeFile = lastSegment.includes(".");
+  if (looksLikeFile) {
+    return pathname.replace(/\/[^/]*$/, "/");
+  }
+  return `${pathname}/`;
+}
+
+/**
  * Returns true if the targetUrl is in scope of the baseUrl for the given scope.
  * - "subpages": same hostname, and target path starts with the parent directory of the base path
  * - "hostname": same hostname
@@ -13,19 +31,16 @@ export function isInScope(
   scope: "subpages" | "hostname" | "domain",
 ): boolean {
   if (baseUrl.protocol !== targetUrl.protocol) return false;
+
   switch (scope) {
     case "subpages": {
       if (baseUrl.hostname !== targetUrl.hostname) return false;
-      // Use the parent directory of the base path
-      const baseDir = baseUrl.pathname.endsWith("/")
-        ? baseUrl.pathname
-        : baseUrl.pathname.replace(/\/[^/]*$/, "/");
+      const baseDir = computeBaseDirectory(baseUrl.pathname);
       return targetUrl.pathname.startsWith(baseDir);
     }
     case "hostname":
       return baseUrl.hostname === targetUrl.hostname;
     case "domain": {
-      // Compare the last two segments of the hostname (e.g. example.com)
       const getDomain = (host: string) => host.split(".").slice(-2).join(".");
       return getDomain(baseUrl.hostname) === getDomain(targetUrl.hostname);
     }

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -204,5 +204,21 @@ describe("URL comparison utilities", () => {
       const targetUrl = new URL("https://example.com/docs/page"); // 'doc' vs 'docs'
       expect(isSubpath(baseUrl, targetUrl)).toBe(false);
     });
+
+    it("should treat non-file last segment without slash as directory", () => {
+      const baseUrl = new URL("https://example.com/api");
+      const inside = new URL("https://example.com/api/child/page.html");
+      const outside = new URL("https://example.com/apisibling/page.html");
+      expect(isSubpath(baseUrl, inside)).toBe(true);
+      expect(isSubpath(baseUrl, outside)).toBe(false);
+    });
+
+    it("should not misclassify when filename-like segment lacks dot", () => {
+      const baseUrl = new URL("https://example.com/api/v1");
+      const nested = new URL("https://example.com/api/v1/ref/page");
+      const sibling = new URL("https://example.com/api/v1ref/page");
+      expect(isSubpath(baseUrl, nested)).toBe(true);
+      expect(isSubpath(baseUrl, sibling)).toBe(false);
+    });
   });
 });

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -101,11 +101,9 @@ export function hasSameDomain(urlA: URL, urlB: URL): boolean {
  *          result = true
  */
 export function isSubpath(baseUrl: URL, targetUrl: URL): boolean {
-  // Normalize paths to ensure consistent comparison
   const basePath = baseUrl.pathname.endsWith("/")
     ? baseUrl.pathname
     : `${baseUrl.pathname}/`;
-
   return targetUrl.pathname.startsWith(basePath);
 }
 


### PR DESCRIPTION
Enhance link resolution by improving URL subpath detection, handling base tags, and ensuring proper link resolution after redirects. Simplify scope checking with shared utility functions and add tests for nested and upward links.