### PR TITLE
Provide `openai:` prefix 

### DIFF
--- a/docs/guides/embedding-models.md
+++ b/docs/guides/embedding-models.md
@@ -54,7 +54,7 @@ Run local models compatible with the OpenAI API format.
 ```bash
 OPENAI_API_KEY="ollama" \
 OPENAI_API_BASE="http://localhost:11434/v1" \
-DOCS_MCP_EMBEDDING_MODEL="nomic-embed-text" \
+DOCS_MCP_EMBEDDING_MODEL="openai:nomic-embed-text" \
 npx @arabold/docs-mcp-server@latest
 ```
 


### PR DESCRIPTION
## Problem

It fees like docs should be explicit to tell users to add `openai:` prefix when using ollama embedding models. 

I got following error for another model : 
```
OPENAI_API_KEY="ollama" \
OPENAI_API_BASE="http://localhost:11434/v1" \
DOCS_MCP_EMBEDDING_MODEL="embeddinggemma:latest" \
npx @arabold/docs-mcp-server@latest
⚠️  No credentials found for embeddinggemma embedding provider. Vector search is disabled.
   Only full-text search will be available. To enable vector search, please configure the required
   environment variables for embeddinggemma or choose a different provider.
   See README.md for configuration options or run with --help for more details.
🚀 Grounded Docs available at http://127.0.0.1:6280
   • Web interface: http://127.0.0.1:6280
   • MCP endpoints: http://127.0.0.1:6280/mcp, http://127.0.0.1:6280/sse
   • Embeddings: disabled (full text search only)
```

## Fix 
```
DOCS_MCP_EMBEDDING_MODEL="openai:embeddinggemma:latest" \
```

## Similar Issue
- https://github.com/arabold/docs-mcp-server/issues/254 
