### PR TITLE
feat(splitter): enhance markdown chunking with list support

### DIFF
--- a/openspec/changes/archive/2026-01-11-enhance-markdown-chunking/.openspec.yaml
+++ b/openspec/changes/archive/2026-01-11-enhance-markdown-chunking/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-11

--- a/openspec/changes/archive/2026-01-11-enhance-markdown-chunking/design.md
+++ b/openspec/changes/archive/2026-01-11-enhance-markdown-chunking/design.md
@@ -1,0 +1,51 @@
+# Design: Enhanced Semantic Markdown Chunking
+
+## Problem
+The current `SemanticMarkdownSplitter` treats most non-heading elements as generic text. This leads to suboptimal chunking for structured content like lists, blockquotes, and media. Additionally, horizontal rules (`<hr>`) are ignored or treated as text separators, whereas they should act as explicit chunk boundaries.
+
+## Solution
+
+### 1. New Content Types
+We will extend `SectionContentType` to include:
+- `list`: For `<ul>` and `<ol>` elements.
+- `blockquote`: For `<blockquote>` elements.
+- `media`: For `<img>` elements.
+
+### 2. Horizontal Rules (`<hr>`)
+- In `splitIntoSections`, `<hr>` elements are detected and skipped (no `DocumentSection` is created for them).
+- Skipping `<hr>` acts as a hard split point between the sections created for the elements before and after it.
+- The `<hr>` itself will not be included in any section content, but its presence ensures that content before and after it are never merged into the same chunk.
+
+### 3. List Handling
+- `<ul>` and `<ol>` elements will be captured as `list` content type.
+- A new `ListContentSplitter` will be implemented.
+- It will attempt to keep the list intact if it fits in `preferredChunkSize`.
+- If larger, it will split at `<li>` boundaries (preserving list structure/indentation if possible, or at least ensuring items are not split mid-text unless an individual item is huge).
+
+### 4. Blockquote Handling
+- `<blockquote>` elements will be captured as `blockquote` content type.
+- They will be split using `TextContentSplitter` (or a specialized one) but preserving the `>` prefix on split chunks if possible is desirable (though standard `turndown` might just handle it as text with `>` markers). Keeping it as a separate type ensures we don't merge it with surrounding paragraphs.
+
+### 5. Media Handling
+- `<img>` elements will be captured as `media` content type.
+- This ensures images (and their alt text/src) are kept as distinct chunks or at least recognized as such.
+
+## Architecture Changes
+
+### Reference Pattern: Code Block Handling
+We will follow the existing pattern used for code blocks (`PRE`/`code` tags):
+1. **Detection**: Identify the specific HTML tag in `splitIntoSections` (e.g., `BLOCKQUOTE`, `UL`, `IMG`).
+2. **Extraction**: Convert the inner HTML back to Markdown using `turndown`.
+3. **Section Creation**: Create a new `DocumentSection` with the specific content type.
+4. **Splitting**: Delegate to a specific splitter in `splitSectionContent` (e.g., `ListContentSplitter` for lists, `TextContentSplitter` for blockquotes).
+
+### `SemanticMarkdownSplitter.ts`
+- Update `splitIntoSections` loop to handle `HR`, `UL/OL`, `BLOCKQUOTE`, `IMG`.
+- Update `splitSectionContent` switch case to handle new types.
+
+### `splitters/ListContentSplitter.ts`
+- New class implementing `ContentSplitter`.
+- Logic to split markdown lists.
+
+### `types.ts`
+- Update `SectionContentType`.

--- a/openspec/changes/archive/2026-01-11-enhance-markdown-chunking/proposal.md
+++ b/openspec/changes/archive/2026-01-11-enhance-markdown-chunking/proposal.md
@@ -1,0 +1,15 @@
+# Proposal: Enhance Semantic Markdown Chunking
+
+## Summary
+Improve the semantic chunking of markdown documents by recognizing and specifically handling more content types: horizontal rules, lists, blockquotes, and media.
+
+## Goals
+- Treat horizontal rules as explicit chunk separators.
+- Preserve list structure by chunking lists intelligently (avoiding splits inside items).
+- Handle blockquotes and media as distinct semantic units.
+- Improve the quality of RAG (Retrieval-Augmented Generation) by providing cleaner, more semantically meaningful chunks.
+
+## Scope
+- `SemanticMarkdownSplitter` logic.
+- New/Updated splitters for lists and text.
+- No changes to JSON splitting or other pipelines.

