### PR TITLE
Improve Cloudflare challenge handling with AutoDetectFetcher

### DIFF
--- a/src/cli/commands/fetchUrl.test.ts
+++ b/src/cli/commands/fetchUrl.test.ts
@@ -6,6 +6,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../scraper/fetcher", () => ({
   HttpFetcher: vi.fn().mockImplementation(() => ({})),
   FileFetcher: vi.fn().mockImplementation(() => ({})),
+  AutoDetectFetcher: vi.fn().mockImplementation(() => ({
+    canFetch: vi.fn().mockReturnValue(true),
+    fetch: vi.fn().mockResolvedValue({
+      content: "<h1>Test</h1>",
+      mimeType: "text/html",
+      source: "https://example.com",
+    }),
+    close: vi.fn().mockResolvedValue(undefined),
+  })),
 }));
 vi.mock("../../tools", () => ({
   FetchUrlTool: vi
@@ -23,11 +32,11 @@ beforeEach(() => vi.clearAllMocks());
 
 describe("fetchUrlAction", () => {
   it("executes FetchUrlTool", async () => {
-    await fetchUrlAction(
-      "https://example.com",
-      { followRedirects: true, scrapeMode: "auto" as any, header: [] },
-      cmd(),
-    );
+    await fetchUrlAction("https://example.com", {
+      followRedirects: true,
+      scrapeMode: "auto" as any,
+      header: [],
+    });
     const { FetchUrlTool } = await import("../../tools");
     expect(FetchUrlTool).toHaveBeenCalledTimes(1);
   });

--- a/src/cli/commands/fetchUrl.ts
+++ b/src/cli/commands/fetchUrl.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Command } from "commander";
-import { FileFetcher, HttpFetcher } from "../../scraper/fetcher";
+import { AutoDetectFetcher } from "../../scraper/fetcher";
 import { ScrapeMode } from "../../scraper/types";
 import { analytics, TelemetryEvent } from "../../telemetry";
 import { FetchUrlTool } from "../../tools";
@@ -22,7 +22,7 @@ export async function fetchUrlAction(
   });
 
   const headers = parseHeaders(options.header);
-  const fetchUrlTool = new FetchUrlTool(new HttpFetcher(), new FileFetcher());
+  const fetchUrlTool = new FetchUrlTool(new AutoDetectFetcher());
 
   const content = await fetchUrlTool.execute({
     url,

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,5 +1,5 @@
 import type { IPipeline } from "../pipeline/trpc/interfaces";
-import { FileFetcher, HttpFetcher } from "../scraper/fetcher";
+import { AutoDetectFetcher } from "../scraper/fetcher";
 import type { IDocumentManagement } from "../store/trpc/interfaces";
 import {
   CancelJobTool,
@@ -49,7 +49,7 @@ export async function initializeTools(
     cancelJob: new CancelJobTool(pipeline),
     // clearCompletedJobs: new ClearCompletedJobsTool(pipeline),
     remove: new RemoveTool(docService, pipeline),
-    fetchUrl: new FetchUrlTool(new HttpFetcher(), new FileFetcher()),
+    fetchUrl: new FetchUrlTool(new AutoDetectFetcher()),
   };
 
   return tools;

--- a/src/scraper/fetcher/AutoDetectFetcher.ts
+++ b/src/scraper/fetcher/AutoDetectFetcher.ts
@@ -1,0 +1,72 @@
+import { ChallengeError } from "../../utils/errors";
+import { logger } from "../../utils/logger";
+import { BrowserFetcher } from "./BrowserFetcher";
+import { FileFetcher } from "./FileFetcher";
+import { HttpFetcher } from "./HttpFetcher";
+import type { ContentFetcher, FetchOptions, RawContent } from "./types";
+
+/**
+ * AutoDetectFetcher automatically selects the appropriate fetcher based on URL type
+ * and handles fallbacks for challenge detection.
+ *
+ * This eliminates the need for consumers to manage multiple fetcher instances
+ * and implement fallback logic themselves.
+ */
+export class AutoDetectFetcher implements ContentFetcher {
+  private readonly httpFetcher = new HttpFetcher();
+  private readonly browserFetcher = new BrowserFetcher();
+  private readonly fileFetcher = new FileFetcher();
+
+  /**
+   * Check if this fetcher can handle the given source.
+   * Returns true for any URL that any of the underlying fetchers can handle.
+   */
+  canFetch(source: string): boolean {
+    return (
+      this.httpFetcher.canFetch(source) ||
+      this.browserFetcher.canFetch(source) ||
+      this.fileFetcher.canFetch(source)
+    );
+  }
+
+  /**
+   * Fetch content from the source, automatically selecting the appropriate fetcher
+   * and handling fallbacks when challenges are detected.
+   */
+  async fetch(source: string, options?: FetchOptions): Promise<RawContent> {
+    // For file:// URLs, use FileFetcher directly
+    if (this.fileFetcher.canFetch(source)) {
+      logger.debug(`Using FileFetcher for: ${source}`);
+      return this.fileFetcher.fetch(source, options);
+    }
+
+    // For HTTP(S) URLs, try HttpFetcher first, fallback to BrowserFetcher on challenge
+    if (this.httpFetcher.canFetch(source)) {
+      try {
+        logger.debug(`Using HttpFetcher for: ${source}`);
+        return await this.httpFetcher.fetch(source, options);
+      } catch (error) {
+        if (error instanceof ChallengeError) {
+          logger.info(
+            `🔄 Challenge detected for ${source}, falling back to browser fetcher...`,
+          );
+          return this.browserFetcher.fetch(source, options);
+        }
+        throw error;
+      }
+    }
+
+    // If we get here, no fetcher can handle this URL
+    throw new Error(`No suitable fetcher found for URL: ${source}`);
+  }
+
+  /**
+   * Close all underlying fetchers to prevent resource leaks.
+   */
+  async close(): Promise<void> {
+    await Promise.allSettled([
+      this.browserFetcher.close(),
+      // HttpFetcher and FileFetcher don't need explicit cleanup
+    ]);
+  }
+}

--- a/src/scraper/fetcher/BrowserFetcher.ts
+++ b/src/scraper/fetcher/BrowserFetcher.ts
@@ -1,0 +1,141 @@
+import { type Browser, chromium, type Page } from "playwright";
+import { ScraperError } from "../../utils/errors";
+import { logger } from "../../utils/logger";
+import { MimeTypeUtils } from "../../utils/mimeTypeUtils";
+import { FingerprintGenerator } from "./FingerprintGenerator";
+import type { ContentFetcher, FetchOptions, RawContent } from "./types";
+
+/**
+ * Fetches content using a headless browser (Playwright).
+ * This fetcher can handle JavaScript-heavy pages and bypass anti-scraping measures.
+ */
+export class BrowserFetcher implements ContentFetcher {
+  private browser: Browser | null = null;
+  private page: Page | null = null;
+  private fingerprintGenerator: FingerprintGenerator;
+
+  constructor() {
+    this.fingerprintGenerator = new FingerprintGenerator();
+  }
+
+  canFetch(source: string): boolean {
+    return source.startsWith("http://") || source.startsWith("https://");
+  }
+
+  async fetch(source: string, options?: FetchOptions): Promise<RawContent> {
+    try {
+      await this.ensureBrowserReady();
+
+      if (!this.page) {
+        throw new ScraperError("Failed to create browser page", false);
+      }
+
+      // Set custom headers if provided
+      if (options?.headers) {
+        await this.page.setExtraHTTPHeaders(options.headers);
+      }
+
+      // Set timeout
+      const timeout = options?.timeout || 30000;
+
+      // Navigate to the page and wait for it to load
+      logger.debug(`🌐 Navigating to ${source} with browser...`);
+      const response = await this.page.goto(source, {
+        waitUntil: "networkidle",
+        timeout,
+      });
+
+      if (!response) {
+        throw new ScraperError(`Failed to navigate to ${source}`, false);
+      }
+
+      // Check if we should follow redirects
+      if (
+        options?.followRedirects === false &&
+        response.status() >= 300 &&
+        response.status() < 400
+      ) {
+        const location = response.headers()["location"];
+        if (location) {
+          throw new ScraperError(`Redirect blocked: ${source} -> ${location}`, false);
+        }
+      }
+
+      // Get the final URL after any redirects
+      const finalUrl = this.page.url();
+
+      // Get the page content
+      const content = await this.page.content();
+      const contentBuffer = Buffer.from(content, "utf-8");
+
+      // Determine content type
+      const contentType = response.headers()["content-type"] || "text/html";
+      const { mimeType, charset } = MimeTypeUtils.parseContentType(contentType);
+
+      return {
+        content: contentBuffer,
+        mimeType,
+        charset,
+        encoding: undefined, // Browser handles encoding automatically
+        source: finalUrl,
+      } satisfies RawContent;
+    } catch (error) {
+      if (options?.signal?.aborted) {
+        throw new ScraperError("Browser fetch cancelled", false);
+      }
+
+      logger.error(`❌ Browser fetch failed for ${source}: ${error}`);
+      throw new ScraperError(
+        `Browser fetch failed for ${source}: ${error instanceof Error ? error.message : String(error)}`,
+        false,
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  private async ensureBrowserReady(): Promise<void> {
+    if (!this.browser) {
+      logger.debug("🚀 Launching browser...");
+      this.browser = await chromium.launch({
+        headless: true,
+        args: [
+          "--no-sandbox",
+          "--disable-setuid-sandbox",
+          "--disable-dev-shm-usage",
+          "--disable-web-security",
+          "--disable-features=site-per-process",
+        ],
+      });
+    }
+
+    if (!this.page) {
+      this.page = await this.browser.newPage();
+
+      // Generate and set realistic browser headers
+      const dynamicHeaders = this.fingerprintGenerator.generateHeaders();
+      await this.page.setExtraHTTPHeaders(dynamicHeaders);
+
+      // Set viewport
+      await this.page.setViewportSize({ width: 1920, height: 1080 });
+    }
+  }
+
+  /**
+   * Close the browser and clean up resources
+   */
+  async close(): Promise<void> {
+    try {
+      if (this.page) {
+        await this.page.close();
+        this.page = null;
+      }
+      if (this.browser) {
+        await this.browser.close();
+        this.browser = null;
+      }
+      logger.debug("🔒 Browser closed successfully");
+    } catch (error) {
+      logger.warn(`⚠️ Error closing browser: ${error}`);
+    }
+  }
+}

--- a/src/scraper/fetcher/HttpFetcher.ts
+++ b/src/scraper/fetcher/HttpFetcher.ts
@@ -2,7 +2,7 @@ import axios, { type AxiosError, type AxiosRequestConfig } from "axios";
 import { CancellationError } from "../../pipeline/errors";
 import { analytics, extractHostname, extractProtocol } from "../../telemetry";
 import { FETCHER_BASE_DELAY, FETCHER_MAX_RETRIES } from "../../utils/config";
-import { RedirectError, ScraperError } from "../../utils/errors";
+import { ChallengeError, RedirectError, ScraperError } from "../../utils/errors";
 import { logger } from "../../utils/logger";
 import { MimeTypeUtils } from "../../utils/mimeTypeUtils";
 import { FingerprintGenerator } from "./FingerprintGenerator";
@@ -177,6 +177,40 @@ export class HttpFetcher implements ContentFetcher {
           const location = axiosError.response?.headers?.location;
           if (location) {
             throw new RedirectError(source, location, status);
+          }
+        }
+
+        // Detect Cloudflare challenges
+        if (status === 403) {
+          const cfMitigated = axiosError.response?.headers?.["cf-mitigated"];
+          const server = axiosError.response?.headers?.["server"];
+          let responseBody = "";
+
+          // Safely convert response data to string
+          if (axiosError.response?.data) {
+            try {
+              if (typeof axiosError.response.data === "string") {
+                responseBody = axiosError.response.data;
+              } else if (Buffer.isBuffer(axiosError.response.data)) {
+                responseBody = axiosError.response.data.toString("utf-8");
+              } else if (axiosError.response.data instanceof ArrayBuffer) {
+                responseBody = Buffer.from(axiosError.response.data).toString("utf-8");
+              }
+            } catch {
+              // Ignore conversion errors
+            }
+          }
+
+          // Check for various Cloudflare challenge indicators
+          const isCloudflareChallenge =
+            cfMitigated === "challenge" ||
+            server === "cloudflare" ||
+            responseBody.includes("Enable JavaScript and cookies to continue") ||
+            responseBody.includes("Just a moment...") ||
+            responseBody.includes("cf_chl_opt");
+
+          if (isCloudflareChallenge) {
+            throw new ChallengeError(source, status, "cloudflare");
           }
         }
 

--- a/src/scraper/fetcher/index.ts
+++ b/src/scraper/fetcher/index.ts
@@ -1,3 +1,5 @@
+export * from "./AutoDetectFetcher";
+export * from "./BrowserFetcher";
 export * from "./FileFetcher";
 export * from "./HttpFetcher";
 export * from "./types";

--- a/src/tools/FetchUrlTool.ts
+++ b/src/tools/FetchUrlTool.ts
@@ -1,9 +1,4 @@
-import type {
-  ContentFetcher,
-  FileFetcher,
-  HttpFetcher,
-  RawContent,
-} from "../scraper/fetcher";
+import type { AutoDetectFetcher, RawContent } from "../scraper/fetcher";
 import { HtmlPipeline } from "../scraper/pipelines/HtmlPipeline";
 import { MarkdownPipeline } from "../scraper/pipelines/MarkdownPipeline";
 import { TextPipeline } from "../scraper/pipelines/TextPipeline";
@@ -11,7 +6,7 @@ import type { ContentPipeline, ProcessedContent } from "../scraper/pipelines/typ
 import { ScrapeMode } from "../scraper/types";
 import { convertToString } from "../scraper/utils/buffer";
 import { resolveCharset } from "../scraper/utils/charset";
-import { ScraperError } from "../utils/errors";
+import { ChallengeError, ScraperError } from "../utils/errors";
 import { logger } from "../utils/logger";
 import { ToolError } from "./errors";
 
@@ -53,9 +48,9 @@ export interface FetchUrlToolOptions {
  */
 export class FetchUrlTool {
   /**
-   * Collection of fetchers that will be tried in order for a given URL.
+   * AutoDetectFetcher handles all URL types and fallback logic automatically.
    */
-  private readonly fetchers: ContentFetcher[];
+  private readonly fetcher: AutoDetectFetcher;
   /**
    * Collection of pipelines that will be tried in order for processing content.
    * The first pipeline that can process the content type will be used.
@@ -63,8 +58,8 @@ export class FetchUrlTool {
    */
   private readonly pipelines: ContentPipeline[];
 
-  constructor(httpFetcher: HttpFetcher, fileFetcher: FileFetcher) {
-    this.fetchers = [httpFetcher, fileFetcher];
+  constructor(fetcher: AutoDetectFetcher) {
+    this.fetcher = fetcher;
     const htmlPipeline = new HtmlPipeline();
     const markdownPipeline = new MarkdownPipeline();
     const textPipeline = new TextPipeline();
@@ -81,25 +76,24 @@ export class FetchUrlTool {
   async execute(options: FetchUrlToolOptions): Promise<string> {
     const { url, scrapeMode = ScrapeMode.Auto, headers } = options;
 
-    const canFetchResults = this.fetchers.map((f) => f.canFetch(url));
-    const fetcherIndex = canFetchResults.indexOf(true);
-    if (fetcherIndex === -1) {
+    if (!this.fetcher.canFetch(url)) {
       throw new ToolError(
         `Invalid URL: ${url}. Must be an HTTP/HTTPS URL or a file:// URL.`,
         this.constructor.name,
       );
     }
 
-    const fetcher = this.fetchers[fetcherIndex];
-    logger.debug(`Using fetcher "${fetcher.constructor.name}" for URL: ${url}`);
-
     try {
       logger.info(`📡 Fetching ${url}...`);
-      const rawContent: RawContent = await fetcher.fetch(url, {
+
+      const fetchOptions = {
         followRedirects: options.followRedirects ?? true,
         maxRetries: 3,
         headers, // propagate custom headers
-      });
+      };
+
+      // AutoDetectFetcher handles all fallback logic automatically
+      const rawContent: RawContent = await this.fetcher.fetch(url, fetchOptions);
 
       logger.info("🔄 Processing content...");
 
@@ -122,7 +116,7 @@ export class FetchUrlTool {
               scrapeMode,
               headers, // propagate custom headers
             },
-            fetcher,
+            this.fetcher,
           );
           break;
         }
@@ -167,8 +161,11 @@ export class FetchUrlTool {
         this.constructor.name,
       );
     } finally {
-      // Cleanup all pipelines to prevent resource leaks (e.g., browser instances)
-      await Promise.allSettled(this.pipelines.map((pipeline) => pipeline.close()));
+      // Cleanup all pipelines and fetcher to prevent resource leaks (e.g., browser instances)
+      await Promise.allSettled([
+        ...this.pipelines.map((pipeline) => pipeline.close()),
+        this.fetcher.close(),
+      ]);
     }
   }
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -56,6 +56,19 @@ class RedirectError extends ScraperError {
   }
 }
 
+class ChallengeError extends ScraperError {
+  constructor(
+    public readonly url: string,
+    public readonly statusCode: number,
+    public readonly challengeType: string,
+  ) {
+    super(
+      `Challenge detected for ${url} (status: ${statusCode}, type: ${challengeType})`,
+      false,
+    );
+  }
+}
+
 export {
   ScraperError,
   NetworkError,
@@ -63,4 +76,5 @@ export {
   InvalidUrlError,
   ParsingError,
   RedirectError,
+  ChallengeError,
 };

--- a/test/html-pipeline-basic-e2e.test.ts
+++ b/test/html-pipeline-basic-e2e.test.ts
@@ -10,17 +10,15 @@
 
 import { beforeAll, describe, expect, it } from "vitest";
 import { FetchUrlTool } from "../src/tools/FetchUrlTool";
-import { HttpFetcher } from "../src/scraper/fetcher/HttpFetcher";
-import { FileFetcher } from "../src/scraper/fetcher/FileFetcher";
+import { AutoDetectFetcher } from "../src/scraper/fetcher/AutoDetectFetcher";
 import { ScrapeMode } from "../src/scraper/types";
 
 describe("HTML Pipeline Basic Tests", () => {
   let fetchUrlTool: FetchUrlTool;
 
   beforeAll(() => {
-    const httpFetcher = new HttpFetcher();
-    const fileFetcher = new FileFetcher();
-    fetchUrlTool = new FetchUrlTool(httpFetcher, fileFetcher);
+    const autoDetectFetcher = new AutoDetectFetcher();
+    fetchUrlTool = new FetchUrlTool(autoDetectFetcher);
   });
 
   describe("Core Functionality", () => {

--- a/test/html-pipeline-nonhtml-e2e.test.ts
+++ b/test/html-pipeline-nonhtml-e2e.test.ts
@@ -7,17 +7,15 @@
 
 import { beforeAll, describe, expect, it } from "vitest";
 import { FetchUrlTool } from "../src/tools/FetchUrlTool";
-import { HttpFetcher } from "../src/scraper/fetcher/HttpFetcher";
-import { FileFetcher } from "../src/scraper/fetcher/FileFetcher";
+import { AutoDetectFetcher } from "../src/scraper/fetcher/AutoDetectFetcher";
 import { ScrapeMode } from "../src/scraper/types";
 
 describe("HTML Pipeline Non-HTML Content Tests", () => {
   let fetchUrlTool: FetchUrlTool;
 
   beforeAll(() => {
-    const httpFetcher = new HttpFetcher();
-    const fileFetcher = new FileFetcher();
-    fetchUrlTool = new FetchUrlTool(httpFetcher, fileFetcher);
+    const autoDetectFetcher = new AutoDetectFetcher();
+    fetchUrlTool = new FetchUrlTool(autoDetectFetcher);
   });
 
   describe("Plain Text Content", () => {

--- a/test/html-pipeline-websites-e2e.test.ts
+++ b/test/html-pipeline-websites-e2e.test.ts
@@ -12,18 +12,16 @@
 
 import { beforeAll, describe, expect, it } from "vitest";
 import { FetchUrlTool } from "../src/tools/FetchUrlTool";
-import { HttpFetcher } from "../src/scraper/fetcher/HttpFetcher";
-import { FileFetcher } from "../src/scraper/fetcher/FileFetcher";
+import { AutoDetectFetcher } from "../src/scraper/fetcher/AutoDetectFetcher";
 import { ScrapeMode } from "../src/scraper/types";
 
 describe("HTML Pipeline Website Tests", () => {
   let fetchUrlTool: FetchUrlTool;
 
   beforeAll(() => {
-    // Initialize the FetchUrlTool with real fetchers
-    const httpFetcher = new HttpFetcher();
-    const fileFetcher = new FileFetcher();
-    fetchUrlTool = new FetchUrlTool(httpFetcher, fileFetcher);
+    // Initialize the FetchUrlTool with AutoDetectFetcher
+    const autoDetectFetcher = new AutoDetectFetcher();
+    fetchUrlTool = new FetchUrlTool(autoDetectFetcher);
   });
 
   describe("Salesforce Documentation", () => {


### PR DESCRIPTION
Enhance the fetching strategy by introducing AutoDetectFetcher to automatically select the appropriate fetcher based on the URL type. Improve error handling for Cloudflare challenges and refactor tests for compatibility with the new approach. Implement cleanup logic for temporary directories in end-to-end tests.

Fixes #239