### PR TITLE
Add ETag and lastModified support with refresh job functionality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@
 - Focus on high value, low effort tests first. Defer complex mocking, complex state management testing and concurrent processing unless explicitly requested by the user.
 - Always test the intended bevavior, not the implementation details.
 - Avoid timing sensitive tests unless absolutely necessary.
+- Use `npx vite-node` to run individual TypeScript files.
 
 ## Git
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arabold/docs-mcp-server",
-  "version": "1.24.0",
+  "version": "1.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arabold/docs-mcp-server",
-      "version": "1.24.0",
+      "version": "1.26.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/cli/commands/findVersion.test.ts
+++ b/src/cli/commands/findVersion.test.ts
@@ -15,7 +15,7 @@ vi.mock("../utils", () => ({ setupLogging: vi.fn() }));
 
 import { findVersionAction } from "./findVersion";
 
-function cmd() {
+function _cmd() {
   return new Command();
 }
 beforeEach(() => vi.clearAllMocks());

--- a/src/cli/commands/list.test.ts
+++ b/src/cli/commands/list.test.ts
@@ -21,7 +21,7 @@ vi.mock("../utils", () => ({
 
 import { listAction } from "./list";
 
-function cmd() {
+function _cmd() {
   return new Command();
 }
 

--- a/src/cli/commands/remove.test.ts
+++ b/src/cli/commands/remove.test.ts
@@ -14,7 +14,7 @@ vi.mock("../utils", () => ({ setupLogging: vi.fn() }));
 
 import { removeAction } from "./remove";
 
-function cmd() {
+function _cmd() {
   return new Command();
 }
 beforeEach(() => {

--- a/src/cli/commands/search.test.ts
+++ b/src/cli/commands/search.test.ts
@@ -19,7 +19,7 @@ vi.mock("../utils", () => ({
 
 import { searchAction } from "./search";
 
-function cmd() {
+function _cmd() {
   return new Command();
 }
 beforeEach(() => vi.clearAllMocks());

--- a/src/pipeline/trpc/interfaces.ts
+++ b/src/pipeline/trpc/interfaces.ts
@@ -20,11 +20,12 @@ export interface PipelineOptions {
 export interface IPipeline {
   start(): Promise<void>;
   stop(): Promise<void>;
-  enqueueJob(
+  enqueueScrapeJob(
     library: string,
     version: string | undefined | null,
     options: ScraperOptions,
   ): Promise<string>;
+  enqueueRefreshJob(library: string, version: string | undefined | null): Promise<string>;
   getJob(jobId: string): Promise<PipelineJob | undefined>;
   getJobs(status?: PipelineJobStatus): Promise<PipelineJob[]>;
   cancelJob(jobId: string): Promise<void>;

--- a/src/scraper/fetcher/BrowserFetcher.ts
+++ b/src/scraper/fetcher/BrowserFetcher.ts
@@ -72,12 +72,16 @@ export class BrowserFetcher implements ContentFetcher {
       const contentType = response.headers()["content-type"] || "text/html";
       const { mimeType, charset } = MimeTypeUtils.parseContentType(contentType);
 
+      // Extract ETag header for caching
+      const etag = response.headers().etag;
+
       return {
         content: contentBuffer,
         mimeType,
         charset,
         encoding: undefined, // Browser handles encoding automatically
         source: finalUrl,
+        etag,
       } satisfies RawContent;
     } catch (error) {
       if (options?.signal?.aborted) {

--- a/src/scraper/fetcher/HttpFetcher.ts
+++ b/src/scraper/fetcher/HttpFetcher.ts
@@ -165,12 +165,23 @@ export class HttpFetcher implements ContentFetcher {
           response.config?.url ||
           source;
 
+        // Extract ETag header for caching
+        const etag = response.headers.etag || response.headers.ETag;
+
+        // Extract Last-Modified header for caching
+        const lastModified = response.headers["last-modified"];
+        const lastModifiedISO = lastModified
+          ? new Date(lastModified).toISOString()
+          : undefined;
+
         return {
           content,
           mimeType,
           charset,
           encoding: contentEncoding,
           source: finalUrl,
+          etag,
+          lastModified: lastModifiedISO,
         } satisfies RawContent;
       } catch (error: unknown) {
         const axiosError = error as AxiosError;

--- a/src/scraper/fetcher/types.ts
+++ b/src/scraper/fetcher/types.ts
@@ -20,6 +20,18 @@ export interface RawContent {
   encoding?: string;
   /** Original source location */
   source: string;
+  /**
+   * ETag value for caching purposes.
+   * For HTTP sources, this comes from the ETag header.
+   * For local files, this is a hash of the last modified date.
+   */
+  etag?: string;
+  /**
+   * Last modified timestamp in ISO8601 format.
+   * For HTTP sources, this comes from the Last-Modified header.
+   * For local files, this is the file modification time.
+   */
+  lastModified?: string;
 }
 
 /**

--- a/src/scraper/strategies/GitHubRepoScraperStrategy.ts
+++ b/src/scraper/strategies/GitHubRepoScraperStrategy.ts
@@ -471,6 +471,8 @@ export class GitHubRepoScraperStrategy extends BaseScraperStrategy {
             title: hasValidTitle ? processedTitle : fallbackTitle,
             library: options.library,
             version: options.version,
+            etag: rawContent.etag,
+            lastModified: rawContent.lastModified,
           },
           contentType: rawContent.mimeType, // Preserve the detected MIME type
         } satisfies Document,

--- a/src/scraper/strategies/GitHubWikiScraperStrategy.ts
+++ b/src/scraper/strategies/GitHubWikiScraperStrategy.ts
@@ -157,6 +157,8 @@ export class GitHubWikiScraperStrategy extends BaseScraperStrategy {
               : pageTitle,
           library: options.library,
           version: options.version,
+          etag: rawContent.etag,
+          lastModified: rawContent.lastModified,
         },
         contentType: rawContent.mimeType,
       };

--- a/src/scraper/strategies/LocalFileStrategy.test.ts
+++ b/src/scraper/strategies/LocalFileStrategy.test.ts
@@ -49,12 +49,14 @@ describe("LocalFileStrategy", () => {
         document: {
           content: "# Test\n\nThis is a test file.",
           contentType: "text/markdown",
-          metadata: {
+          metadata: expect.objectContaining({
             url: "file:///test.md",
             title: "Test",
             library: "test",
             version: "1.0",
-          },
+            etag: expect.any(String),
+            lastModified: expect.any(String),
+          }),
         },
       }),
     );

--- a/src/scraper/strategies/LocalFileStrategy.ts
+++ b/src/scraper/strategies/LocalFileStrategy.ts
@@ -94,6 +94,8 @@ export class LocalFileStrategy extends BaseScraperStrategy {
               : "Untitled",
           library: options.library,
           version: options.version,
+          etag: rawContent.etag,
+          lastModified: rawContent.lastModified,
         },
       } satisfies Document,
     };

--- a/src/scraper/strategies/WebScraperStrategy.ts
+++ b/src/scraper/strategies/WebScraperStrategy.ts
@@ -127,6 +127,8 @@ export class WebScraperStrategy extends BaseScraperStrategy {
                 : "Untitled",
             library: options.library,
             version: options.version,
+            etag: rawContent.etag,
+            lastModified: rawContent.lastModified,
             ...processed.metadata,
           },
         } satisfies Document,

--- a/src/store/DocumentManagementService.ts
+++ b/src/store/DocumentManagementService.ts
@@ -340,6 +340,27 @@ export class DocumentManagementService {
   }
 
   /**
+   * Removes all documents for a specific page ID.
+   * This is more efficient than URL-based deletion when the page ID is known.
+   */
+  async removeDocumentsByPageId(pageId: number): Promise<number> {
+    logger.debug(`🗑️ Removing documents for page ID: ${pageId}`);
+    const count = await this.store.deleteDocumentsByPageId(pageId);
+    logger.debug(`🗑️ Deleted ${count} documents for page ID: ${pageId}`);
+    return count;
+  }
+
+  /**
+   * Retrieves all pages for a specific version ID with their metadata.
+   * Used for refresh operations to get existing pages with their ETags.
+   */
+  async getPagesByVersionId(
+    versionId: number,
+  ): Promise<Array<{ id: number; url: string; etag: string | null }>> {
+    return this.store.getPagesByVersionId(versionId);
+  }
+
+  /**
    * Completely removes a library version and all associated documents.
    * Also removes the library if no other versions remain.
    * @param library Library name

--- a/src/store/DocumentStore.test.ts
+++ b/src/store/DocumentStore.test.ts
@@ -188,6 +188,55 @@ describe("DocumentStore - With Embeddings", () => {
       expect(versions).toContain("1.0.0");
       expect(versions).toContain("2.0.0");
     });
+
+    it("should store and retrieve etag and lastModified metadata", async () => {
+      const testEtag = '"abc123-def456"';
+      const testLastModified = "2023-12-01T10:30:00Z";
+
+      const docs: Document[] = [
+        {
+          pageContent: "Test document with etag and lastModified",
+          metadata: {
+            title: "ETag Test Doc",
+            url: "https://example.com/etag-test",
+            path: ["test"],
+            etag: testEtag,
+            lastModified: testLastModified,
+          },
+        },
+      ];
+
+      await store.addDocuments("etagtest", "1.0.0", docs);
+
+      // Query the database directly to verify the etag and last_modified are stored
+      // @ts-expect-error Accessing private property for testing
+      const db = store.db;
+      const pageResult = db
+        .prepare(`
+        SELECT p.etag, p.last_modified
+        FROM pages p
+        JOIN versions v ON p.version_id = v.id
+        JOIN libraries l ON v.library_id = l.id
+        WHERE l.name = ? AND COALESCE(v.name, '') = ? AND p.url = ?
+      `)
+        .get("etagtest", "1.0.0", "https://example.com/etag-test") as
+        | {
+            etag: string | null;
+            last_modified: string | null;
+          }
+        | undefined;
+
+      expect(pageResult).toBeDefined();
+      expect(pageResult?.etag).toBe(testEtag);
+      expect(pageResult?.last_modified).toBe(testLastModified);
+
+      // Also verify we can retrieve the document and it contains the metadata
+      const results = await store.findByContent("etagtest", "1.0.0", "etag", 10);
+      expect(results.length).toBeGreaterThan(0);
+
+      const doc = results[0];
+      expect(doc.metadata.url).toBe("https://example.com/etag-test");
+    });
   });
 
   describe("Hybrid Search with Embeddings", () => {

--- a/src/store/DocumentStore.ts
+++ b/src/store/DocumentStore.ts
@@ -80,6 +80,7 @@ export class DocumentStore {
     getPageId: Database.Statement<[number, string]>;
     deleteDocuments: Database.Statement<[string, string]>;
     deleteDocumentsByUrl: Database.Statement<[string, string, string]>;
+    deleteDocumentsByPageId: Database.Statement<[number]>;
     queryVersions: Database.Statement<[string]>;
     checkExists: Database.Statement<[string, string]>;
     queryLibraryVersions: Database.Statement<[]>;
@@ -113,6 +114,7 @@ export class DocumentStore {
     deleteLibraryById: Database.Statement<[number]>;
     countVersionsByLibraryId: Database.Statement<[number]>;
     getVersionId: Database.Statement<[string, string]>;
+    getPagesByVersionId: Database.Statement<[number]>;
   };
 
   /**
@@ -237,6 +239,9 @@ export class DocumentStore {
            JOIN libraries l ON v.library_id = l.id
            WHERE p.url = ? AND l.name = ? AND COALESCE(v.name, '') = COALESCE(?, '')
          )`,
+      ),
+      deleteDocumentsByPageId: this.db.prepare<[number]>(
+        "DELETE FROM documents WHERE page_id = ?",
       ),
       getDocumentBySort: this.db.prepare<[string, string]>(
         `SELECT d.id
@@ -373,6 +378,9 @@ export class DocumentStore {
         `SELECT v.id, v.library_id FROM versions v
          JOIN libraries l ON v.library_id = l.id
          WHERE l.name = ? AND COALESCE(v.name, '') = COALESCE(?, '')`,
+      ),
+      getPagesByVersionId: this.db.prepare<[number]>(
+        "SELECT id, url, etag FROM pages WHERE version_id = ?",
       ),
     };
     this.statements = statements;
@@ -1062,6 +1070,40 @@ export class DocumentStore {
       return result.changes;
     } catch (error) {
       throw new ConnectionError("Failed to delete documents by URL", error);
+    }
+  }
+
+  /**
+   * Removes all documents for a specific page ID.
+   * This is more efficient than URL-based deletion when the page ID is known.
+   * @returns Number of documents deleted
+   */
+  async deleteDocumentsByPageId(pageId: number): Promise<number> {
+    try {
+      const result = this.statements.deleteDocumentsByPageId.run(pageId);
+      return result.changes;
+    } catch (error) {
+      throw new ConnectionError("Failed to delete documents by page ID", error);
+    }
+  }
+
+  /**
+   * Retrieves all pages for a specific version ID with their metadata.
+   * Used for refresh operations to get existing pages with their ETags.
+   * @returns Array of page records
+   */
+  async getPagesByVersionId(
+    versionId: number,
+  ): Promise<Array<{ id: number; url: string; etag: string | null }>> {
+    try {
+      const result = this.statements.getPagesByVersionId.all(versionId) as Array<{
+        id: number;
+        url: string;
+        etag: string | null;
+      }>;
+      return result;
+    } catch (error) {
+      throw new ConnectionError("Failed to get pages by version ID", error);
     }
   }
 

--- a/src/store/DocumentStore.ts
+++ b/src/store/DocumentStore.ts
@@ -951,13 +951,19 @@ export class DocumentStore {
           // Extract content type from metadata if available
           const contentType = firstDoc.metadata.contentType || null;
 
+          // Extract etag from document metadata if available
+          const etag = firstDoc.metadata.etag || null;
+
+          // Extract lastModified from document metadata if available
+          const lastModified = firstDoc.metadata.lastModified || null;
+
           // Insert or update page record
           this.statements.insertPage.run(
             versionId,
             url,
             title,
-            null, // etag - will be populated during scraping
-            null, // last_modified - will be populated during scraping
+            etag,
+            lastModified,
             contentType,
           );
 

--- a/src/tools/RefreshVersionTool.ts
+++ b/src/tools/RefreshVersionTool.ts
@@ -1,0 +1,95 @@
+import * as semver from "semver";
+import type { IPipeline } from "../pipeline/trpc/interfaces";
+import { logger } from "../utils/logger";
+import { ValidationError } from "./errors";
+
+export interface RefreshVersionToolOptions {
+  library: string;
+  version?: string | null; // Make version optional
+  /** If false, returns jobId immediately without waiting. Defaults to true. */
+  waitForCompletion?: boolean;
+}
+
+export interface RefreshResult {
+  /** Indicates the number of pages refreshed if waitForCompletion was true and the job succeeded. May be 0 or inaccurate if job failed or waitForCompletion was false. */
+  pagesRefreshed: number;
+}
+
+/** Return type for RefreshVersionTool.execute */
+export type RefreshExecuteResult = RefreshResult | { jobId: string };
+
+/**
+ * Tool for refreshing an existing library version by re-scraping all pages
+ * and using Etag comparison to skip unchanged content.
+ */
+export class RefreshVersionTool {
+  private pipeline: IPipeline;
+
+  constructor(pipeline: IPipeline) {
+    this.pipeline = pipeline;
+  }
+
+  async execute(options: RefreshVersionToolOptions): Promise<RefreshExecuteResult> {
+    const { library, version, waitForCompletion = true } = options;
+
+    let internalVersion: string;
+    const partialVersionRegex = /^\d+(\.\d+)?$/; // Matches '1' or '1.2'
+
+    if (version === null || version === undefined) {
+      internalVersion = "";
+    } else {
+      const validFullVersion = semver.valid(version);
+      if (validFullVersion) {
+        internalVersion = validFullVersion;
+      } else if (partialVersionRegex.test(version)) {
+        const coercedVersion = semver.coerce(version);
+        if (coercedVersion) {
+          internalVersion = coercedVersion.version;
+        } else {
+          throw new ValidationError(
+            `Invalid version format for refreshing: '${version}'. Use 'X.Y.Z', 'X.Y.Z-prerelease', 'X.Y', 'X', or omit.`,
+            "RefreshVersionTool",
+          );
+        }
+      } else {
+        throw new ValidationError(
+          `Invalid version format for refreshing: '${version}'. Use 'X.Y.Z', 'X.Y.Z-prerelease', 'X.Y', 'X', or omit.`,
+          "RefreshVersionTool",
+        );
+      }
+    }
+
+    internalVersion = internalVersion.toLowerCase();
+
+    // Use the injected pipeline instance
+    const pipeline = this.pipeline;
+
+    // Normalize pipeline version argument: use null for unversioned to be explicit cross-platform
+    const refreshVersion: string | null = internalVersion === "" ? null : internalVersion;
+
+    // Enqueue the refresh job using the injected pipeline
+    const jobId = await pipeline.enqueueRefreshJob(library, refreshVersion);
+
+    // Conditionally wait for completion
+    if (waitForCompletion) {
+      try {
+        await pipeline.waitForJobCompletion(jobId);
+        // Fetch final job state to get status and potentially final page count
+        const finalJob = await pipeline.getJob(jobId);
+        const finalPagesRefreshed = finalJob?.progress?.pagesScraped ?? 0; // Get count from final job state
+        logger.debug(
+          `Refresh job ${jobId} finished with status ${finalJob?.status}. Pages refreshed: ${finalPagesRefreshed}`,
+        );
+        return {
+          pagesRefreshed: finalPagesRefreshed,
+        };
+      } catch (error) {
+        logger.error(`❌ Refresh job ${jobId} failed or was cancelled: ${error}`);
+        throw error; // Re-throw so the caller knows it failed
+      }
+    }
+
+    // If not waiting, return the job ID immediately
+    return { jobId };
+  }
+}

--- a/src/tools/ScrapeTool.ts
+++ b/src/tools/ScrapeTool.ts
@@ -132,7 +132,7 @@ export class ScrapeTool {
     const enqueueVersion: string | null = internalVersion === "" ? null : internalVersion;
 
     // Enqueue the job using the injected pipeline
-    const jobId = await pipeline.enqueueJob(library, enqueueVersion, {
+    const jobId = await pipeline.enqueueScrapeJob(library, enqueueVersion, {
       url: url,
       library: library,
       version: internalVersion,


### PR DESCRIPTION
Introduce ETag and lastModified metadata for improved caching in fetchers and strategies, along with the implementation of a refresh job feature to enhance document management.