### PR TITLE
Force close all active connections on server shutdown

### DIFF
--- a/src/app/AppServer.test.ts
+++ b/src/app/AppServer.test.ts
@@ -19,6 +19,7 @@ const mockFastify = vi.hoisted(() => ({
   setErrorHandler: vi.fn(), // Add missing mock method
   server: {
     on: vi.fn(), // Mock HTTP server for WebSocket upgrade handling
+    closeAllConnections: vi.fn(), // Mock for forcing connection closure
   },
 }));
 

--- a/src/app/AppServer.ts
+++ b/src/app/AppServer.ts
@@ -176,6 +176,11 @@ export class AppServer {
 
       // Close WebSocket server if it exists
       if (this.wss) {
+        // Forcibly close all active client connections before closing the server
+        for (const client of this.wss.clients) {
+          client.terminate();
+        }
+
         await new Promise<void>((resolve, reject) => {
           this.wss?.close((err) => {
             if (err) {
@@ -198,6 +203,11 @@ export class AppServer {
 
       // Shutdown telemetry service (this will flush remaining events)
       await telemetry.shutdown();
+
+      // Force close all connections to ensure immediate shutdown
+      if (this.server.server) {
+        this.server.server.closeAllConnections();
+      }
 
       // Close Fastify server
       await this.server.close();


### PR DESCRIPTION
Ensure all active client connections are forcibly closed before shutting down the server to prevent lingering connections. This change improves the shutdown process by terminating clients and closing the server connections immediately.