### PR TITLE
Add HtmlNormalizationMiddleware for URL and link normalization

### DIFF
--- a/docs/content-processing.md
+++ b/docs/content-processing.md
@@ -39,13 +39,15 @@ Transform raw content using middleware chains and content-type-specific logic:
 
 Transform content through ordered middleware chains within pipelines:
 
-**HTML Processing** uses the most extensive middleware pipeline:
+**HTML Processing** uses the most extensive middleware pipeline, executed in a specific order to ensure correctness and efficiency:
 
-- Dynamic content rendering with Playwright (when needed)
-- DOM parsing and metadata extraction
-- Content sanitization (removes navigation, ads, boilerplate)
-- Link discovery and resolution
-- Conversion to clean markdown format
+- **Dynamic Content Rendering**: (Optional) Uses Playwright to render JavaScript-heavy pages when needed
+- **DOM Parsing**: Converts the raw HTML string into a manipulable DOM object using Cheerio
+- **Metadata Extraction**: Extracts the document title from `<title>` or `<h1>` tags in the full DOM
+- **Link Discovery**: Gathers all links from the complete page for the crawler to potentially follow
+- **Content Sanitization**: Removes large, irrelevant sections like navigation, footers, ads, and boilerplate
+- **URL Normalization**: Cleans the _remaining_ content by converting relative image/link URLs to absolute ones and removing non-functional links (anchors, `javascript:`, etc.) while preserving their text content
+- **Markdown Conversion**: Converts the final, cleaned, and normalized HTML into Markdown format
 
 **Markdown Processing** applies lighter middleware:
 
@@ -157,9 +159,11 @@ graph TD
     subgraph "HTML Processing"
         A1[Raw HTML] --> B1[Playwright Rendering]
         B1 --> C1[DOM Parsing]
-        C1 --> D1[Content Cleaning]
-        D1 --> E1[HTML to Markdown]
-        E1 --> F1[SemanticMarkdownSplitter]
+        C1 --> D1[Metadata & Link Extraction]
+        D1 --> E1[Content Sanitization]
+        E1 --> F1[URL Normalization]
+        F1 --> G1[HTML to Markdown]
+        G1 --> H1[SemanticMarkdownSplitter]
     end
 
     subgraph "JSON Processing"
@@ -177,7 +181,7 @@ graph TD
         B4 --> C4[SemanticMarkdownSplitter]
     end
 
-    F1 --> G[GreedySplitter]
+    H1 --> G[GreedySplitter]
     C2 --> G
     C3 --> G
     C4 --> G

