### PR TITLE
fix(docker): use --legacy-peer-deps to resolve langchain dependency conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
 COPY package*.json ./
 
 # Install all dependencies (including dev dependencies for building)
-RUN npm ci
+RUN npm install --legacy-peer-deps
 
 # Copy source code
 COPY . .
@@ -28,7 +28,7 @@ COPY . .
 RUN npm run build
 
 # Install production dependencies in a clean directory
-RUN rm -rf node_modules && npm ci --omit=dev
+RUN rm -rf node_modules && npm install --legacy-peer-deps --omit=dev
 
 # Production stage
 FROM node:22-slim


### PR DESCRIPTION
## Problem
Docker build currently fails with a peer dependency conflict:
```
npm error ERESOLVE unable to resolve dependency tree
npm error peer @langchain/core@">=0.3.58 <0.4.0" from langchain@0.3.36
```

## Solution
Use `npm install --legacy-peer-deps` instead of `npm ci` to bypass the peer dependency conflict.

## Changes
- Line 22: `RUN npm ci` → `RUN npm install --legacy-peer-deps`
- Line 31: `RUN npm ci --omit=dev` → `RUN npm install --legacy-peer-deps --omit=dev`

## Testing
- ✅ Docker image builds successfully
- ✅ All services (worker, mcp, web) start correctly
- ✅ No functional regressions observed

## Alternative Considered
Updating langchain packages to ensure compatible versions, but this would require broader dependency updates and extensive testing across the entire codebase. Using `--legacy-peer-deps` is a minimal, non-invasive fix that unblocks Docker builds immediately.

## Related Issues
Addresses the build failure that occurs when running `docker build` on the current main branch.