### PR TITLE
fix(scraper): correctly detect mime type for binary files from github

### DIFF
--- a/src/scraper/strategies/GitHubRepoProcessor.ts
+++ b/src/scraper/strategies/GitHubRepoProcessor.ts
@@ -83,9 +83,13 @@ export class GitHubRepoProcessor {
 
     const rawContent = await this.httpFetcher.fetch(rawUrl, { signal, etag });
 
-    // Override GitHub's generic 'text/plain' MIME type with file extension-based detection
+    // Override GitHub's generic 'text/plain' or 'application/octet-stream' MIME type with file extension-based detection
     const detectedMimeType = MimeTypeUtils.detectMimeTypeFromPath(filePath);
-    if (detectedMimeType && rawContent.mimeType === "text/plain") {
+    if (
+      detectedMimeType &&
+      (rawContent.mimeType === "text/plain" ||
+        rawContent.mimeType === "application/octet-stream")
+    ) {
       return {
         ...rawContent,
         mimeType: detectedMimeType,


### PR DESCRIPTION
## Summary
Fixes an issue where binary files (like PDFs) scraped from GitHub were being skipped because they were served with `application/octet-stream` MIME type.

## Changes
- Updated `GitHubRepoProcessor` to attempt file extension-based MIME type detection when the server returns `application/octet-stream`, in addition to `text/plain`.

## Testing
- Verified with unit tests.
- Confirmed that `MimeTypeUtils` correctly identifies `.pdf` files.