--- a/src/scraper/middleware/HtmlNormalizationMiddleware.test.ts
+++ b/src/scraper/middleware/HtmlNormalizationMiddleware.test.ts
@@ -1,0 +1,342 @@
+import * as cheerio from "cheerio";
+import { describe, expect, it } from "vitest";
+import type { ScraperOptions } from "../types";
+import { HtmlNormalizationMiddleware } from "./HtmlNormalizationMiddleware";
+import type { MiddlewareContext } from "./types";
+
+describe("HtmlNormalizationMiddleware", () => {
+  const middleware = new HtmlNormalizationMiddleware();
+
+  const createContext = (
+    htmlContent: string,
+    source = "https://example.com/page",
+  ): MiddlewareContext => {
+    const $ = cheerio.load(htmlContent);
+    const options: ScraperOptions = {
+      url: source,
+      library: "test-library",
+      version: "1.0.0",
+    };
+    return {
+      content: htmlContent,
+      source,
+      metadata: {},
+      links: [],
+      errors: [],
+      options,
+      dom: $,
+    };
+  };
+
+  describe("process", () => {
+    it("should skip normalization when no DOM is available", async () => {
+      const options: ScraperOptions = {
+        url: "https://example.com",
+        library: "test-library",
+        version: "1.0.0",
+      };
+      const context: MiddlewareContext = {
+        content: "<p>test</p>",
+        source: "https://example.com",
+        metadata: {},
+        links: [],
+        errors: [],
+        options,
+      };
+
+      let nextCalled = false;
+      await middleware.process(context, async () => {
+        nextCalled = true;
+      });
+
+      expect(nextCalled).toBe(true);
+      expect(context.errors).toHaveLength(0);
+    });
+
+    it("should handle processing errors gracefully", async () => {
+      const context = createContext("<img src='test.jpg'>");
+      // Intentionally break the DOM to cause an error
+      context.dom = null as any;
+
+      let nextCalled = false;
+      await middleware.process(context, async () => {
+        nextCalled = true;
+      });
+
+      expect(nextCalled).toBe(true);
+    });
+  });
+
+  describe("image URL normalization", () => {
+    it("should convert relative image URLs to absolute URLs", async () => {
+      const context = createContext(
+        `
+        <div>
+          <img src="image1.jpg" alt="Image 1">
+          <img src="/images/image2.png" alt="Image 2">
+          <img src="./relative/image3.gif" alt="Image 3">
+          <img src="../parent/image4.svg" alt="Image 4">
+        </div>
+      `,
+        "https://example.com/docs/page.html",
+      );
+
+      await middleware.process(context, async () => {});
+
+      const $ = context.dom!;
+      const images = $("img");
+
+      expect($(images[0]).attr("src")).toBe("https://example.com/docs/image1.jpg");
+      expect($(images[1]).attr("src")).toBe("https://example.com/images/image2.png");
+      expect($(images[2]).attr("src")).toBe(
+        "https://example.com/docs/relative/image3.gif",
+      );
+      expect($(images[3]).attr("src")).toBe("https://example.com/parent/image4.svg");
+    });
+
+    it("should leave absolute image URLs unchanged", async () => {
+      const context = createContext(`
+        <div>
+          <img src="https://cdn.example.com/image1.jpg" alt="Image 1">
+          <img src="http://other.com/image2.png" alt="Image 2">
+        </div>
+      `);
+
+      await middleware.process(context, async () => {});
+
+      const $ = context.dom!;
+      const images = $("img");
+
+      expect($(images[0]).attr("src")).toBe("https://cdn.example.com/image1.jpg");
+      expect($(images[1]).attr("src")).toBe("http://other.com/image2.png");
+    });
+
+    it("should handle images without src attribute", async () => {
+      const context = createContext(`
+        <div>
+          <img alt="No source">
+          <img src="" alt="Empty source">
+        </div>
+      `);
+
+      await middleware.process(context, async () => {});
+
+      const $ = context.dom!;
+      const images = $("img");
+
+      expect($(images[0]).attr("src")).toBeUndefined();
+      expect($(images[1]).attr("src")).toBe("");
+    });
+
+    it("should handle malformed relative URLs gracefully", async () => {
+      const context = createContext(`
+        <img src="::invalid::url" alt="Invalid URL">
+      `);
+
+      await middleware.process(context, async () => {});
+
+      const $ = context.dom!;
+      const img = $("img");
+
+      // URL constructor is permissive and will resolve this as a relative path
+      expect(img.attr("src")).toBe("https://example.com/::invalid::url");
+    });
+  });
+
+  describe("link normalization", () => {
+    it("should convert relative link URLs to absolute URLs", async () => {
+      const context = createContext(
+        `
+        <div>
+          <a href="page1.html">Page 1</a>
+          <a href="/docs/page2.html">Page 2</a>
+          <a href="./section/page3.html">Page 3</a>
+          <a href="../other/page4.html">Page 4</a>
+        </div>
+      `,
+        "https://example.com/docs/current.html",
+      );
+
+      await middleware.process(context, async () => {});
+
+      const $ = context.dom!;
+      const links = $("a");
+
+      expect($(links[0]).attr("href")).toBe("https://example.com/docs/page1.html");
+      expect($(links[1]).attr("href")).toBe("https://example.com/docs/page2.html");
+      expect($(links[2]).attr("href")).toBe(
+        "https://example.com/docs/section/page3.html",
+      );
+      expect($(links[3]).attr("href")).toBe("https://example.com/other/page4.html");
+    });
+
+    it("should leave absolute HTTP/HTTPS URLs unchanged", async () => {
+      const context = createContext(`
+        <div>
+          <a href="https://external.com/page">External HTTPS</a>
+          <a href="http://other.com/page">External HTTP</a>
+        </div>
+      `);
+
+      await middleware.process(context, async () => {});
+
+      const $ = context.dom!;
+      const links = $("a");
+
+      expect($(links[0]).attr("href")).toBe("https://external.com/page");
+      expect($(links[1]).attr("href")).toBe("http://other.com/page");
+    });
+
+    it("should unwrap anchor links while preserving text content", async () => {
+      const context = createContext(`
+        <div>
+          <p>See <a href="#section1">this section</a> for details.</p>
+          <a href="#top">Back to top</a>
+        </div>
+      `);
+
+      await middleware.process(context, async () => {});
+
+      const $ = context.dom!;
+      const html = $.html();
+
+      expect(html).toContain("See this section for details.");
+      expect(html).toContain("Back to top");
+      expect(html).not.toContain('<a href="#section1">');
+      expect(html).not.toContain('<a href="#top">');
+    });
+
+    it("should unwrap javascript: links while preserving text content", async () => {
+      const context = createContext(`
+        <div>
+          <a href="javascript:alert('Hello')">Click me</a>
+          <a href="javascript:void(0)">Another action</a>
+        </div>
+      `);
+
+      await middleware.process(context, async () => {});
+
+      const $ = context.dom!;
+      const html = $.html();
+
+      expect(html).toContain("Click me");
+      expect(html).toContain("Another action");
+      expect(html).not.toContain("javascript:");
+      expect(html).not.toContain("<a href=");
+    });
+
+    it("should unwrap other non-HTTP protocol links while preserving text content", async () => {
+      const context = createContext(`
+        <div>
+          <a href="mailto:test@example.com">Email us</a>
+          <a href="tel:+1234567890">Call us</a>
+          <a href="ftp://files.example.com">FTP</a>
+        </div>
+      `);
+
+      await middleware.process(context, async () => {});
+
+      const $ = context.dom!;
+      const html = $.html();
+
+      expect(html).toContain("Email us");
+      expect(html).toContain("Call us");
+      expect(html).toContain("FTP");
+      expect(html).not.toContain("mailto:");
+      expect(html).not.toContain("tel:");
+      expect(html).not.toContain("ftp:");
+      expect(html).not.toContain("<a href=");
+    });
+
+    it("should unwrap links without href attribute", async () => {
+      const context = createContext(`
+        <div>
+          <a>Link without href</a>
+          <a href="">Link with empty href</a>
+        </div>
+      `);
+
+      await middleware.process(context, async () => {});
+
+      const $ = context.dom!;
+      const html = $.html();
+
+      expect(html).toContain("Link without href");
+      expect(html).toContain("Link with empty href");
+      expect($("a")).toHaveLength(0);
+    });
+
+    it("should handle malformed relative URLs by converting them", async () => {
+      const context = createContext(`
+        <a href="::invalid::url">Invalid link</a>
+      `);
+
+      await middleware.process(context, async () => {});
+
+      const $ = context.dom!;
+      const links = $("a");
+
+      // URL constructor is permissive and will resolve this as a relative path
+      expect($(links[0]).attr("href")).toBe("https://example.com/::invalid::url");
+      expect($("a")).toHaveLength(1);
+    });
+  });
+
+  describe("complex scenarios", () => {
+    it("should handle mixed content correctly", async () => {
+      const context = createContext(
+        `
+        <div>
+          <h1>Test Page</h1>
+          <img src="logo.png" alt="Logo">
+          <p>Check out <a href="https://external.com">this external link</a>.</p>
+          <p>Or see <a href="#section">this section</a> below.</p>
+          <p>Contact us via <a href="mailto:info@example.com">email</a>.</p>
+          <a href="./relative/page.html">Relative page</a>
+          <img src="https://cdn.example.com/banner.jpg" alt="Banner">
+        </div>
+      `,
+        "https://example.com/docs/",
+      );
+
+      await middleware.process(context, async () => {});
+
+      const $ = context.dom!;
+      const html = $.html();
+
+      // Images should be normalized
+      expect($('img[src="https://example.com/docs/logo.png"]')).toHaveLength(1);
+      expect($('img[src="https://cdn.example.com/banner.jpg"]')).toHaveLength(1);
+
+      // External HTTP link should remain
+      expect($('a[href="https://external.com"]')).toHaveLength(1);
+
+      // Relative link should be converted
+      expect($('a[href="https://example.com/docs/relative/page.html"]')).toHaveLength(1);
+
+      // Anchor and mailto links should be unwrapped
+      expect(html).toContain("this section");
+      expect(html).toContain("email");
+      expect(html).not.toContain('#section"');
+      expect(html).not.toContain("mailto:");
+    });
+
+    it("should preserve nested elements when unwrapping links", async () => {
+      const context = createContext(`
+        <div>
+          <a href="#test"><strong>Bold</strong> and <em>italic</em> text</a>
+        </div>
+      `);
+
+      await middleware.process(context, async () => {});
+
+      const $ = context.dom!;
+      const html = $.html();
+
+      expect(html).toContain("<strong>Bold</strong> and <em>italic</em> text");
+      expect($("strong")).toHaveLength(1);
+      expect($("em")).toHaveLength(1);
+      expect($("a")).toHaveLength(0);
+    });
+  });
+});