--- a/openspec/changes/archive/2026-01-11-enhance-markdown-chunking/specs/markdown-features/spec.md
+++ b/openspec/changes/archive/2026-01-11-enhance-markdown-chunking/specs/markdown-features/spec.md
@@ -1,0 +1,38 @@
+# Spec: Extended Markdown Features
+
+## ADDED Requirements
+
+### Requirement: Support horizontal rules as chunk separators
+The splitter MUST recognize horizontal rules (lines starting with `---`, `***`, or `___`) as explicit hard split points. Content before and after the rule MUST be placed in separate chunks.
+
+#### Scenario: Horizontal Rule Splitting
+Given a markdown document with two paragraphs separated by a horizontal rule
+When the document is split
+Then the paragraphs should be in separate chunks
+And the chunk boundary should align with the horizontal rule
+
+### Requirement: Support list chunking
+The splitter MUST recognize markdown lists (`-`, `*`, `1.`) by identifying `<ul>` and `<ol>` tags. It SHALL utilize a dedicated `ListContentSplitter` to attempt keeping the list within a single chunk. If the list exceeds the maximum chunk size, it SHALL split at list item boundaries rather than in the middle of an item's text.
+
+#### Scenario: List Preservation
+Given a markdown document with a bullet list
+When the document is split
+Then the list items should preferably be kept together
+And if the list is larger than the chunk size, it should split between list items
+
+### Requirement: Support blockquote chunking
+The splitter MUST recognize blockquotes (`>`) as distinct semantic units, following the same architectural pattern as code blocks. It SHALL identify `<blockquote>` elements during DOM traversal and capture them as a unique section type. They SHALL be chunked separately from surrounding text, preserving the `>` citation style.
+
+#### Scenario: Blockquote Isolation
+Given a markdown document with a blockquote
+When the document is split
+Then the blockquote should be treated as a distinct semantic unit
+And the content should preserve the ">" markdown prefix
+
+### Requirement: Support media chunking
+The splitter MUST recognize images and other media elements by identifying `<img>` tags. These SHALL be treated as distinct content types to ensure they are properly indexed and not merged destructively with unrelated text.
+
+#### Scenario: Image Handling
+Given a markdown document with an image
+When the document is split
+Then the image should be preserved as a content unit

--- a/openspec/changes/archive/2026-01-11-enhance-markdown-chunking/tasks.md
+++ b/openspec/changes/archive/2026-01-11-enhance-markdown-chunking/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [x] Define new `SectionContentType`s in `src/splitter/types.ts` <!-- id: types -->
+- [x] Create `ListContentSplitter` in `src/splitter/splitters/ListContentSplitter.ts` <!-- id: list-splitter -->
+- [x] Update `SemanticMarkdownSplitter.ts` to detect `HR`, `UL`, `OL`, `BLOCKQUOTE`, `IMG` <!-- id: splitter-logic -->
+- [x] Integrate `ListContentSplitter` into `SemanticMarkdownSplitter` <!-- id: integrate-list -->
+- [x] Add tests for `ListContentSplitter` <!-- id: test-list -->
+- [x] Add tests for `SemanticMarkdownSplitter` with new content types <!-- id: test-semantic -->
+- [x] Verify horizontal rule splitting behavior <!-- id: verify-hr -->

