### PR TITLE
Add Python language support to TreeSitter source code splitter

### DIFF
--- a/docs/source-code-splitter.md
+++ b/docs/source-code-splitter.md
@@ -352,6 +352,7 @@ graph TD
 - **Unsupported Languages**: Automatic delegation to TextDocumentSplitter
 - **Parse Errors**: Graceful fallback for malformed syntax
 - **Boundary Detection Failures**: Line-based processing for complex edge cases
+- **Large File Handling**: For files exceeding a universal 32KB limit in the underlying parser, the system provides graceful degradation. It performs a full semantic parse on the initial ~32KB and falls back to `TextDocumentSplitter` for the remainder of the file, ensuring that no content is lost
 
 ### Error Recovery
 
@@ -383,6 +384,12 @@ The tree-sitter implementation provides comprehensive support for web developmen
 - Generic type parameters
 - TSX (TypeScript + JSX)
 
+**Python:**
+
+- Classes, functions, and methods
+- `import` and `from...import` statements
+- Decorators and `async` functions
+
 ### Architecture for Extension
 
 The modular design supports future language additions through:
@@ -401,10 +408,10 @@ The modular design supports future language additions through:
 
 **Future Language Candidates:**
 
-- Python (classes, functions, indentation-aware parsing)
 - Java (packages, classes, methods)
 - C# (namespaces, classes, properties, methods)
 - Go (packages, structs, methods, functions)
+- Rust (modules, structs, impl blocks, functions)
 
 ## Integration with Pipeline System
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arabold/docs-mcp-server",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arabold/docs-mcp-server",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -52,6 +52,7 @@
         "sqlite-vec": "^0.1.7-alpha.2",
         "tree-sitter": "^0.21.1",
         "tree-sitter-javascript": "^0.23.1",
+        "tree-sitter-python": "^0.21.0",
         "tree-sitter-typescript": "^0.23.2",
         "turndown": "^7.2.0",
         "zod": "^4.0.14"
