### PR TITLE
fix(scraper): improve file extension detection for complex URLs

### DIFF
--- a/src/scraper/pipelines/DocumentPipeline.test.ts
+++ b/src/scraper/pipelines/DocumentPipeline.test.ts
@@ -257,6 +257,57 @@ describe("DocumentPipeline", () => {
       expect(result.contentType).toBe("text/markdown");
     });
 
+    it("should handle URL with hash fragment", async () => {
+      const content = loadFixture("sample.pdf");
+      const rawContent: RawContent = {
+        content,
+        mimeType: "application/pdf",
+        source: "https://example.com/documents/report.pdf#section-1",
+        status: FetchStatus.SUCCESS,
+      };
+
+      const result = await pipeline.process(rawContent, baseOptions);
+
+      // Should succeed using MIME type detection
+      expect(result.errors).toHaveLength(0);
+      expect(result.textContent).toBeTruthy();
+      expect(result.contentType).toBe("text/markdown");
+    });
+
+    it("should extract extension from URL when MIME type is generic (query params)", async () => {
+      const content = loadFixture("sample.pdf");
+      const rawContent: RawContent = {
+        content,
+        mimeType: "application/octet-stream", // Generic MIME type
+        source: "https://example.com/documents/report.pdf?version=2",
+        status: FetchStatus.SUCCESS,
+      };
+
+      const result = await pipeline.process(rawContent, baseOptions);
+
+      // Should succeed using URL parsing fallback
+      expect(result.errors).toHaveLength(0);
+      expect(result.textContent).toBeTruthy();
+      expect(result.contentType).toBe("text/markdown");
+    });
+
+    it("should extract extension from URL when MIME type is generic (hash fragment)", async () => {
+      const content = loadFixture("sample.pdf");
+      const rawContent: RawContent = {
+        content,
+        mimeType: "application/octet-stream", // Generic MIME type
+        source: "https://example.com/files/document.pdf#page-3",
+        status: FetchStatus.SUCCESS,
+      };
+
+      const result = await pipeline.process(rawContent, baseOptions);
+
+      // Should succeed using URL parsing fallback
+      expect(result.errors).toHaveLength(0);
+      expect(result.textContent).toBeTruthy();
+      expect(result.contentType).toBe("text/markdown");
+    });
+
     it("should fail when both MIME type and extension are unavailable", async () => {
       const content = loadFixture("sample.pdf");
       const rawContent: RawContent = {


### PR DESCRIPTION
## Summary

Fixes file extension detection for PDFs and documents with complex URL structures that include query parameters, hash IDs, or have extensions in the middle of the URL path.

## Problem

The current file extension detection logic fails when processing URLs that don't end cleanly with a file extension. This causes the `DocumentPipeline` to reject valid PDF and document URLs with the error "Could not determine file extension."

**Examples of failing URLs:**
- `https://example.com/file.pdf/59569026-c221-12db-de3f-98becb9a67af?t=1767868182094`
- `https://example.com/docs/file.pdf/some-hash-id/download`
- `https://example.com/documents/report.pdf?version=2`

## Solution

Implemented a two-strategy approach for file extension detection:

1. **Primary Strategy**: Extract extension from HTTP `Content-Type` header
   - Most reliable method as it comes directly from the server
   - Maps common MIME types (e.g., `application/pdf` → `pdf`)
   
2. **Fallback Strategy**: Parse extension from URL path with improved handling
   - Strips query parameters (`?`) and hash fragments (`#`) before parsing
   - Uses regex to find ALL extensions in the path and returns the last one
   - Handles edge cases like `/file.pdf/something` correctly

## Changes

- **`src/scraper/pipelines/DocumentPipeline.ts`**:
  - Updated `extractExtension()` to accept `mimeType` parameter
  - Added `getExtensionFromMimeType()` for Content-Type header parsing
  - Improved `getExtensionFromPath()` to handle complex URL structures
  - Enhanced error logging to include MIME type information

- **`src/scraper/pipelines/DocumentPipeline.test.ts`**:
  - Added test for URLs with query parameters
  - Added test for PDFs with extension in middle of URL path
  - Added test for failure case when both MIME type and extension are unavailable
  - Updated existing test to verify MIME type detection works without extension

## Testing

- ✅ All unit tests pass
- ✅ Tested with real-world complex PDF URLs
- ✅ Verified fallback behavior when MIME type is unavailable
- ✅ Confirmed error handling when both strategies fail

## Related Issues

This addresses the issue where documents from certain CDNs and document management systems (that use hash-based routing or tracking parameters) were being rejected during scraping.