### PR TITLE
Fix auth enabling logic

### DIFF
--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -270,8 +270,8 @@ export function parseAuthConfig(options: {
 }): AuthConfig | undefined {
   // Check CLI flags first, then env vars, then defaults
   const enabled =
-    options.authEnabled ??
-    (process.env.DOCS_MCP_AUTH_ENABLED?.toLowerCase() === "true" || false);
+    options.authEnabled ||
+    process.env.DOCS_MCP_AUTH_ENABLED?.toLowerCase() === "true";
 
   if (!enabled) {
     return undefined;


### PR DESCRIPTION
Currently if `--auth-enabled` is not set, `DOCS_MCP_AUTH_ENABLED` is not checked at all because the default of the first option is set to false.
This change ensures both option and environment variable are checked, so the variable will be useful for enabling the auth without the CLI option.