--- a/src/scraper/middleware/HtmlNormalizationMiddleware.ts
+++ b/src/scraper/middleware/HtmlNormalizationMiddleware.ts
@@ -1,0 +1,141 @@
+import type * as cheerio from "cheerio";
+import type { AnyNode } from "domhandler";
+import { logger } from "../../utils/logger";
+import type { ContentProcessorMiddleware, MiddlewareContext } from "./types";
+
+/**
+ * Middleware that normalizes URLs and links in HTML content after DOM parsing.
+ *
+ * This middleware performs the following transformations:
+ * - Converts relative image URLs to absolute URLs
+ * - Converts relative link URLs to absolute URLs
+ * - Removes anchor links (#...) but preserves their text content
+ * - Removes non-HTTP links (javascript:, mailto:, etc.) but preserves their text content
+ *
+ * This ensures that indexed documents contain functional absolute URLs and removes
+ * non-functional links while preserving contextually valuable text content.
+ */
+export class HtmlNormalizationMiddleware implements ContentProcessorMiddleware {
+  async process(context: MiddlewareContext, next: () => Promise<void>): Promise<void> {
+    if (!context.dom) {
+      logger.debug(
+        `Skipping HTML normalization for ${context.source} - no DOM available`,
+      );
+      await next();
+      return;
+    }
+
+    try {
+      logger.debug(`Normalizing HTML URLs and links for ${context.source}`);
+
+      const $ = context.dom;
+      const baseUrl = context.source;
+
+      // Normalize image URLs
+      this.normalizeImageUrls($, baseUrl);
+
+      // Normalize and clean links
+      this.normalizeLinks($, baseUrl);
+
+      logger.debug(`Successfully normalized HTML content for ${context.source}`);
+    } catch (error) {
+      logger.error(`❌ Failed to normalize HTML for ${context.source}: ${error}`);
+      context.errors.push(
+        error instanceof Error
+          ? error
+          : new Error(`HTML normalization failed: ${String(error)}`),
+      );
+    }
+
+    await next();
+  }
+
+  /**
+   * Normalizes image URLs by converting relative URLs to absolute URLs.
+   */
+  private normalizeImageUrls($: cheerio.CheerioAPI, baseUrl: string): void {
+    $("img").each((_index, element) => {
+      const $img = $(element);
+      const src = $img.attr("src");
+
+      if (!src) return;
+
+      try {
+        // If it's already an absolute URL, leave it unchanged
+        new URL(src);
+      } catch {
+        // It's a relative URL, convert to absolute
+        try {
+          const absoluteUrl = new URL(src, baseUrl).href;
+          $img.attr("src", absoluteUrl);
+          logger.debug(`Converted relative image URL: ${src} → ${absoluteUrl}`);
+        } catch (error) {
+          logger.debug(`Failed to resolve relative image URL: ${src} - ${error}`);
+        }
+      }
+    });
+  }
+
+  /**
+   * Normalizes links by:
+   * - Converting relative URLs to absolute URLs
+   * - Unwrapping anchor links (preserving text content)
+   * - Unwrapping non-HTTP links (preserving text content)
+   */
+  private normalizeLinks($: cheerio.CheerioAPI, baseUrl: string): void {
+    $("a").each((_index, element) => {
+      const $link = $(element);
+      const href = $link.attr("href");
+
+      if (!href) {
+        // Links without href - unwrap them (preserve content, remove tag)
+        this.unwrapElement($, $link);
+        return;
+      }
+
+      // Handle anchor links (starting with #)
+      if (href.startsWith("#")) {
+        logger.debug(`Removing anchor link: ${href}`);
+        this.unwrapElement($, $link);
+        return;
+      }
+
+      // Check if it's already an absolute URL
+      try {
+        const url = new URL(href);
+
+        // Handle non-HTTP protocols (javascript:, mailto:, etc.)
+        if (url.protocol !== "http:" && url.protocol !== "https:") {
+          logger.debug(`Removing non-HTTP link: ${href}`);
+          this.unwrapElement($, $link);
+          return;
+        }
+
+        // It's already a valid HTTP/HTTPS absolute URL, leave it unchanged
+      } catch {
+        // It's a relative URL, convert to absolute
+        try {
+          const absoluteUrl = new URL(href, baseUrl).href;
+          $link.attr("href", absoluteUrl);
+          logger.debug(`Converted relative link URL: ${href} → ${absoluteUrl}`);
+        } catch (error) {
+          logger.debug(`Failed to resolve relative link URL: ${href} - ${error}`);
+          // If we can't resolve it, unwrap it to preserve the text content
+          this.unwrapElement($, $link);
+        }
+      }
+    });
+  }
+
+  /**
+   * Unwraps an element by replacing it with its HTML content.
+   * This preserves the inner HTML (including nested elements) while removing the wrapping tag.
+   */
+  private unwrapElement(
+    _$: cheerio.CheerioAPI,
+    $element: cheerio.Cheerio<AnyNode>,
+  ): void {
+    const htmlContent = $element.html() || $element.text();
+    $element.replaceWith(htmlContent);
+  }
+}

