### PR TITLE
Refactor FTS query normalization to handle advanced syntax and improve term splitting.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,7 @@ dist
 README.md
 ARCHITECTURE.md
 CHANGELOG.md
+
+server.pid
+docs-mcp-data
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ public/assets/
 !*.env.example
 *.code-workspace
 .tsbuildinfo
+/server.pid
+/docs-mcp-data/
+/.idea


### PR DESCRIPTION
Normalizes a user query string for use with SQLite FTS5 MATCH operator.

Behavior:
- If the user already uses FTS operators (AND/OR/NOT/NEAR), quotes, wildcards, or parentheses,
  we pass the query through as-is (assume they know what they want).
- Otherwise, we split on whitespace and join terms with OR so that multi-word queries
  match documents containing any of the terms (instead of forcing a phrase/AND match