### PR TITLE
Add host configuration for server binding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,9 +54,8 @@ ENV DOCS_MCP_STORE_PATH=/data
 # Define volumes
 VOLUME /data
 
-# Expose the ports the applications listen on
+# Expose the default port of the application
 EXPOSE 6280
-EXPOSE 6281
 
 # Set the command to run the application
 ENTRYPOINT ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Run a standalone server that includes both MCP endpoints and web interface in a 
      -v docs-mcp-data:/data \
      -p 6280:6280 \
      ghcr.io/arabold/docs-mcp-server:latest \
-     --protocol http --port 6280
+     --protocol http --host 0.0.0.0 --port 6280
    ```
 
    Replace `your-openai-api-key` with your actual OpenAI API key.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: ["worker", "--port", "8080"]
+    command: ["worker", "--host", "0.0.0.0", "--port", "8080"]
     container_name: docs-mcp-worker
     restart: unless-stopped
     env_file:
@@ -43,6 +43,8 @@ services:
         "mcp",
         "--protocol",
         "http",
+        "--host",
+        "0.0.0.0",
         "--port",
         "6280",
         "--server-url",
@@ -70,7 +72,16 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: ["web", "--port", "6281", "--server-url", "http://worker:8080/api"]
+    command:
+      [
+        "web",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "6281",
+        "--server-url",
+        "http://worker:8080/api",
+      ]
     container_name: docs-mcp-web
     restart: unless-stopped
     ports:

--- a/src/app/AppServer.test.ts
+++ b/src/app/AppServer.test.ts
@@ -93,6 +93,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: false,
         enableWorker: false,
         port: 3000,
+        host: "127.0.0.1",
         // externalWorkerUrl not provided
       };
 
@@ -114,6 +115,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: false,
         enableWorker: false,
         port: 3000,
+        host: "127.0.0.1",
         // externalWorkerUrl not provided
       };
 
@@ -135,6 +137,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: false,
         enableWorker: true,
         port: 3000,
+        host: "127.0.0.1",
       };
 
       const server = new AppServer(
@@ -153,6 +156,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: false,
         enableWorker: false,
         port: 3000,
+        host: "127.0.0.1",
         externalWorkerUrl: "http://external-worker:8080",
       };
 
@@ -172,6 +176,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: true,
         enableWorker: true,
         port: 3000,
+        host: "127.0.0.1",
       };
 
       const server = new AppServer(
@@ -192,6 +197,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: false,
         enableWorker: false,
         port: 3000,
+        host: "127.0.0.1",
       };
 
       const server = new AppServer(
@@ -217,6 +223,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: false,
         enableWorker: true, // Required for web interface
         port: 3000,
+        host: "127.0.0.1",
       };
 
       const server = new AppServer(
@@ -244,6 +251,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: false,
         enableWorker: true, // Required for MCP server
         port: 3000,
+        host: "127.0.0.1",
       };
 
       const server = new AppServer(
@@ -274,6 +282,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: true,
         enableWorker: false,
         port: 3000,
+        host: "127.0.0.1",
       };
 
       const server = new AppServer(
@@ -301,6 +310,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: true,
         enableWorker: true,
         port: 3000,
+        host: "127.0.0.1",
       };
 
       const server = new AppServer(
@@ -338,6 +348,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: false,
         enableWorker: true,
         port: 3000,
+        host: "127.0.0.1",
       };
 
       const server = new AppServer(
@@ -370,6 +381,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: true,
         enableWorker: false,
         port: 4000,
+        host: "0.0.0.0",
       };
 
       const server = new AppServer(
@@ -394,6 +406,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: true,
         enableWorker: true,
         port: 3000,
+        host: "127.0.0.1",
       };
 
       const server = new AppServer(
@@ -426,6 +439,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: false,
         enableWorker: false,
         port: 3000,
+        host: "127.0.0.1",
         externalWorkerUrl: "http://external-worker:8080",
       };
 
@@ -452,6 +466,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: true,
         enableWorker: false,
         port: 3000,
+        host: "127.0.0.1",
       };
 
       const server = new AppServer(
@@ -476,6 +491,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: true,
         enableWorker: true,
         port: 3000,
+        host: "127.0.0.1",
       };
 
       const server = new AppServer(
@@ -502,6 +518,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: true,
         enableWorker: false,
         port: 3000,
+        host: "127.0.0.1",
       };
 
       const server = new AppServer(
@@ -528,6 +545,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: false,
         enableWorker: true,
         port: 3000,
+        host: "127.0.0.1",
       };
 
       const server = new AppServer(
@@ -556,6 +574,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: true,
         enableWorker: false,
         port: 3000,
+        host: "127.0.0.1",
       };
 
       const server = new AppServer(
@@ -582,6 +601,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: false,
         enableWorker: true,
         port: 3000,
+        host: "127.0.0.1",
         externalWorkerUrl: "http://external-worker:8080", // This should be ignored
       };
 
@@ -610,6 +630,7 @@ describe("AppServer Behavior Tests", () => {
         enableApiServer: true,
         enableWorker: false,
         port: 65535, // Maximum valid port
+        host: "0.0.0.0",
       };
 
       const server = new AppServer(

--- a/src/app/AppServer.ts
+++ b/src/app/AppServer.ts
@@ -122,7 +122,7 @@ export class AppServer {
     try {
       const address = await this.server.listen({
         port: this.config.port,
-        host: "0.0.0.0",
+        host: this.config.host,
       });
 
       this.logStartupInfo(address);

--- a/src/app/AppServerConfig.ts
+++ b/src/app/AppServerConfig.ts
@@ -21,6 +21,9 @@ export interface AppServerConfig {
   /** Port to run the server on */
   port: number;
 
+  /** Host to bind the server to */
+  host: string;
+
   /** URL of external worker server (if using external worker instead of embedded) */
   externalWorkerUrl?: string;
 

--- a/src/cli/commands/default.ts
+++ b/src/cli/commands/default.ts
@@ -20,6 +20,7 @@ import {
   resolveEmbeddingContext,
   resolveProtocol,
   validateAuthConfig,
+  validateHost,
   validatePort,
   warnHttpUsage,
 } from "../utils";
@@ -43,6 +44,11 @@ export function createDefaultAction(program: Command): Command {
           })
           .default(CLI_DEFAULTS.HTTP_PORT.toString()),
       )
+      .addOption(
+        new Option("--host <host>", "Host to bind the server to")
+          .argParser(validateHost)
+          .default(CLI_DEFAULTS.HOST),
+      )
       .option("--resume", "Resume interrupted jobs on startup", false)
       .option("--no-resume", "Do not resume jobs on startup")
       .option(
@@ -65,6 +71,7 @@ export function createDefaultAction(program: Command): Command {
         async (options: {
           protocol: string;
           port: string;
+          host: string;
           resume: boolean;
           readOnly: boolean;
           authEnabled?: boolean;
@@ -79,6 +86,7 @@ export function createDefaultAction(program: Command): Command {
 
           logger.debug("No subcommand specified, starting unified server by default...");
           const port = validatePort(options.port);
+          const host = validateHost(options.host);
 
           // Parse and validate auth configuration
           const authConfig = parseAuthConfig({
@@ -131,6 +139,7 @@ export function createDefaultAction(program: Command): Command {
               enableApiServer: true, // Enable API (tRPC) in http mode
               enableWorker: true, // Always enable in-process worker for unified server
               port,
+              host,
               readOnly: options.readOnly,
               auth: authConfig,
               startupContext: {

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -20,6 +20,7 @@ import {
   resolveEmbeddingContext,
   resolveProtocol,
   validateAuthConfig,
+  validateHost,
   validatePort,
 } from "../utils";
 
@@ -43,6 +44,11 @@ export function createMcpCommand(program: Command): Command {
             return String(n);
           })
           .default(CLI_DEFAULTS.HTTP_PORT.toString()),
+      )
+      .addOption(
+        new Option("--host <host>", "Host to bind the MCP server to")
+          .argParser(validateHost)
+          .default(CLI_DEFAULTS.HOST),
       )
       .option(
         "--server-url <url>",
@@ -68,6 +74,7 @@ export function createMcpCommand(program: Command): Command {
         async (cmdOptions: {
           protocol: string;
           port: string;
+          host: string;
           serverUrl?: string;
           readOnly: boolean;
           authEnabled?: boolean;
@@ -75,6 +82,7 @@ export function createMcpCommand(program: Command): Command {
           authAudience?: string;
         }) => {
           const port = validatePort(cmdOptions.port);
+          const host = validateHost(cmdOptions.host);
           const serverUrl = cmdOptions.serverUrl;
           // Resolve protocol using same logic as default action
           const resolvedProtocol = resolveProtocol(cmdOptions.protocol);
@@ -146,6 +154,7 @@ export function createMcpCommand(program: Command): Command {
                 enableApiServer: false, // Never enable API in mcp command
                 enableWorker: !serverUrl,
                 port,
+                host,
                 externalWorkerUrl: serverUrl,
                 readOnly: cmdOptions.readOnly,
                 auth: authConfig,

--- a/src/cli/commands/web.ts
+++ b/src/cli/commands/web.ts
@@ -15,6 +15,7 @@ import {
   createAppServerConfig,
   createPipelineWithCallbacks,
   resolveEmbeddingContext,
+  validateHost,
   validatePort,
 } from "../utils";
 
@@ -33,12 +34,18 @@ export function createWebCommand(program: Command): Command {
         })
         .default(CLI_DEFAULTS.WEB_PORT.toString()),
     )
+    .addOption(
+      new Option("--host <host>", "Host to bind the web interface to")
+        .argParser(validateHost)
+        .default(CLI_DEFAULTS.HOST),
+    )
     .option(
       "--server-url <url>",
       "URL of external pipeline worker RPC (e.g., http://localhost:6280/api)",
     )
-    .action(async (cmdOptions: { port: string; serverUrl?: string }) => {
+    .action(async (cmdOptions: { port: string; host: string; serverUrl?: string }) => {
       const port = validatePort(cmdOptions.port);
+      const host = validateHost(cmdOptions.host);
       const serverUrl = cmdOptions.serverUrl;
 
       try {
@@ -72,6 +79,7 @@ export function createWebCommand(program: Command): Command {
           enableApiServer: false,
           enableWorker: !serverUrl,
           port,
+          host,
           externalWorkerUrl: serverUrl,
           startupContext: {
             cliCommand: "web",

--- a/src/cli/commands/worker.ts
+++ b/src/cli/commands/worker.ts
@@ -15,6 +15,7 @@ import {
   createPipelineWithCallbacks,
   ensurePlaywrightBrowsersInstalled,
   resolveEmbeddingContext,
+  validateHost,
   validatePort,
 } from "../utils";
 
@@ -33,10 +34,16 @@ export function createWorkerCommand(program: Command): Command {
         })
         .default("8080"),
     )
+    .addOption(
+      new Option("--host <host>", "Host to bind the worker API to")
+        .argParser(validateHost)
+        .default(CLI_DEFAULTS.HOST),
+    )
     .option("--resume", "Resume interrupted jobs on startup", true)
     .option("--no-resume", "Do not resume jobs on startup")
-    .action(async (cmdOptions: { port: string; resume: boolean }) => {
+    .action(async (cmdOptions: { port: string; host: string; resume: boolean }) => {
       const port = validatePort(cmdOptions.port);
+      const host = validateHost(cmdOptions.host);
 
       try {
         logger.info(`🚀 Starting external pipeline worker on port ${port}`);
@@ -62,6 +69,7 @@ export function createWorkerCommand(program: Command): Command {
           enableApiServer: true,
           enableWorker: true,
           port,
+          host,
           startupContext: {
             cliCommand: "worker",
           },

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -15,6 +15,7 @@ import {
   type EmbeddingModelConfig,
 } from "../store/embeddings/EmbeddingConfig";
 import {
+  DEFAULT_HOST,
   DEFAULT_HTTP_PORT,
   DEFAULT_MAX_CONCURRENCY,
   DEFAULT_PROTOCOL,
@@ -137,6 +138,24 @@ export function validatePort(portString: string): number {
 }
 
 /**
+ * Validates host string for basic format checking
+ */
+export function validateHost(hostString: string): string {
+  // Basic validation - allow IPv4, IPv6, and hostnames
+  const trimmed = hostString.trim();
+  if (!trimmed) {
+    throw new Error("❌ Host cannot be empty");
+  }
+
+  // Very basic format check - reject obviously invalid values
+  if (trimmed.includes(" ") || trimmed.includes("\t") || trimmed.includes("\n")) {
+    throw new Error("❌ Host cannot contain whitespace");
+  }
+
+  return trimmed;
+}
+
+/**
  * Creates a pipeline (local or client) and attaches default CLI callbacks.
  * This makes the side-effects explicit and keeps creation consistent.
  */
@@ -184,6 +203,7 @@ export function createAppServerConfig(options: {
   enableApiServer?: boolean;
   enableWorker?: boolean;
   port: number;
+  host: string;
   externalWorkerUrl?: string;
   readOnly?: boolean;
   auth?: AuthConfig;
@@ -199,6 +219,7 @@ export function createAppServerConfig(options: {
     enableApiServer: options.enableApiServer ?? false,
     enableWorker: options.enableWorker ?? true,
     port: options.port,
+    host: options.host,
     externalWorkerUrl: options.externalWorkerUrl,
     readOnly: options.readOnly ?? false,
     auth: options.auth,
@@ -233,6 +254,7 @@ export const CLI_DEFAULTS = {
   PROTOCOL: DEFAULT_PROTOCOL,
   HTTP_PORT: DEFAULT_HTTP_PORT,
   WEB_PORT: DEFAULT_WEB_PORT,
+  HOST: DEFAULT_HOST,
   MAX_CONCURRENCY: DEFAULT_MAX_CONCURRENCY,
   TELEMETRY: true,
 } as const;

--- a/src/scraper/ScraperRegistry.test.ts
+++ b/src/scraper/ScraperRegistry.test.ts
@@ -46,7 +46,7 @@ describe("ScraperRegistry", () => {
       const registry = new ScraperRegistry();
 
       // Spy on cleanup methods of all strategies
-      const strategies = registry["strategies"];
+      const strategies = registry.strategies;
       const cleanupSpies = strategies
         .map((strategy) => {
           if (strategy.cleanup) {
@@ -68,7 +68,7 @@ describe("ScraperRegistry", () => {
       const registry = new ScraperRegistry();
 
       // Mock one strategy to throw error during cleanup
-      const strategies = registry["strategies"];
+      const strategies = registry.strategies;
       const strategyWithCleanup = strategies.find((s) => s.cleanup);
       if (strategyWithCleanup?.cleanup) {
         vi.spyOn(strategyWithCleanup, "cleanup" as any).mockRejectedValue(

--- a/src/scraper/pipelines/HtmlPipeline.charset.test.ts
+++ b/src/scraper/pipelines/HtmlPipeline.charset.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RawContent } from "../fetcher/types";
 import { ScrapeMode } from "../types";
 import { HtmlPipeline } from "./HtmlPipeline";

--- a/src/scraper/pipelines/HtmlPipeline.test.ts
+++ b/src/scraper/pipelines/HtmlPipeline.test.ts
@@ -277,7 +277,7 @@ describe("HtmlPipeline", () => {
       const pipeline = new HtmlPipeline();
 
       // Spy on the closeBrowser method
-      const closeBrowserSpy = vi.spyOn(pipeline["playwrightMiddleware"], "closeBrowser");
+      const closeBrowserSpy = vi.spyOn(pipeline.playwrightMiddleware, "closeBrowser");
 
       await pipeline.close();
 
@@ -297,7 +297,7 @@ describe("HtmlPipeline", () => {
       const pipeline = new HtmlPipeline();
 
       // Mock closeBrowser to throw an error
-      vi.spyOn(pipeline["playwrightMiddleware"], "closeBrowser").mockRejectedValue(
+      vi.spyOn(pipeline.playwrightMiddleware, "closeBrowser").mockRejectedValue(
         new Error("Browser cleanup failed"),
       );
 

--- a/src/scraper/strategies/WebScraperStrategy.test.ts
+++ b/src/scraper/strategies/WebScraperStrategy.test.ts
@@ -866,14 +866,14 @@ describe("WebScraperStrategy", () => {
       const strategy = new WebScraperStrategy();
 
       // Spy on the close method of all pipelines
-      strategy["pipelines"].forEach((pipeline) => {
+      strategy.pipelines.forEach((pipeline) => {
         vi.spyOn(pipeline, "close");
       });
 
       await strategy.cleanup();
 
       // Verify close was called on all pipelines
-      strategy["pipelines"].forEach((pipeline) => {
+      strategy.pipelines.forEach((pipeline) => {
         expect(pipeline.close).toHaveBeenCalledOnce();
       });
     });
@@ -882,7 +882,7 @@ describe("WebScraperStrategy", () => {
       const strategy = new WebScraperStrategy();
 
       // Mock one pipeline to throw an error during cleanup
-      vi.spyOn(strategy["pipelines"][0], "close").mockRejectedValue(
+      vi.spyOn(strategy.pipelines[0], "close").mockRejectedValue(
         new Error("Pipeline cleanup failed"),
       );
 

--- a/src/store/DocumentManagementService.test.ts
+++ b/src/store/DocumentManagementService.test.ts
@@ -1292,7 +1292,7 @@ describe("DocumentManagementService", () => {
         });
 
         // Spy on pipeline close methods
-        const pipelines = service["pipelines"];
+        const pipelines = service.pipelines;
         const closeSpies = pipelines.map((pipeline) =>
           vi.spyOn(pipeline, "close").mockResolvedValue(),
         );
@@ -1315,7 +1315,7 @@ describe("DocumentManagementService", () => {
         });
 
         // Mock one pipeline to throw error during cleanup
-        const pipelines = service["pipelines"];
+        const pipelines = service.pipelines;
         vi.spyOn(pipelines[0], "close").mockRejectedValue(
           new Error("Pipeline cleanup failed"),
         );

--- a/src/tools/FetchUrlTool.test.ts
+++ b/src/tools/FetchUrlTool.test.ts
@@ -292,8 +292,8 @@ describe("FetchUrlTool", () => {
       });
 
       // Spy on pipeline close methods
-      const closeSpy1 = vi.spyOn(fetchUrlTool["pipelines"][0], "close");
-      const closeSpy2 = vi.spyOn(fetchUrlTool["pipelines"][1], "close");
+      const closeSpy1 = vi.spyOn(fetchUrlTool.pipelines[0], "close");
+      const closeSpy2 = vi.spyOn(fetchUrlTool.pipelines[1], "close");
 
       await fetchUrlTool.execute(options);
 
@@ -314,8 +314,8 @@ describe("FetchUrlTool", () => {
         .mockRejectedValue(new ScraperError("Fetch failed", true));
 
       // Spy on pipeline close methods
-      const closeSpy1 = vi.spyOn(fetchUrlTool["pipelines"][0], "close");
-      const closeSpy2 = vi.spyOn(fetchUrlTool["pipelines"][1], "close");
+      const closeSpy1 = vi.spyOn(fetchUrlTool.pipelines[0], "close");
+      const closeSpy2 = vi.spyOn(fetchUrlTool.pipelines[1], "close");
 
       // Expect error to be thrown
       await expect(fetchUrlTool.execute(options)).rejects.toThrow(ToolError);
@@ -339,7 +339,7 @@ describe("FetchUrlTool", () => {
       });
 
       // Mock one pipeline to throw error during cleanup
-      vi.spyOn(fetchUrlTool["pipelines"][0], "close").mockRejectedValue(
+      vi.spyOn(fetchUrlTool.pipelines[0], "close").mockRejectedValue(
         new Error("Pipeline cleanup failed"),
       );
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -20,6 +20,9 @@ export const DEFAULT_HTTP_PORT = 6280;
 /** Default port for the Web UI */
 export const DEFAULT_WEB_PORT = 6281;
 
+/** Default host for server binding */
+export const DEFAULT_HOST = "127.0.0.1";
+
 /**
  * Default timeout in milliseconds for page operations (e.g., Playwright waitForSelector).
  */


### PR DESCRIPTION
Introduce a host configuration option for server binding, allowing users to specify the host address for the application. Update the Dockerfile, application server, and CLI commands accordingly.