--- a/src/scraper/pipelines/HtmlPipeline.ts
+++ b/src/scraper/pipelines/HtmlPipeline.ts
@@ -10,6 +10,7 @@ import { HtmlSanitizerMiddleware } from "../middleware";
 import { HtmlCheerioParserMiddleware } from "../middleware/HtmlCheerioParserMiddleware";
 import { HtmlLinkExtractorMiddleware } from "../middleware/HtmlLinkExtractorMiddleware";
 import { HtmlMetadataExtractorMiddleware } from "../middleware/HtmlMetadataExtractorMiddleware";
+import { HtmlNormalizationMiddleware } from "../middleware/HtmlNormalizationMiddleware";
 import { HtmlPlaywrightMiddleware } from "../middleware/HtmlPlaywrightMiddleware";
 import { HtmlToMarkdownMiddleware } from "../middleware/HtmlToMarkdownMiddleware";
 import type { ContentProcessorMiddleware, MiddlewareContext } from "../middleware/types";
@@ -40,6 +41,7 @@ export class HtmlPipeline extends BasePipeline {
       new HtmlMetadataExtractorMiddleware(),
       new HtmlLinkExtractorMiddleware(),
       new HtmlSanitizerMiddleware(),
+      new HtmlNormalizationMiddleware(),
       new HtmlToMarkdownMiddleware(),
     ];
 


### PR DESCRIPTION
Introduce a middleware that normalizes URLs and links in HTML content, ensuring all links are functional and removing non-functional ones while preserving their text content. This enhancement improves the overall quality of indexed documents.

Fixed #205