--- a/openspec/specs/markdown-features/spec.md
+++ b/openspec/specs/markdown-features/spec.md
@@ -1,0 +1,40 @@
+# markdown-features Specification
+
+## Purpose
+TBD - created by archiving change enhance-markdown-chunking. Update Purpose after archive.
+## Requirements
+### Requirement: Support horizontal rules as chunk separators
+The splitter MUST recognize horizontal rules (lines starting with `---`, `***`, or `___`) as explicit hard split points. Content before and after the rule MUST be placed in separate chunks.
+
+#### Scenario: Horizontal Rule Splitting
+Given a markdown document with two paragraphs separated by a horizontal rule
+When the document is split
+Then the paragraphs should be in separate chunks
+And the chunk boundary should align with the horizontal rule
+
+### Requirement: Support list chunking
+The splitter MUST recognize markdown lists (`-`, `*`, `1.`) by identifying `<ul>` and `<ol>` tags. It SHALL utilize a dedicated `ListContentSplitter` to attempt keeping the list within a single chunk. If the list exceeds the maximum chunk size, it SHALL split at list item boundaries rather than in the middle of an item's text.
+
+#### Scenario: List Preservation
+Given a markdown document with a bullet list
+When the document is split
+Then the list items should preferably be kept together
+And if the list is larger than the chunk size, it should split between list items
+
+### Requirement: Support blockquote chunking
+The splitter MUST recognize blockquotes (`>`) as distinct semantic units, following the same architectural pattern as code blocks. It SHALL identify `<blockquote>` elements during DOM traversal and capture them as a unique section type. They SHALL be chunked separately from surrounding text, preserving the `>` citation style.
+
+#### Scenario: Blockquote Isolation
+Given a markdown document with a blockquote
+When the document is split
+Then the blockquote should be treated as a distinct semantic unit
+And the content should preserve the ">" markdown prefix
+
+### Requirement: Support media chunking
+The splitter MUST recognize images and other media elements by identifying `<img>` tags. These SHALL be treated as distinct content types to ensure they are properly indexed and not merged destructively with unrelated text.
+
+#### Scenario: Image Handling
+Given a markdown document with an image
+When the document is split
+Then the image should be preserved as a content unit
+

--- a/src/splitter/splitters/ListContentSplitter.test.ts
+++ b/src/splitter/splitters/ListContentSplitter.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { ListContentSplitter } from "./ListContentSplitter";
+import type { ContentSplitterOptions } from "./types";
+
+describe("ListContentSplitter", () => {
+  const options = {
+    chunkSize: 50,
+  } satisfies ContentSplitterOptions;
+  const splitter = new ListContentSplitter(options);
+
+  it("should keep small lists intact", async () => {
+    const list = "- Item 1\n- Item 2\n- Item 3";
+    const chunks = await splitter.split(list);
+
+    expect(chunks.length).toBe(1);
+    expect(chunks[0]).toBe(list);
+  });
+
+  it("should split long lists by items", async () => {
+    // The first two items are around 45 chars each; the full list is > 50 chars, so it should split.
+    const list =
+      "- This is item number 1 which is quite long\n- This is item number 2 which is also long\n- This is item number 3";
+
+    const chunks = await splitter.split(list);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    // Should split at item boundaries
+    expect(chunks[0]).toContain("- This is item number 1");
+    // Verify all chunks respect size limit
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(options.chunkSize);
+    }
+  });
+
+  it("should merge small items if they fit", async () => {
+    // Items are short: "- A" (3 chars).
+    // Should merge many into one chunk.
+    const list = "- A\n- B\n- C\n- D\n- E\n- F\n- G\n- H\n- I\n- J";
+    const chunks = await splitter.split(list);
+
+    expect(chunks.length).toBe(1);
+    expect(chunks[0]).toBe(list);
+  });
+
+  it("should fallback to text splitting for huge items", async () => {
+    // Item bigger than chunk size (50)
+    const hugeItem =
+      "- This is a very very very very very very very very very long item that needs splitting";
+    const list = `${hugeItem}\n- Short item`;
+
+    const chunks = await splitter.split(list);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    // The huge item should be split into multiple chunks
+    const hugeItemChunks = chunks.filter((c) => c.includes("very very"));
+    expect(hugeItemChunks.length).toBeGreaterThan(0);
+
+    // Verify size limits
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(options.chunkSize);
+    }
+  });
+
+  it("should handle numbered lists", async () => {
+    const list = "1. Item 1\n2. Item 2\n3. Item 3";
+    const chunks = await splitter.split(list);
+    expect(chunks.length).toBe(1);
+    expect(chunks[0]).toBe(list);
+  });
+});