@@ -19359,6 +19360,31 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tree-sitter-python": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-python/-/tree-sitter-python-0.21.0.tgz",
+      "integrity": "sha512-IUKx7JcTVbByUx1iHGFS/QsIjx7pqwTMHL9bl/NGyhyyydbfNrpruo2C7W6V4KZrbkkCOlX8QVrCoGOFW5qecg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0",
+        "node-gyp-build": "^4.8.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-python/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/tree-sitter-typescript": {
       "version": "0.23.2",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "sqlite-vec": "^0.1.7-alpha.2",
     "tree-sitter": "^0.21.1",
     "tree-sitter-javascript": "^0.23.1",
+    "tree-sitter-python": "^0.21.0",
     "tree-sitter-typescript": "^0.23.2",
     "turndown": "^7.2.0",
     "zod": "^4.0.14"

--- a/src/splitter/treesitter/LanguageParserRegistry.test.ts
+++ b/src/splitter/treesitter/LanguageParserRegistry.test.ts
@@ -17,6 +17,10 @@ describe("LanguageParserRegistry", () => {
       expect(registry.getSupportedLanguages()).toContain("javascript");
     });
 
+    it("should initialize with Python parser", () => {
+      expect(registry.getSupportedLanguages()).toContain("python");
+    });
+
     it("should register JavaScript file extensions", () => {
       expect(registry.isExtensionSupported(".js")).toBe(true);
       expect(registry.isExtensionSupported(".jsx")).toBe(true);
@@ -24,11 +28,24 @@ describe("LanguageParserRegistry", () => {
       expect(registry.isExtensionSupported(".cjs")).toBe(true);
     });
 
+    it("should register Python file extensions", () => {
+      expect(registry.isExtensionSupported(".py")).toBe(true);
+      expect(registry.isExtensionSupported(".pyi")).toBe(true);
+      expect(registry.isExtensionSupported(".pyw")).toBe(true);
+    });
+
     it("should register JavaScript MIME types", () => {
       expect(registry.isMimeTypeSupported("text/javascript")).toBe(true);
       expect(registry.isMimeTypeSupported("application/javascript")).toBe(true);
       expect(registry.isMimeTypeSupported("text/jsx")).toBe(true);
       expect(registry.isMimeTypeSupported("application/jsx")).toBe(true);
+    });
+
+    it("should register Python MIME types", () => {
+      expect(registry.isMimeTypeSupported("text/python")).toBe(true);
+      expect(registry.isMimeTypeSupported("text/x-python")).toBe(true);
+      expect(registry.isMimeTypeSupported("application/python")).toBe(true);
+      expect(registry.isMimeTypeSupported("application/x-python")).toBe(true);
     });
   });
 
@@ -39,10 +56,22 @@ describe("LanguageParserRegistry", () => {
       expect(parser?.name).toBe("javascript");
     });
 
+    it("should find Python parser by language name", () => {
+      const parser = registry.getParser("python");
+      expect(parser).toBeDefined();
+      expect(parser?.name).toBe("python");
+    });
+
     it("should find parser by file extension", () => {
       const parser = registry.getParserByExtension(".js");
       expect(parser).toBeDefined();
       expect(parser?.name).toBe("javascript");
+    });
+
+    it("should find Python parser by file extension", () => {
+      const parser = registry.getParserByExtension(".py");
+      expect(parser).toBeDefined();
+      expect(parser?.name).toBe("python");
     });
 
     it("should find parser by MIME type", () => {
@@ -51,32 +80,43 @@ describe("LanguageParserRegistry", () => {
       expect(parser?.name).toBe("javascript");
     });
 
+    it("should find Python parser by MIME type", () => {
+      const parser = registry.getParserByMimeType("text/python");
+      expect(parser).toBeDefined();
+      expect(parser?.name).toBe("python");
+    });
+
     it("should handle case insensitive lookups", () => {
       expect(registry.getParserByExtension(".JS")).toBeDefined();
       expect(registry.getParserByMimeType("TEXT/JAVASCRIPT")).toBeDefined();
+      expect(registry.getParserByExtension(".PY")).toBeDefined();
+      expect(registry.getParserByMimeType("TEXT/PYTHON")).toBeDefined();
     });
 
     it("should return undefined for unsupported languages", () => {
-      expect(registry.getParser("python")).toBeUndefined();
-      expect(registry.getParserByExtension(".py")).toBeUndefined();
-      expect(registry.getParserByMimeType("text/python")).toBeUndefined();
+      expect(registry.getParser("ruby")).toBeUndefined();
+      expect(registry.getParserByExtension(".rb")).toBeUndefined();
+      expect(registry.getParserByMimeType("text/ruby")).toBeUndefined();
     });
   });
 
   describe("supported checks", () => {
     it("should correctly identify supported languages", () => {
       expect(registry.isLanguageSupported("javascript")).toBe(true);
-      expect(registry.isLanguageSupported("python")).toBe(false);
+      expect(registry.isLanguageSupported("python")).toBe(true);
+      expect(registry.isLanguageSupported("ruby")).toBe(false);
     });
 
     it("should correctly identify supported extensions", () => {
       expect(registry.isExtensionSupported(".js")).toBe(true);
-      expect(registry.isExtensionSupported(".py")).toBe(false);
+      expect(registry.isExtensionSupported(".py")).toBe(true);
+      expect(registry.isExtensionSupported(".rb")).toBe(false);
     });
 
     it("should correctly identify supported MIME types", () => {
       expect(registry.isMimeTypeSupported("text/javascript")).toBe(true);
-      expect(registry.isMimeTypeSupported("text/python")).toBe(false);
+      expect(registry.isMimeTypeSupported("text/python")).toBe(true);
+      expect(registry.isMimeTypeSupported("text/ruby")).toBe(false);
     });
   });
 

--- a/src/splitter/treesitter/LanguageParserRegistry.ts
+++ b/src/splitter/treesitter/LanguageParserRegistry.ts
@@ -5,6 +5,7 @@
  * based on file extensions and MIME types.
  */
 
+import { PythonParser } from "./parsers/PythonParser";
 import { TypeScriptParser } from "./parsers/TypeScriptParser";
 import type { LanguageParser } from "./parsers/types";
 
@@ -145,5 +146,9 @@ export class LanguageParserRegistry {
     for (const mt of jsMimes) {
       this.mimeTypeMap.set(mt.toLowerCase(), "javascript");
     }
+
+    // Register Python parser
+    const pythonParser = new PythonParser();
+    this.registerParser(pythonParser);
   }
 }

