### PR TITLE
feat(cli): add ascii art banner on server startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
         "6280",
         "--server-url",
         "http://worker:8080/api",
+        "--no-logo",
       ]
     container_name: docs-mcp-server
     restart: unless-stopped
@@ -86,6 +87,7 @@ services:
         "6281",
         "--server-url",
         "http://worker:8080/api",
+        "--no-logo",
       ]
     container_name: docs-mcp-web
     restart: unless-stopped

--- a/src/app/AppServer.ts
+++ b/src/app/AppServer.ts
@@ -20,6 +20,7 @@ import { registerWorkerService, stopWorkerService } from "../services/workerServ
 import type { IDocumentManagement } from "../store/trpc/interfaces";
 import { TelemetryEvent, telemetry } from "../telemetry";
 import { shouldEnableTelemetry } from "../telemetry/TelemetryConfig";
+import { printBanner } from "../utils/banner";
 import type { AppConfig } from "../utils/config";
 import { logger } from "../utils/logger";
 import { getProjectRoot } from "../utils/paths";
@@ -513,6 +514,11 @@ export class AppServer {
    * Log startup information showing which services are enabled.
    */
   private logStartupInfo(address: string): void {
+    // Print the ASCII art banner if enabled
+    if (this.serverConfig.showLogo !== false) {
+      printBanner();
+    }
+
     // Determine the service mode
     const isWorkerOnly =
       this.serverConfig.enableWorker &&

--- a/src/app/AppServerConfig.ts
+++ b/src/app/AppServerConfig.ts
@@ -28,6 +28,9 @@ export interface AppServerConfig {
   /** URL of external worker server (if using external worker instead of embedded) */
   externalWorkerUrl?: string;
 
+  /** Show ASCII art logo on startup (default: true) */
+  showLogo?: boolean;
+
   /** Startup context for telemetry (optional) */
   startupContext?: {
     /** CLI command that started the server (if applicable) */

--- a/src/cli/commands/default.ts
+++ b/src/cli/commands/default.ts
@@ -166,6 +166,7 @@ export function createDefaultAction(cli: Argv) {
           enableApiServer: true,
           enableWorker: true,
           port: appConfig.server.ports.default,
+          showLogo: argv.logo as boolean,
           startupContext: {
             cliCommand: "default",
             mcpProtocol: "http",

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -176,6 +176,7 @@ export function createMcpCommand(cli: Argv) {
             enableWorker: !serverUrl,
             port: appConfig.server.ports.mcp,
             externalWorkerUrl: serverUrl,
+            showLogo: argv.logo as boolean,
             startupContext: {
               cliCommand: "mcp",
               mcpProtocol: "http",

--- a/src/cli/commands/web.ts
+++ b/src/cli/commands/web.ts
@@ -97,6 +97,7 @@ export function createWebCommand(cli: Argv) {
           enableWorker: !serverUrl,
           port: appConfig.server.ports.web,
           externalWorkerUrl: serverUrl,
+          showLogo: argv.logo as boolean,
           startupContext: {
             cliCommand: "web",
           },

--- a/src/cli/commands/worker.ts
+++ b/src/cli/commands/worker.ts
@@ -92,6 +92,7 @@ export function createWorkerCommand(cli: Argv) {
           enableApiServer: true,
           enableWorker: true,
           port: appConfig.server.ports.worker,
+          showLogo: argv.logo as boolean,
           startupContext: {
             cliCommand: "worker",
           },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -76,6 +76,11 @@ export function createCli(argv: string[]): Argv {
       type: "string",
       description: "Path to configuration file",
     })
+    .option("logo", {
+      type: "boolean",
+      description: "Show ASCII art logo on startup",
+      default: true,
+    })
     // Middleware for Global Setup (similar to preAction)
     .middleware(async (argv) => {
       // 0. Validate Options

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -200,6 +200,7 @@ export function createAppServerConfig(options: {
   enableWorker?: boolean;
   port: number;
   externalWorkerUrl?: string;
+  showLogo?: boolean;
   startupContext?: {
     cliCommand?: string;
     mcpProtocol?: "stdio" | "http";
@@ -213,6 +214,7 @@ export function createAppServerConfig(options: {
     enableWorker: options.enableWorker ?? true,
     port: options.port,
     externalWorkerUrl: options.externalWorkerUrl,
+    showLogo: options.showLogo ?? true,
     startupContext: options.startupContext,
   };
 }

--- a/src/utils/banner.ts
+++ b/src/utils/banner.ts
@@ -1,0 +1,18 @@
+/**
+ * ASCII art banner for console startup display.
+ * Uses ANSI colors: gray (dim) top line, bright white bottom line.
+ */
+export const BANNER = [
+  "\x1b[90m  █▀▀ █▀█ █▀█ █ █ █▄ █ █▀▄ █▀▀ █▀▄   █▀▄ █▀█ █▀▀ █▀▀\x1b[0m",
+  "\x1b[97m  █▄█ █▀▄ █▄█ █▄█ █ ▀█ █▄▀ ██▄ █▄▀   █▄▀ █▄█ █▄▄ ▄▄█\x1b[0m",
+].join("\n");
+
+/**
+ * Prints the startup banner to console.
+ * Only call this for HTTP server startup, not stdio mode.
+ */
+export function printBanner(): void {
+  console.log(); // Blank line before banner
+  console.log(BANNER);
+  console.log(); // Blank line after banner
+}


### PR DESCRIPTION
## Summary

Adds a stylish ASCII art "Grounded Docs" banner that displays on HTTP server startup.

- **Gray/white gradient**: Top line in gray, bottom line in bright white for a modern look
- **Configurable**: `--logo` / `--no-logo` CLI flag (default: show logo)
- **Non-intrusive**: Only shows for HTTP server startup, not stdio mode
- **Docker-optimized**: Only worker shows banner in docker-compose (mcp/web use `--no-logo`)

## Preview

```
  █▀▀ █▀█ █▀█ █ █ █▄ █ █▀▄ █▀▀ █▀▄   █▀▄ █▀█ █▀▀ █▀▀   (gray)
  █▄█ █▀▄ █▄█ █▄█ █ ▀█ █▄▀ ██▄ █▄▀   █▄▀ █▄█ █▄▄ ▄▄█   (bright white)

🚀 Worker available at http://localhost:8080
```

## Files Changed

- `src/utils/banner.ts` - New banner utility
- `src/cli/index.ts` - Global `--logo` option
- `src/app/AppServerConfig.ts` - `showLogo` config property
- `src/cli/utils.ts` - Updated `createAppServerConfig()`
- `src/cli/commands/*.ts` - Pass `showLogo` through
- `src/app/AppServer.ts` - Conditional banner display
- `docker-compose.yml` - `--no-logo` for mcp/web services