--- a/src/splitter/splitters/ListContentSplitter.ts
+++ b/src/splitter/splitters/ListContentSplitter.ts
@@ -1,0 +1,99 @@
+import { TextContentSplitter } from "./TextContentSplitter";
+import type { ContentSplitter, ContentSplitterOptions } from "./types";
+
+export class ListContentSplitter implements ContentSplitter {
+  private textSplitter: TextContentSplitter;
+
+  constructor(private options: ContentSplitterOptions) {
+    this.textSplitter = new TextContentSplitter(options);
+  }
+
+  async split(content: string): Promise<string[]> {
+    if (content.length <= this.options.chunkSize) {
+      return [content];
+    }
+
+    // Split by list items
+    // This regex looks for lines starting with -, *, or digits followed by dot, at the start of line or after newline
+    // It captures the delimiter to keep it
+    const listItems = this.splitByListItems(content);
+
+    // Merge items that fit together
+    const mergedChunks = this.mergeChunks(listItems);
+
+    // Check if any chunk is still too large
+    const finalChunks: string[] = [];
+    for (const chunk of mergedChunks) {
+      if (chunk.length > this.options.chunkSize) {
+        // Fallback to text splitting for huge items
+        const subChunks = await this.textSplitter.split(chunk);
+        finalChunks.push(...subChunks);
+      } else {
+        finalChunks.push(chunk);
+      }
+    }
+
+    return finalChunks;
+  }
+
+  private splitByListItems(content: string): string[] {
+    const lines = content.split("\n");
+    const items: string[] = [];
+    let currentItem = "";
+
+    // Regex for list item start: optional whitespace, then -, *, or 1., then space
+    const listItemRegex = /^\s*([-*]|\d+\.)\s/;
+
+    for (const line of lines) {
+      if (listItemRegex.test(line)) {
+        // Start of new item
+        if (currentItem) {
+          items.push(currentItem);
+        }
+        currentItem = line;
+      } else {
+        // Continuation of current item (or content before first item)
+        if (currentItem) {
+          currentItem += `\n${line}`;
+        } else {
+          // Content before first list item? Should rarely happen if we passed a list
+          // But valid markdown can have text before list in same block if not carefully separated
+          currentItem = line;
+        }
+      }
+    }
+
+    if (currentItem) {
+      items.push(currentItem);
+    }
+
+    return items;
+  }
+
+  private mergeChunks(chunks: string[]): string[] {
+    const mergedChunks: string[] = [];
+    let currentChunk = "";
+
+    for (const chunk of chunks) {
+      if (!currentChunk) {
+        currentChunk = chunk;
+        continue;
+      }
+
+      // Check if adding this chunk exceeds size
+      // We add a newline separator since we split by lines originally
+      if (currentChunk.length + 1 + chunk.length <= this.options.chunkSize) {
+        currentChunk += `\n${chunk}`;
+      } else {
+        mergedChunks.push(currentChunk);
+        currentChunk = chunk;
+      }
+    }
+
+    if (currentChunk) {
+      mergedChunks.push(currentChunk);
+    }
+
+    return mergedChunks;
+  }
+}

--- a/src/splitter/splitters/index.ts
+++ b/src/splitter/splitters/index.ts
@@ -1,4 +1,5 @@
 export * from "./CodeContentSplitter";
+export * from "./ListContentSplitter";
 export * from "./TableContentSplitter";
 export * from "./TextContentSplitter";
 export * from "./types";

--- a/src/splitter/types.ts
+++ b/src/splitter/types.ts
@@ -7,7 +7,10 @@ export type SectionContentType =
   | "table"
   | "heading"
   | "structural"
-  | "frontmatter";
+  | "frontmatter"
+  | "list"
+  | "blockquote"
+  | "media";
 
 /**
  * Final output chunk after processing and size-based splitting


### PR DESCRIPTION
## Summary
This PR enhances the `SemanticMarkdownSplitter` to provide better chunking for structured content. Specifically:
- **Lists**: Detected and processed via a new `ListContentSplitter` that keeps items together where possible.
- **Blockquotes**: Recognized as distinct semantic units.
- **Media**: Images are now separated into their own `media` chunks.
- **Horizontal Rules**: Treated as hard split points.

## Changes
- Updated `SemanticMarkdownSplitter` to handle `UL`, `OL`, `BLOCKQUOTE`, `IMG`, and `HR` tags.
- Added `ListContentSplitter` for intelligent list processing.
- Updated `SectionContentType` type definition.
- Refactored section creation logic to reduce duplication.

## Testing
- Added comprehensive unit tests for `ListContentSplitter`.
- Added new test cases to `SemanticMarkdownSplitter` covering all new features.
- Verified no regressions in existing tests.