### PR TITLE
Improve error message for missing OPENAI_API_KEY

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -5,6 +5,7 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { IPipeline } from "../pipeline";
+import { ModelConfigurationError } from "../store/embeddings/EmbeddingFactory";
 import type { IDocumentManagement } from "../store/trpc/interfaces";
 import { analytics } from "../telemetry";
 import { logger } from "../utils/logger";
@@ -107,7 +108,19 @@ export async function runCli(): Promise<void> {
 
     await program.parseAsync(process.argv);
   } catch (error) {
-    logger.error(`❌ Error in CLI: ${error}`);
+    // Handle embedding configuration errors with helpful messages
+    if (error instanceof ModelConfigurationError) {
+      logger.error("❌ Missing API key for embedding provider");
+      logger.error(
+        "   Please set OPENAI_API_KEY or configure an alternative embedding model.",
+      );
+      logger.error(
+        "   See README.md for configuration options or run with --help for more details.",
+      );
+    } else {
+      logger.error(`❌ Error in CLI: ${error}`);
+    }
+
     if (!isShuttingDown) {
       isShuttingDown = true;
 

--- a/src/store/DocumentStore.ts
+++ b/src/store/DocumentStore.ts
@@ -8,6 +8,7 @@ import type { DocumentMetadata } from "../types";
 import { EMBEDDING_BATCH_CHARS, EMBEDDING_BATCH_SIZE } from "../utils/config";
 import { logger } from "../utils/logger";
 import { applyMigrations } from "./applyMigrations";
+import { ModelConfigurationError } from "./embeddings/EmbeddingFactory";
 import { ConnectionError, DimensionError, StoreError } from "./errors";
 import type { StoredScraperOptions } from "./types";
 import {
@@ -412,8 +413,8 @@ export class DocumentStore {
       // 4. Initialize embeddings client (await to catch errors)
       await this.initializeEmbeddings();
     } catch (error) {
-      // Re-throw StoreError directly, wrap others in ConnectionError
-      if (error instanceof StoreError) {
+      // Re-throw StoreError and ModelConfigurationError directly, wrap others in ConnectionError
+      if (error instanceof StoreError || error instanceof ModelConfigurationError) {
         throw error;
       }
       throw new ConnectionError("Failed to initialize database connection", error);

--- a/src/store/embeddings/EmbeddingFactory.test.ts
+++ b/src/store/embeddings/EmbeddingFactory.test.ts
@@ -55,6 +55,21 @@ describe("createEmbeddingModel", () => {
     });
   });
 
+  test("should throw ModelConfigurationError for OpenAI without OPENAI_API_KEY", () => {
+    vi.stubGlobal("process", {
+      env: {
+        // Missing OPENAI_API_KEY
+      },
+    });
+
+    expect(() => createEmbeddingModel("text-embedding-3-small")).toThrow(
+      ModelConfigurationError,
+    );
+    expect(() => createEmbeddingModel("openai:text-embedding-3-small")).toThrow(
+      ModelConfigurationError,
+    );
+  });
+
   test("should correctly parse model names containing colons or slashes", () => {
     const model = createEmbeddingModel(
       "openai:jeffh/intfloat-multilingual-e5-large-instruct:f16",

--- a/src/store/embeddings/EmbeddingFactory.ts
+++ b/src/store/embeddings/EmbeddingFactory.ts
@@ -68,6 +68,11 @@ export function createEmbeddingModel(providerAndModel: string): Embeddings {
 
   switch (provider) {
     case "openai": {
+      if (!process.env.OPENAI_API_KEY) {
+        throw new ModelConfigurationError(
+          "OPENAI_API_KEY environment variable is required for OpenAI embeddings",
+        );
+      }
       const config: Partial<OpenAIEmbeddingsParams> & { configuration?: ClientOptions } =
         {
           ...baseConfig,


### PR DESCRIPTION
Enhance error handling for missing OPENAI_API_KEY by introducing a more user-friendly message. The new message clearly states the requirement for an API key for the embedding provider and directs users to the README.md for configuration instructions. Additionally, it suggests using `--help` for further options. This change improves the onboarding experience and reduces confusion for users encountering this issue.

Fixes #188