--- a/src/splitter/treesitter/parsers/PythonParser.test.ts
+++ b/src/splitter/treesitter/parsers/PythonParser.test.ts
@@ -1,0 +1,498 @@
+/**
+ * Tests for PythonParser - Python source code parsing and boundary extraction
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { PythonParser } from "./PythonParser";
+
+describe("PythonParser", () => {
+  let parser: PythonParser;
+
+  beforeEach(() => {
+    parser = new PythonParser();
+  });
+
+  describe("initialization", () => {
+    it("should have correct name and extensions", () => {
+      expect(parser.name).toBe("python");
+      expect(parser.fileExtensions).toContain(".py");
+      expect(parser.fileExtensions).toContain(".pyi");
+      expect(parser.fileExtensions).toContain(".pyw");
+    });
+
+    it("should have correct MIME types", () => {
+      expect(parser.mimeTypes).toContain("text/python");
+      expect(parser.mimeTypes).toContain("text/x-python");
+      expect(parser.mimeTypes).toContain("application/python");
+      expect(parser.mimeTypes).toContain("application/x-python");
+    });
+  });
+
+  describe("parsing", () => {
+    it("should parse simple Python code without errors", () => {
+      const code = `
+def hello():
+    return "world"
+
+class Calculator:
+    def add(self, a, b):
+        return a + b
+      `;
+
+      const result = parser.parse(code);
+      expect(result.tree).toBeDefined();
+      expect(result.hasErrors).toBe(false);
+      expect(result.errorNodes).toHaveLength(0);
+    });
+
+    it("should handle syntax errors gracefully", () => {
+      const invalidCode = `
+def hello(
+    return "world"
+      `;
+
+      const result = parser.parse(invalidCode);
+      expect(result.tree).toBeDefined();
+      expect(result.hasErrors).toBe(true);
+      expect(result.errorNodes.length).toBeGreaterThan(0);
+    });
+
+    it("should handle empty content", () => {
+      const result = parser.parse("");
+      expect(result.tree).toBeDefined();
+      expect(result.hasErrors).toBe(false);
+    });
+  });
+
+  describe("boundary extraction", () => {
+    it("should extract function boundaries", () => {
+      const code = `
+def calculate_sum(a, b):
+    """Calculate the sum of two numbers."""
+    return a + b
+
+async def async_function():
+    """An async function."""
+    return await some_operation()
+      `;
+
+      const result = parser.parse(code);
+      const boundaries = parser.extractBoundaries(result.tree, code);
+
+      expect(boundaries).toHaveLength(2);
+
+      const syncFunction = boundaries.find((b) => b.name === "calculate_sum");
+      expect(syncFunction).toBeDefined();
+      expect(syncFunction?.type).toBe("function");
+      expect(syncFunction?.boundaryType).toBe("content");
+
+      const asyncFunction = boundaries.find((b) => b.name === "async_function");
+      expect(asyncFunction).toBeDefined();
+      expect(asyncFunction?.type).toBe("function");
+      expect(asyncFunction?.boundaryType).toBe("content");
+    });
+
+    it("should extract class boundaries", () => {
+      const code = `
+class Calculator:
+    """A simple calculator class."""
+    
+    def __init__(self):
+        self.value = 0
+    
+    def add(self, number):
+        """Add a number to the current value."""
+        self.value += number
+        return self.value
+
+class AdvancedCalculator(Calculator):
+    """Advanced calculator with more operations."""
+    
+    def multiply(self, number):
+        self.value *= number
+        return self.value
+      `;
+
+      const result = parser.parse(code);
+      const boundaries = parser.extractBoundaries(result.tree, code);
+
+      // Should have 2 classes + their methods
+      const classes = boundaries.filter((b) => b.type === "class");
+      expect(classes).toHaveLength(2);
+
+      const calculatorClass = classes.find((c) => c.name === "Calculator");
+      expect(calculatorClass).toBeDefined();
+      expect(calculatorClass?.boundaryType).toBe("structural");
+
+      const advancedClass = classes.find((c) => c.name === "AdvancedCalculator");
+      expect(advancedClass).toBeDefined();
+      expect(advancedClass?.boundaryType).toBe("structural");
+
+      // Should also have methods
+      const methods = boundaries.filter((b) => b.type === "function");
+      expect(methods.length).toBeGreaterThan(0);
+    });
+
+    it("should extract import boundaries", () => {
+      const code = `
+import os
+import sys
+from typing import List, Dict
+from collections import defaultdict
+      `;
+
+      const result = parser.parse(code);
+      const boundaries = parser.extractBoundaries(result.tree, code);
+
+      expect(boundaries).toHaveLength(4);
+
+      const osImport = boundaries.find((b) => b.name === "import os");
+      expect(osImport).toBeDefined();
+      expect(osImport?.type).toBe("module");
+      expect(osImport?.boundaryType).toBe("structural");
+
+      const typingImport = boundaries.find((b) => b.name === "from typing");
+      expect(typingImport).toBeDefined();
+      expect(typingImport?.type).toBe("module");
+      expect(typingImport?.boundaryType).toBe("structural");
+    });
+
+    it("should handle nested functions correctly (suppress local helpers)", () => {
+      const code = `
+def outer_function():
+    """Outer function with nested helper."""
+    
+    def inner_helper():
+        """This should be suppressed as a local helper."""
+        return "helper"
+    
+    return inner_helper()
+
+def another_function():
+    """Another top-level function."""
+    return "another"
+      `;
+
+      const result = parser.parse(code);
+      const boundaries = parser.extractBoundaries(result.tree, code);
+
+      // Should only have the two top-level functions, not the inner helper
+      expect(boundaries).toHaveLength(2);
+      expect(boundaries.map((b) => b.name)).toEqual(
+        expect.arrayContaining(["outer_function", "another_function"]),
+      );
+      expect(boundaries.map((b) => b.name)).not.toContain("inner_helper");
+    });
+
+    it("should handle methods inside classes (not suppress them)", () => {
+      const code = `
+class MyClass:
+    """A class with methods."""
+    
+    def method1(self):
+        """First method."""
+        return 1
+    
+    def method2(self):
+        """Second method."""
+        def local_helper():
+            return "helper"
+        return local_helper()
+      `;
+
+      const result = parser.parse(code);
+      const boundaries = parser.extractBoundaries(result.tree, code);
+
+      // Should have class + 2 methods, but not the local helper
+      const classBoundary = boundaries.find((b) => b.name === "MyClass");
+      expect(classBoundary).toBeDefined();
+
+      const methods = boundaries.filter((b) => b.type === "function");
+      expect(methods).toHaveLength(2);
+      expect(methods.map((m) => m.name)).toEqual(
+        expect.arrayContaining(["method1", "method2"]),
+      );
+      expect(methods.map((m) => m.name)).not.toContain("local_helper");
+    });
+
+    it("should include preceding comments in boundary", () => {
+      const code = `
+# This is a comment before the function
+# Another comment line
+def documented_function():
+    """Function with both comments and docstring."""
+    return "value"
+      `;
+
+      const result = parser.parse(code);
+      const boundaries = parser.extractBoundaries(result.tree, code);
+
+      expect(boundaries).toHaveLength(1);
+      const func = boundaries[0];
+      expect(func.name).toBe("documented_function");
+
+      // The boundary should start at the first comment line
+      const lines = code.split("\n");
+      const commentLineIndex = lines.findIndex((line) =>
+        line.includes("This is a comment"),
+      );
+      expect(func.startLine).toBe(commentLineIndex + 1); // 1-indexed
+    });
+
+    it("should handle docstrings correctly", () => {
+      const code = `
+def function_with_docstring():
+    """
+    This is a multi-line docstring.
+    
+    It describes what the function does.
+    """
+    return "result"
+
+class ClassWithDocstring:
+    """
+    This is a class docstring.
+    """
+    
+    def method_with_docstring(self):
+        """Method docstring."""
+        pass
+      `;
+
+      const result = parser.parse(code);
+      const boundaries = parser.extractBoundaries(result.tree, code);
+
+      expect(boundaries.length).toBeGreaterThan(0);
+
+      // The docstring should be included in the function body naturally
+      // since we don't adjust boundaries for docstrings in Python
+      const func = boundaries.find((b) => b.name === "function_with_docstring");
+      expect(func).toBeDefined();
+      expect(func?.endLine).toBeGreaterThan(func?.startLine || 0);
+    });
+
+    it("should explicitly include docstrings within function boundaries", () => {
+      const code = `def calculate_area(radius):
+    """
+    Calculate the area of a circle.
+    
+    Args:
+        radius (float): The radius of the circle
+        
+    Returns:
+        float: The area of the circle
+    """
+    pi = 3.14159
+    return pi * radius * radius`;
+
+      const result = parser.parse(code);
+      const boundaries = parser.extractBoundaries(result.tree, code);
+
+      // Should have 1 function boundary (no import statement now)
+      expect(boundaries).toHaveLength(1);
+      const func = boundaries[0];
+      expect(func.name).toBe("calculate_area");
+
+      // Extract the actual boundary content to verify docstring inclusion
+      const lines = code.split("\n");
+      const boundaryContent = lines.slice(func.startLine - 1, func.endLine).join("\n");
+
+      // Boundary should include both the signature AND the docstring
+      expect(boundaryContent).toContain("def calculate_area(radius):");
+      expect(boundaryContent).toContain('"""');
+      expect(boundaryContent).toContain("Calculate the area of a circle");
+      expect(boundaryContent).toContain("Args:");
+      expect(boundaryContent).toContain("Returns:");
+      expect(boundaryContent).toContain("pi = 3.14159");
+      expect(boundaryContent).toContain("return pi * radius * radius");
+    });
+
+    it("should include docstrings in class boundaries", () => {
+      const code = `class DataProcessor:
+    """
+    A class for processing various types of data.
+    
+    This class provides methods for cleaning, transforming,
+    and analyzing data from different sources.
+    """
+    
+    def __init__(self, config):
+        """Initialize the processor with configuration."""
+        self.config = config`;
+
+      const result = parser.parse(code);
+      const boundaries = parser.extractBoundaries(result.tree, code);
+
+      // Should have class + constructor method
+      const classBoundary = boundaries.find((b) => b.name === "DataProcessor");
+      expect(classBoundary).toBeDefined();
+
+      // Extract class boundary content
+      const lines = code.split("\n");
+      const classBoundaryContent = lines
+        .slice(classBoundary!.startLine - 1, classBoundary!.endLine)
+        .join("\n");
+
+      // Class boundary should include the class docstring
+      expect(classBoundaryContent).toContain("class DataProcessor:");
+      expect(classBoundaryContent).toContain('"""');
+      expect(classBoundaryContent).toContain(
+        "A class for processing various types of data",
+      );
+      expect(classBoundaryContent).toContain("This class provides methods");
+
+      // Method should also have its docstring
+      const methodBoundary = boundaries.find((b) => b.name === "__init__");
+      expect(methodBoundary).toBeDefined();
+
+      const methodBoundaryContent = lines
+        .slice(methodBoundary!.startLine - 1, methodBoundary!.endLine)
+        .join("\n");
+      expect(methodBoundaryContent).toContain("def __init__(self, config):");
+      expect(methodBoundaryContent).toContain(
+        "Initialize the processor with configuration",
+      );
+    });
+
+    it("should handle empty functions and classes", () => {
+      const code = `
+def empty_function():
+    pass
+
+class EmptyClass:
+    pass
+      `;
+
+      const result = parser.parse(code);
+      const boundaries = parser.extractBoundaries(result.tree, code);
+
+      expect(boundaries).toHaveLength(2);
+
+      const func = boundaries.find((b) => b.name === "empty_function");
+      expect(func).toBeDefined();
+      expect(func?.type).toBe("function");
+
+      const cls = boundaries.find((b) => b.name === "EmptyClass");
+      expect(cls).toBeDefined();
+      expect(cls?.type).toBe("class");
+    });
+  });
+
+  describe("large file handling", () => {
+    it("should handle files larger than 32KB gracefully", () => {
+      // Generate a Python file larger than 32,767 characters
+      let largeCode = "# Large Python file test\n";
+      let functionCount = 1;
+
+      // Build content to exceed the limit
+      while (largeCode.length < 35000) {
+        largeCode += `
+def test_function_${functionCount}():
+    """Test function ${functionCount}."""
+    value = ${functionCount}
+    result = value * 2
+    print(f"Function {functionCount} result: {result}")
+    return result
+
+class TestClass${functionCount}:
+    """Test class ${functionCount}."""
+    
+    def __init__(self, value):
+        self.value = value
+    
+    def process(self):
+        return self.value * 10
+`;
+        functionCount++;
+      }
+
+      expect(largeCode.length).toBeGreaterThan(32767);
+
+      // Parser should not crash and should return a valid result
+      const result = parser.parse(largeCode);
+
+      // Should have a valid tree
+      expect(result.tree).toBeDefined();
+      expect(result.tree.rootNode).toBeDefined();
+
+      // Should flag errors due to truncation
+      expect(result.hasErrors).toBe(true);
+
+      // Should still be able to extract boundaries from the parsed portion
+      const boundaries = parser.extractBoundaries(result.tree, largeCode);
+
+      // Should find some boundaries from the beginning of the file
+      expect(boundaries.length).toBeGreaterThan(0);
+
+      // Should find early functions and classes
+      const boundaryNames = boundaries.map((b) => b.name);
+      expect(boundaryNames).toContain("test_function_1");
+      expect(boundaryNames).toContain("TestClass1");
+
+      // All boundaries should have valid line numbers
+      for (const boundary of boundaries) {
+        expect(boundary.startLine).toBeGreaterThan(0);
+        expect(boundary.endLine).toBeGreaterThan(0);
+        expect(boundary.endLine).toBeGreaterThanOrEqual(boundary.startLine);
+      }
+    });
+
+    it("should maintain perfect content reconstruction for large files", () => {
+      // Generate content just over the limit
+      let testCode = "import sys\nimport os\n";
+      let count = 1;
+
+      while (testCode.length < 35000) {
+        testCode += `def func_${count}():\n    return ${count}\n\n`;
+        count++;
+      }
+
+      const originalLength = testCode.length;
+      expect(originalLength).toBeGreaterThan(32767);
+
+      // Parse and extract boundaries
+      const result = parser.parse(testCode);
+      const boundaries = parser.extractBoundaries(result.tree, testCode);
+
+      // Verify we can reconstruct content from boundaries
+      // Even though parsing was truncated, boundary extraction should work with original content
+      expect(boundaries.length).toBeGreaterThan(0);
+
+      // Each boundary should reference valid portions of the original content
+      for (const boundary of boundaries) {
+        const boundaryContent = testCode.slice(boundary.startByte, boundary.endByte);
+        expect(boundaryContent.length).toBeGreaterThan(0);
+        expect(boundary.startByte).toBeGreaterThanOrEqual(0);
+        expect(boundary.endByte).toBeLessThanOrEqual(originalLength);
+        expect(boundary.endByte).toBeGreaterThan(boundary.startByte);
+      }
+    });
+  });
+
+  describe("structural nodes extraction", () => {
+    it("should extract structural nodes for compatibility", () => {
+      const code = `
+import os
+
+class Calculator:
+    def add(self, a, b):
+        return a + b
+
+def standalone_function():
+    return "hello"
+      `;
+
+      const result = parser.parse(code);
+      const nodes = parser.extractStructuralNodes(result.tree, code);
+
+      expect(nodes.length).toBeGreaterThan(0);
+
+      // Should include import, class, and functions
+      const nodeNames = nodes.map((n) => n.name);
+      expect(nodeNames).toContain("import os");
+      expect(nodeNames).toContain("Calculator");
+      expect(nodeNames).toContain("add");
+      expect(nodeNames).toContain("standalone_function");
+    });
+  });
+});

--- a/src/splitter/treesitter/parsers/PythonParser.ts
+++ b/src/splitter/treesitter/parsers/PythonParser.ts
@@ -1,0 +1,417 @@
+/**
+ * Python parser for tree-sitter based source code splitting.
+ *
+ * Goals:
+ *  - Semantic parsing of Python source code (.py files)
+ *  - Direct boundary extraction aligned with canonical ruleset
+ *  - Handle Python-specific docstrings (inside function/class bodies)
+ *  - Support for functions, classes, methods, and nested structures
+ */
+
+import Parser, { type SyntaxNode, type Tree } from "tree-sitter";
+import Python from "tree-sitter-python";
+import type { CodeBoundary, LanguageParser, ParseResult, StructuralNode } from "./types";
+import { StructuralNodeType, TREE_SITTER_SIZE_LIMIT } from "./types";
+
+/**
+ * Sets of node types we care about for Python.
+ */
+const STRUCTURAL_DECL_TYPES = new Set([
+  "class_definition",
+  "import_statement",
+  "import_from_statement",
+]);
+
+// Executable / content declarations we also emit
+const CONTENT_DECL_TYPES = new Set(["function_definition", "async_function_definition"]);
+
+/**
+ * Decide if node type is boundary-worthy (before suppression rules).
+ */
+function isCandidateBoundary(node: SyntaxNode): boolean {
+  return STRUCTURAL_DECL_TYPES.has(node.type) || CONTENT_DECL_TYPES.has(node.type);
+}
+
+/**
+ * Determine if a function-like node is a local helper (nested inside another function body),
+ * in which case we suppress emission (canonical ruleset).
+ */
+function isLocalHelper(node: SyntaxNode): boolean {
+  const functionLike = new Set(["function_definition", "async_function_definition"]);
+
+  let ancestor = node.parent;
+  while (ancestor) {
+    if (functionLike.has(ancestor.type)) {
+      // Current node is nested inside a function body -> local helper
+      return true;
+    }
+    // Stop climbing at structural containers where function declarations are allowed as direct members
+    if (ancestor.type === "class_definition" || ancestor.type === "module") {
+      break;
+    }
+    ancestor = ancestor.parent;
+  }
+  return false;
+}
+
+/**
+ * Extract Python docstring from function or class body.
+ * Python docstrings are string literals as the first statement in the body.
+ */
+function findDocumentationStart(
+  node: SyntaxNode,
+  source: string,
+): { startLine: number; startByte: number } {
+  let startByte = node.startIndex;
+  let startLine = node.startPosition.row + 1;
+
+  // For Python, look for docstring inside the function/class body
+  if (
+    node.type === "function_definition" ||
+    node.type === "async_function_definition" ||
+    node.type === "class_definition"
+  ) {
+    // Find the body (block) of the function/class
+    const body = node.childForFieldName("body");
+    if (body && body.type === "block") {
+      const firstChild = body.children.find((child) => child.type !== "newline");
+
+      // Check if first statement is a string (docstring)
+      if (firstChild && firstChild.type === "expression_statement") {
+        const expr = firstChild.childForFieldName("value") || firstChild.children[0];
+        if (expr && expr.type === "string") {
+          // We keep the function/class signature as the start, but we'll include
+          // the docstring in the content by not adjusting the boundaries here.
+          // The docstring will be naturally included in the function body.
+        }
+      }
+    }
+  }
+
+  // Look for preceding comments (Python uses # comments, not JSDoc)
+  const parent = node.parent;
+  if (!parent) {
+    return { startLine, startByte };
+  }
+
+  const siblings = parent.children;
+  const idx = siblings.indexOf(node);
+  if (idx === -1) {
+    return { startLine, startByte };
+  }
+
+  // Walk upward collecting contiguous comment block
+  let sawComment = false;
+  for (let i = idx - 1; i >= 0; i--) {
+    const s = siblings[i];
+    const text = source.slice(s.startIndex, s.endIndex);
+
+    if (s.type === "comment") {
+      sawComment = true;
+      startByte = s.startIndex;
+      startLine = s.startPosition.row + 1;
+      continue;
+    }
+
+    if (/^\s*$/.test(text)) {
+      if (sawComment) {
+        startByte = s.startIndex;
+        startLine = s.startPosition.row + 1;
+      }
+      continue;
+    }
+
+    // Hit non-comment code: stop
+    break;
+  }
+
+  return { startLine, startByte };
+}
+
+/**
+ * Name extraction for Python nodes.
+ */
+function extractName(node: SyntaxNode): string {
+  switch (node.type) {
+    case "function_definition":
+    case "async_function_definition":
+    case "class_definition": {
+      const nameNode = node.childForFieldName("name");
+      return nameNode?.text || `<anonymous_${node.type}>`;
+    }
+    case "import_statement": {
+      // Extract imported module names
+      const names: string[] = [];
+      const dotted_names = node.children.filter(
+        (c) => c.type === "dotted_name" || c.type === "identifier",
+      );
+      for (const name of dotted_names) {
+        names.push(name.text);
+      }
+      return names.length > 0 ? `import ${names.join(", ")}` : "import";
+    }
+    case "import_from_statement": {
+      const moduleNode = node.childForFieldName("module_name");
+      const moduleName = moduleNode?.text || "?";
+      return `from ${moduleName}`;
+    }
+    default:
+      return node.type;
+  }
+}
+
+/**
+ * Boundary classification mapping for Python.
+ */
+function classifyBoundaryKind(node: SyntaxNode): {
+  boundaryType: "structural" | "content";
+  simple: CodeBoundary["type"];
+} {
+  if (node.type === "class_definition") {
+    return { boundaryType: "structural", simple: "class" };
+  }
+  if (node.type === "import_statement" || node.type === "import_from_statement") {
+    return { boundaryType: "structural", simple: "module" };
+  }
+  if (node.type === "function_definition" || node.type === "async_function_definition") {
+    return { boundaryType: "content", simple: "function" };
+  }
+  return { boundaryType: "content", simple: "other" };
+}
+
+export class PythonParser implements LanguageParser {
+  readonly name = "python";
+  readonly fileExtensions = [".py", ".pyi", ".pyw"];
+  readonly mimeTypes = [
+    "text/python",
+    "text/x-python",
+    "application/python",
+    "application/x-python",
+  ];
+
+  private createParser(): Parser {
+    const parser = new Parser();
+    parser.setLanguage(Python as unknown);
+    return parser;
+  }
+
+  parse(source: string): ParseResult {
+    // Validate input
+    if (typeof source !== "string") {
+      throw new Error(`PythonParser expected string input, got ${typeof source}`);
+    }
+
+    if (source == null) {
+      throw new Error("PythonParser received null or undefined source");
+    }
+
+    // Handle tree-sitter size limit
+    if (source.length > TREE_SITTER_SIZE_LIMIT) {
+      // For files exceeding the limit, we truncate at a reasonable boundary and return a limited parse
+      // Try to find a good truncation point (end of line)
+      let truncatedSource = source.slice(0, TREE_SITTER_SIZE_LIMIT);
+      const lastNewline = truncatedSource.lastIndexOf("\n");
+      if (lastNewline > TREE_SITTER_SIZE_LIMIT * 0.9) {
+        // If we can find a newline in the last 10% of the limit, use that
+        truncatedSource = source.slice(0, lastNewline + 1);
+      }
+
+      try {
+        const parser = this.createParser();
+        const tree = parser.parse(truncatedSource);
+        const errorNodes: SyntaxNode[] = [];
+        this.collectErrorNodes(tree.rootNode, errorNodes);
+
+        return {
+          tree,
+          hasErrors: true, // Mark as having errors due to truncation
+          errorNodes,
+        };
+      } catch (error) {
+        throw new Error(
+          `Failed to parse truncated Python file (${truncatedSource.length} chars): ${(error as Error).message}`,
+        );
+      }
+    }
+
+    // Normal parsing for files within the size limit
+    try {
+      const parser = this.createParser();
+      const tree = parser.parse(source);
+      const errorNodes: SyntaxNode[] = [];
+      this.collectErrorNodes(tree.rootNode, errorNodes);
+
+      return {
+        tree,
+        hasErrors: errorNodes.length > 0,
+        errorNodes,
+      };
+    } catch (error) {
+      throw new Error(
+        `Failed to parse Python file (${source.length} chars): ${(error as Error).message}`,
+      );
+    }
+  }
+
+  private collectErrorNodes(node: SyntaxNode, acc: SyntaxNode[]): void {
+    if (node.hasError && node.type === "ERROR") {
+      acc.push(node);
+    }
+    for (const c of node.children) {
+      this.collectErrorNodes(c, acc);
+    }
+  }
+
+  getNodeText(node: SyntaxNode, source: string): string {
+    return source.slice(node.startIndex, node.endIndex);
+  }
+
+  getNodeLines(node: SyntaxNode, _source: string) {
+    return {
+      startLine: node.startPosition.row + 1,
+      endLine: node.endPosition.row + 1,
+    };
+  }
+
+  /**
+   * Legacy structural node extraction (used by existing tests).
+   * Produces a flat list (no parent/child linking beyond simple push).
+   */
+  extractStructuralNodes(tree: Tree, source?: string): StructuralNode[] {
+    const src = source ?? tree.rootNode.text;
+    const out: StructuralNode[] = [];
+    const structuralTypes = new Set<string>([
+      ...STRUCTURAL_DECL_TYPES,
+      ...CONTENT_DECL_TYPES,
+    ]);
+
+    const visit = (node: SyntaxNode): void => {
+      if (structuralTypes.has(node.type)) {
+        if (this.shouldSkipStructuralNode(node)) {
+          for (const child of node.children) visit(child);
+          return;
+        }
+
+        const name = extractName(node);
+        const { startLine, startByte } = findDocumentationStart(node, src);
+        const endLine = node.endPosition.row + 1;
+        const structuralNode: StructuralNode = {
+          type: this.classifyStructuralNode(node),
+          name,
+          startLine,
+          endLine,
+          startByte,
+          endByte: node.endIndex,
+          children: [],
+          text: this.getNodeText(node, src),
+          indentLevel: 0,
+          modifiers: [],
+          documentation: undefined,
+        };
+        out.push(structuralNode);
+        // Continue into children (we keep nested declarations; suppression handled separately)
+        for (const child of node.children) visit(child);
+        return;
+      }
+      for (const child of node.children) visit(child);
+    };
+
+    visit(tree.rootNode);
+    return this.deduplicate(out);
+  }
+
+  /**
+   * Boundary extraction: produces CodeBoundary[] directly from AST.
+   */
+  extractBoundaries(tree: Tree, source: string): CodeBoundary[] {
+    if (!source.trim()) return [];
+    const boundaries: CodeBoundary[] = [];
+
+    const walk = (node: SyntaxNode): void => {
+      if (isCandidateBoundary(node)) {
+        if (this.shouldSkipStructuralNode(node)) {
+          for (const c of node.children) walk(c);
+          return;
+        }
+
+        // Local helper suppression
+        if (
+          (node.type === "function_definition" ||
+            node.type === "async_function_definition") &&
+          isLocalHelper(node)
+        ) {
+          // Do not emit boundary for local helper
+          for (const c of node.children) walk(c);
+          return;
+        }
+
+        const name = extractName(node);
+        const docInfo = findDocumentationStart(node, source);
+        const classification = classifyBoundaryKind(node);
+
+        boundaries.push({
+          type: classification.simple,
+          boundaryType: classification.boundaryType,
+          name,
+          startLine: docInfo.startLine,
+          endLine: node.endPosition.row + 1,
+          startByte: docInfo.startByte,
+          endByte: node.endIndex,
+        });
+
+        // Traverse children (we allow nested boundaries where rules permit)
+        for (const c of node.children) walk(c);
+        return;
+      }
+
+      for (const c of node.children) walk(c);
+    };
+
+    walk(tree.rootNode);
+
+    // Deduplicate by start/end/name triple
+    const seen = new Set<string>();
+    return boundaries.filter((b) => {
+      const key = `${b.startByte}:${b.endByte}:${b.name}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }
+
+  /**
+   * Determine if a structural node should be skipped in favor of children.
+   */
+  private shouldSkipStructuralNode(_node: SyntaxNode): boolean {
+    // Currently no wrapper types to skip in Python
+    return false;
+  }
+
+  private classifyStructuralNode(node: SyntaxNode): StructuralNodeType {
+    switch (node.type) {
+      case "function_definition":
+      case "async_function_definition":
+        return StructuralNodeType.FUNCTION_DECLARATION;
+      case "class_definition":
+        return StructuralNodeType.CLASS_DECLARATION;
+      case "import_statement":
+      case "import_from_statement":
+        return StructuralNodeType.IMPORT_STATEMENT;
+      default:
+        return StructuralNodeType.VARIABLE_DECLARATION;
+    }
+  }
+
+  private deduplicate(nodes: StructuralNode[]): StructuralNode[] {
+    const seen = new Set<string>();
+    const out: StructuralNode[] = [];
+    for (const n of nodes) {
+      const key = `${n.startByte}:${n.endByte}:${n.type}:${n.name}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(n);
+    }
+    out.sort((a, b) => a.startByte - b.startByte);
+    return out;
+  }
+}

--- a/src/splitter/treesitter/parsers/types.ts
+++ b/src/splitter/treesitter/parsers/types.ts
@@ -4,6 +4,12 @@
 
 import type { SyntaxNode, Tree } from "tree-sitter";
 
+/**
+ * Universal tree-sitter parser size limit.
+ * Set to 30,000 characters to be safely under the observed 32,767 limit.
+ */
+export const TREE_SITTER_SIZE_LIMIT = 30000;
+
 export enum StructuralNodeType {
   // Function declarations
   FUNCTION_DECLARATION = "function_declaration",


### PR DESCRIPTION
Implement PythonParser for semantic parsing of Python source code, including support for functions, classes, and docstrings. Register the Python parser in the LanguageParserRegistry and enhance TypeScriptParser for better handling of large files. Comprehensive tests for PythonParser have been added, covering various scenarios including syntax errors and boundary extraction.

Closes #214