### PR TITLE
Implement complete library/version removal functionality

### DIFF
--- a/src/cli/commands/remove.ts
+++ b/src/cli/commands/remove.ts
@@ -30,12 +30,10 @@ export async function removeAction(
       }),
     );
 
-    console.log(
-      `✅ Successfully removed documents for ${library}${version ? `@${version}` : " (unversioned)"}.`,
-    );
+    console.log(`✅ Successfully removed ${library}${version ? `@${version}` : ""}.`);
   } catch (error) {
     console.error(
-      `❌ Failed to remove documents for ${library}${version ? `@${version}` : " (unversioned)"}:`,
+      `❌ Failed to remove ${library}${version ? `@${version}` : ""}:`,
       error instanceof Error ? error.message : String(error),
     );
     throw error;

--- a/src/store/DocumentManagementService.ts
+++ b/src/store/DocumentManagementService.ts
@@ -365,6 +365,33 @@ export class DocumentManagementService {
   }
 
   /**
+   * Completely removes a library version and all associated documents.
+   * Also removes the library if no other versions remain.
+   * @param library Library name
+   * @param version Version string (null/undefined for unversioned)
+   */
+  async removeVersion(library: string, version?: string | null): Promise<void> {
+    const normalizedVersion = this.normalizeVersion(version);
+    logger.info(`🗑️ Removing version: ${library}@${normalizedVersion || "[no version]"}`);
+
+    const result = await this.store.removeVersion(library, normalizedVersion, true);
+
+    logger.info(
+      `🗑️ Removed ${result.documentsDeleted} documents, version: ${result.versionDeleted}, library: ${result.libraryDeleted}`,
+    );
+
+    if (result.versionDeleted && result.libraryDeleted) {
+      logger.info(`✅ Completely removed library ${library} (was last version)`);
+    } else if (result.versionDeleted) {
+      logger.info(`✅ Removed version ${library}@${normalizedVersion || "[no version]"}`);
+    } else {
+      logger.warn(
+        `⚠️ Version ${library}@${normalizedVersion || "[no version]"} not found`,
+      );
+    }
+  }
+
+  /**
    * Adds a document to the store, splitting it into smaller chunks for better search results.
    * Uses SemanticMarkdownSplitter to maintain markdown structure and content types during splitting.
    * Preserves hierarchical structure of documents and distinguishes between text and code segments.

--- a/src/store/trpc/interfaces.ts
+++ b/src/store/trpc/interfaces.ts
@@ -30,6 +30,7 @@ export interface IDocumentManagement {
     limit?: number,
   ): Promise<StoreSearchResult[]>;
   removeAllDocuments(library: string, version?: string | null): Promise<void>;
+  removeVersion(library: string, version?: string | null): Promise<void>;
 
   // Minimal set used indirectly by pipeline/UI where needed
   getVersionsByStatus(statuses: VersionStatus[]): Promise<DbVersionWithLibrary[]>;

--- a/src/tools/RemoveTool.ts
+++ b/src/tools/RemoveTool.ts
@@ -24,15 +24,14 @@ export class RemoveTool {
   ) {}
 
   /**
-   * Executes the tool to remove the specified library version documents.
+   * Executes the tool to remove the specified library version completely.
    * Aborts any QUEUED/RUNNING job for the same library+version before deleting.
+   * Removes all documents, the version record, and the library if no other versions exist.
    */
   async execute(args: RemoveToolArgs): Promise<{ message: string }> {
     const { library, version } = args;
 
-    logger.info(
-      `🗑️ Removing library: ${library}${version ? `, version: ${version}` : " (unversioned)"}`,
-    );
+    logger.info(`🗑️ Removing library: ${library}${version ? `@${version}` : ""}`);
 
     try {
       // Abort any QUEUED or RUNNING job for this library+version
@@ -53,15 +52,16 @@ export class RemoveTool {
         // Wait for job to finish cancelling if running
         await this.pipeline.waitForJobCompletion(job.id);
       }
-      // Core logic: Call the document management service
-      await this.documentManagementService.removeAllDocuments(library, version);
 
-      const message = `Successfully removed documents for ${library}${version ? `@${version}` : " (unversioned)"}.`;
+      // Core logic: Call the document management service to remove the version completely
+      await this.documentManagementService.removeVersion(library, version);
+
+      const message = `Successfully removed ${library}${version ? `@${version}` : ""}.`;
       logger.info(`✅ ${message}`);
       // Return a simple success object, the McpServer will format the final response
       return { message };
     } catch (error) {
-      const errorMessage = `Failed to remove documents for ${library}${version ? `@${version}` : " (unversioned)"}: ${error instanceof Error ? error.message : String(error)}`;
+      const errorMessage = `Failed to remove ${library}${version ? `@${version}` : ""}: ${error instanceof Error ? error.message : String(error)}`;
       logger.error(`❌ Error removing library: ${errorMessage}`);
       // Re-throw the error for the McpServer to handle and format
       throw new ToolError(errorMessage, this.constructor.name);


### PR DESCRIPTION
Enhance the library management system by introducing a new `removeVersion` function that completely removes a library version along with all associated documents. This update ensures that if the last version of a library is removed, the library entry is also deleted, preventing orphaned entries in the database. The existing `removeAllDocuments` function remains unchanged to maintain backward compatibility.

Fixes #185