### PR TITLE
make path variable resolved on worker launch

### DIFF
--- a/src/cli/commands/worker.ts
+++ b/src/cli/commands/worker.ts
@@ -5,6 +5,7 @@
 import type { Command } from "commander";
 import { Option } from "commander";
 import { startAppServer } from "../../app";
+import { resolveStorePath } from "../../utils/paths";
 import type { PipelineOptions } from "../../pipeline";
 import { createLocalDocumentManagement } from "../../store";
 import { analytics, TelemetryEvent } from "../../telemetry";
@@ -81,9 +82,11 @@ export function createWorkerCommand(program: Command): Command {
           // Get global options from parent command
           const globalOptions = program.parent?.opts() || {};
 
+          const resolvedStorePath = resolveStorePath(globalOptions.storePath);
+
           // Initialize services
           const docService = await createLocalDocumentManagement(
-            globalOptions.storePath,
+            resolvedStorePath,
             embeddingConfig,
           );
           const pipelineOptions: PipelineOptions = {


### PR DESCRIPTION
**Problem: not being able to launch docker stack**

### Steps to reproduce:

1. clone repo
2. export OPENAI_API_KEY envvar
3. `docker compose up -d && docker compose logs -f`

### Visual confirmation:
<img width="1404" height="585" alt="Screenshot 2025-09-30 at 08 38 08" src="https://github.com/user-attachments/assets/4155b6c4-4ab7-42f9-add8-61f604245ec1" />

### What's changed:
added resolving of the storePath in worker launch

### Visual confirmation of success:
<img width="739" height="950" alt="Screenshot 2025-09-30 at 08 38 39" src="https://github.com/user-attachments/assets/ba1c47d6-d39f-4999-8731-91844b0f78d7" />
<img width="705" height="850" alt="Screenshot 2025-09-30 at 08 38 50" src="https://github.com/user-attachments/assets/06bb612e-f2d6-4325-89ca-c605c7e3477f" />

