### PR TITLE
Support configurable embedding vector dimension for OpenAI-compatible providers

### DIFF
--- a/db/migrations/012-drop-documents-vec-for-runtime.sql
+++ b/db/migrations/012-drop-documents-vec-for-runtime.sql
@@ -1,4 +1,0 @@
--- Migration: Drop documents_vec so the app can recreate it at runtime with configurable embedding dimension.
--- Supports different embedding providers (e.g. 1536 vs 3584 dimensions). The table is recreated in
--- DocumentStore.ensureVectorTable() using config.embeddings.vectorDimension (env: DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION).
-DROP TABLE IF EXISTS documents_vec;

--- a/db/migrations/013-create-metadata-table.sql
+++ b/db/migrations/013-create-metadata-table.sql
@@ -1,0 +1,7 @@
+-- Migration: Create metadata table for tracking global configuration state.
+-- Used to persist the active embedding model and vector dimension so the system
+-- can detect configuration changes between startups and prevent silent data corruption.
+CREATE TABLE IF NOT EXISTS metadata (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);

--- a/docs/concepts/data-storage.md
+++ b/docs/concepts/data-storage.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-The storage system uses SQLite with a normalized, four-table schema design for efficient document storage, retrieval, and version management. The schema supports page-level metadata tracking, ETag-based change detection, and hierarchical document chunking.
+The storage system uses SQLite with a normalized schema design for efficient document storage, retrieval, and version management. The schema supports page-level metadata tracking, ETag-based change detection, hierarchical document chunking, and embedding model identity tracking.
 
 ## Database Schema
 
-The database consists of four core tables with normalized relationships:
+The database consists of four core tables with normalized relationships, plus a metadata table for system-level configuration tracking:
 
 ```mermaid
 erDiagram
@@ -57,6 +57,11 @@ erDiagram
         int sort_order
         blob embedding
         datetime created_at
+    }
+
+    metadata {
+        text key PK
+        text value
     }
 ```
 
@@ -137,6 +142,18 @@ Document chunks with embeddings and hierarchical metadata.
 
 **Code Reference:** `src/store/types.ts` lines 39-48 (DbChunk interface)
 
+### Metadata Table
+
+Key-value store for system-level configuration tracking, independent of library/version data.
+
+**Schema:**
+- `key` (TEXT PRIMARY KEY): Configuration key name
+- `value` (TEXT NOT NULL): Configuration value
+
+**Purpose:** Tracks the active embedding model identity (`embedding_model` and `embedding_dimension` keys) to detect incompatible configuration changes between server restarts. When a model or dimension change is detected, the server prompts the user to confirm vector invalidation before proceeding.
+
+**Code Reference:** `db/migrations/013-create-metadata-table.sql`, `src/store/DocumentStore.ts` - `getEmbeddingMetadata()`, `setEmbeddingMetadata()`, `checkEmbeddingModelChange()`
+
 ## Schema Evolution
 
 ### Migration System
@@ -154,6 +171,9 @@ Sequential SQL migrations in `db/migrations/`:
 9. `008-case-insensitive-names.sql` - Case-insensitive library name handling
 10. `009-add-pages-table.sql` - Page-level metadata normalization
 11. `010-add-depth-to-pages.sql` - Crawl depth tracking for refresh operations
+12. `011-add-vector-triggers.sql` - FTS and vector table trigger maintenance
+13. `012-add-source-content-type.sql` - Source content type tracking on pages
+14. `013-create-metadata-table.sql` - Key-value metadata table for embedding model tracking
 
 **Code Reference:** All migration files in `db/migrations/` directory
 

--- a/docs/guides/embedding-models.md
+++ b/docs/guides/embedding-models.md
@@ -113,3 +113,36 @@ AZURE_OPENAI_API_VERSION="2024-02-01" \
 DOCS_MCP_EMBEDDING_MODEL="microsoft:text-embedding-ada-002" \
 npx @arabold/docs-mcp-server@latest
 ```
+
+## Changing the Embedding Model
+
+When you change the embedding model or vector dimension after initial setup, existing embedding vectors become semantically incompatible with the new configuration. The server detects this automatically by tracking the active model identity in a metadata table.
+
+### What Happens on Model Change
+
+**Interactive mode (TTY connected):** The server displays a warning and prompts for confirmation before proceeding. Rejecting the prompt aborts startup with no changes made.
+
+```
+⚠️  Embedding model change detected:
+   Previous: openai:text-embedding-3-small (1536 dimensions)
+   Current:  openai:text-embedding-ada-002 (1536 dimensions)
+
+   All existing embedding vectors will be invalidated.
+   Libraries must be re-scraped to restore vector search.
+   Full-text search will continue working for all existing documents.
+
+   Proceed with model change? (y/N)
+```
+
+**Non-interactive mode (MCP/stdio, CI/CD):** The server fails startup entirely with a descriptive error message. To resolve the change, start the server interactively once to confirm the migration.
+
+### After Confirming a Model Change
+
+- All stored embedding vectors are set to NULL
+- The vector search index (`documents_vec`) is recreated empty with the new dimension
+- Full-text search continues working for all existing documents
+- Libraries must be re-scraped to regenerate embeddings with the new model
+
+### Vector Dimension Override
+
+The vector dimension defaults to the model's native dimension (e.g., 1536 for `text-embedding-3-small`). You can override it with `embeddings.vectorDimension` in the config file or `DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION` as an environment variable. The value must be a positive integer (minimum 1).

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -223,7 +223,7 @@ Settings for the vector embedding generation.
 | `batchChars` | `50000` | Maximum total characters per embedding batch. |
 | `requestTimeoutMs` | `30000` | Timeout for each embedding API request (ms). |
 | `initTimeoutMs` | `30000` | Timeout for the initial test embedding during model initialization (ms). |
-| `vectorDimension` | `1536` | Dimension of the vector space (must match model). |
+| `vectorDimension` | `1536` | Dimension of the vector space. Must be a positive integer (minimum 1). Override with `DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION`. Changing this value triggers a model change confirmation on next startup. |
 
 ### Search (`search`)
 

--- a/openspec/changes/add-embedding-model-change-safety/.openspec.yaml
+++ b/openspec/changes/add-embedding-model-change-safety/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-17

--- a/openspec/changes/add-embedding-model-change-safety/design.md
+++ b/openspec/changes/add-embedding-model-change-safety/design.md
@@ -1,0 +1,128 @@
+## Context
+
+The system uses embedding vectors for semantic search via `sqlite-vec`. Vectors are produced by a configured embedding model (e.g., `openai:text-embedding-3-small`) and stored in `documents.embedding` (JSON blob) alongside an indexed `documents_vec` virtual table. The vector table is currently created by a SQL migration with a hard-coded dimension of 1536.
+
+PR 330 introduces runtime-configurable vector dimensions so different embedding providers (e.g., 1536d for OpenAI, 3584d for Gemini) can work without migration changes. However, it has critical gaps:
+
+1. **Silent backfill of incompatible vectors**: When the dimension changes, `ensureVectorTable()` drops and recreates the vec table, then backfills old vectors that were padded to the previous dimension. These old vectors are dimensionally and semantically incompatible with the new configuration.
+2. **No model change detection**: Switching between models with the same dimension (e.g., `text-embedding-3-small` to `text-embedding-ada-002`, both 1536d) is completely undetected. Old vectors remain, producing silently degraded search results.
+3. **No user feedback**: There is no warning, confirmation prompt, or guidance when the embedding configuration changes.
+
+The existing specs document this as a "known gap" in `embedding-generation/spec.md:154` but provide no solution.
+
+**Stakeholders**: All users who configure embedding models, especially those running the server in MCP/stdio mode where there is no TTY for interactive prompts.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Detect embedding model and/or vector dimension changes at startup by comparing the current configuration against persisted metadata in the database.
+- Require explicit user confirmation (interactive TTY) before proceeding with a destructive model change.
+- Fail startup entirely in non-interactive mode (no TTY) when a model change is detected, with a clear error message explaining what happened and how to resolve it.
+- On confirmed change, invalidate all existing vectors (set to NULL) and recreate the vec table empty -- no backfill of incompatible data.
+- Silently initialize metadata on first startup or upgrade from a pre-metadata database.
+- Adopt PR 330's `ensureVectorTable()` approach for runtime-configurable dimensions, but fix the broken backfill.
+
+**Non-Goals:**
+- Per-library or per-version model tracking. A global metadata record is sufficient; per-vector model tracking would bloat table sizes with no practical benefit since you cannot mix models within a search anyway.
+- Automatic re-scraping after model change. The system invalidates vectors and continues in FTS-only mode; the user must manually re-scrape to regenerate vectors.
+- Supporting multiple embedding models simultaneously. The system uses one model globally.
+- Migrating or converting vectors between models. This is mathematically impossible for different embedding spaces.
+
+## Decisions
+
+### Decision 1: Global Metadata Table for Model Tracking
+
+**Choice**: Store embedding model identity and dimension in a new `metadata` key-value table (`CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)`).
+
+**Alternatives considered**:
+- *Per-vector model column in `documents`*: Rejected -- massive storage bloat (one string per row) for information that is always the same globally. The system enforces a single model across the entire database.
+- *Per-version model tracking*: Rejected -- adds complexity without benefit. Even if tracked per-version, you cannot search across versions with mixed models. A global record is sufficient to detect changes.
+- *File-based metadata (e.g., `.embedding-meta.json`)*: Rejected -- metadata should live alongside the data it describes. A separate file can get out of sync with the database.
+
+**Keys stored**:
+- `embedding_model`: The full model spec string (e.g., `openai:text-embedding-3-small`). Compared against `config.app.embeddingModel`.
+- `embedding_dimension`: The configured vector dimension as a string (e.g., `"1536"`). Compared against `config.embeddings.vectorDimension`.
+
+### Decision 2: Fail Non-Interactive Startup on Model Change
+
+**Choice**: When a model or dimension change is detected and `process.stdout.isTTY` is falsy, throw a fatal `EmbeddingModelChangedError` that prevents startup entirely.
+
+**Rationale**: In MCP/stdio mode, there is no user present to see warnings. Silently degrading search quality or silently dropping vectors could lead to hours of confusion. A hard failure with a descriptive error message is the safest option for automated environments.
+
+**Error message format**:
+```
+Embedding model change detected:
+  Previous: openai:text-embedding-3-small (1536 dimensions)
+  Current:  gemini:embedding-001 (768 dimensions)
+
+All existing vectors are incompatible and must be invalidated.
+To confirm this change, start the server interactively (with a TTY connected)
+and follow the prompts.
+```
+
+**Alternative considered**:
+- *Escape hatch env var (`DOCS_MCP_CONFIRM_MODEL_CHANGE=true`)*: Not adopted initially to keep the surface area small. Can be added later if automated deployments need it.
+
+### Decision 3: Interactive Confirmation Flow
+
+**Choice**: When a model change is detected and `process.stdout.isTTY` is truthy, display a warning and prompt the user for explicit confirmation before proceeding.
+
+**Flow**:
+1. Display warning with previous vs. current model/dimension
+2. Explain consequences: "All existing embedding vectors will be invalidated. Libraries must be re-scraped to restore vector search."
+3. Prompt: `Proceed with model change? (y/N)`
+4. Default is `N` (abort). Only `y` or `Y` confirms.
+5. On confirm: invalidate vectors, update metadata, continue startup.
+6. On abort: throw error, exit.
+
+**Implementation**: The confirmation prompt is handled at the CLI layer (not in `DocumentStore`). `DocumentStore.initialize()` detects the mismatch and throws a structured error (`EmbeddingModelChangedError`) containing old/new model info. The CLI command handler catches this error and either prompts (TTY) or re-throws (non-TTY).
+
+### Decision 4: Vector Invalidation Strategy
+
+**Choice**: On confirmed model change, execute two operations in a transaction:
+1. `UPDATE documents SET embedding = NULL` -- clears all stored embedding blobs
+2. Drop and recreate `documents_vec` as empty (no backfill)
+
+**Rationale**: Setting embeddings to NULL rather than deleting documents preserves all indexed content. FTS search continues working immediately. The user can re-scrape at their convenience to regenerate vectors.
+
+**Alternative considered**:
+- *Delete only from `documents_vec`, keep `documents.embedding` blobs*: Rejected -- stale blobs would be backfilled into the vec table on next dimension reconciliation, recreating the incompatibility problem.
+
+### Decision 5: First-Run / Upgrade Behavior
+
+**Choice**: If the `metadata` table does not contain `embedding_model` or `embedding_dimension` keys, silently store the current configuration values without prompting.
+
+**Rationale**: Existing deployments upgrading to this version have no stored metadata. Requiring confirmation on upgrade would break all existing automated deployments. The first run establishes the baseline; subsequent changes are detected against it.
+
+### Decision 6: Initialization Order in DocumentStore
+
+**Choice**: The startup sequence in `DocumentStore.initialize()` becomes:
+1. Load `sqlite-vec` extension
+2. Apply migrations (including metadata table creation)
+3. Check embedding model/dimension metadata (detect changes, throw if mismatch)
+4. If no mismatch (or after confirmed invalidation): `ensureVectorTable()` with current dimension
+5. Prepare SQL statements
+6. Initialize embeddings client
+
+This ensures the metadata check happens before any table manipulation, preventing the table from being left in an inconsistent state if the user aborts.
+
+### Decision 7: Adopt PR 330's ensureVectorTable() With Fixes
+
+**Choice**: Keep PR 330's approach of creating `documents_vec` at runtime with configurable dimensions, but modify the backfill behavior:
+- On **first creation** (table doesn't exist): Create empty. Vectors will be populated during scraping.
+- On **dimension match** (table exists, same dimension): No-op. Existing vectors are valid.
+- On **dimension mismatch**: This case is now handled by the model change detection in step 3 above. By the time `ensureVectorTable()` runs, vectors have already been invalidated if needed.
+
+The original PR 330 backfill (`INSERT OR REPLACE ... FROM documents WHERE embedding IS NOT NULL`) is removed entirely.
+
+## Risks / Trade-offs
+
+**[Risk] Non-interactive failure blocks automated deployments that intentionally change models** → Mitigation: The error message clearly explains how to resolve it (interactive startup). A future enhancement could add a `DOCS_MCP_CONFIRM_MODEL_CHANGE=true` env var escape hatch if demand warrants it.
+
+**[Risk] First-run silent initialization stores wrong baseline if config is misconfigured** → Mitigation: The baseline is only stored after successful embedding initialization. If the model fails to initialize (bad credentials, invalid model), no metadata is stored, so the next attempt with correct config becomes the new "first run."
+
+**[Risk] Setting all embeddings to NULL is expensive on large databases** → Mitigation: This is a single UPDATE statement that SQLite handles efficiently. The alternative (deleting and re-inserting documents) would be far more expensive and would break FTS indexes.
+
+**[Risk] Users may not realize they need to re-scrape after model change** → Mitigation: The confirmation prompt and post-invalidation log message explicitly state that re-scraping is required. The system continues in FTS-only mode as a safety net.
+
+**[Trade-off] Global model tracking vs per-version tracking** → We chose global for simplicity. This means the system cannot detect if individual versions were scraped with different models (e.g., if a user changed models between scraping two libraries). This is acceptable because: (a) search is always performed within a single version, and (b) the model change detection catches the transition point.

--- a/openspec/changes/add-embedding-model-change-safety/proposal.md
+++ b/openspec/changes/add-embedding-model-change-safety/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The system currently has no mechanism to detect when the configured embedding model or vector dimension changes between startups. Vectors produced by different embedding models are semantically incompatible -- cosine similarity between them is meaningless -- yet the system silently continues serving degraded search results. PR 330 introduces configurable vector dimensions but compounds this problem by silently backfilling old vectors into a potentially incompatible table. This change adds safety rails to prevent silent data corruption and enforce explicit user acknowledgment before invalidating existing vectors.
+
+## What Changes
+
+- **BREAKING**: Non-interactive startup (MCP/stdio) SHALL fail with a descriptive error when an embedding model or dimension change is detected, requiring manual interactive confirmation.
+- Store the active embedding model identifier and vector dimension as global metadata in the database to enable change detection across restarts.
+- On first startup (or upgrade from a database without metadata), silently initialize the metadata record with the current configuration -- no user action required.
+- When a model or dimension change is detected during interactive startup, display a warning explaining that all existing vectors will be invalidated, and require explicit user confirmation before proceeding.
+- On confirmed model/dimension change, set all `documents.embedding` values to `NULL` and recreate the `documents_vec` table empty (no backfill of incompatible vectors).
+- Adopt PR 330's runtime-configurable `documents_vec` creation via `ensureVectorTable()`, but remove the broken backfill that inserts old-dimension vectors into a new-dimension table.
+- Add Zod validation ensuring `vectorDimension >= 1`.
+
+## Capabilities
+
+### New Capabilities
+- `embedding-model-change-safety`: Defines startup-time detection of embedding model/dimension changes, interactive confirmation flow, non-interactive failure behavior, vector invalidation on confirmed change, and metadata persistence for tracking the active embedding configuration.
+
+### Modified Capabilities
+- `embedding-generation`: Close the documented "known gap" about model change tracking. Add requirements for vector invalidation when the model changes, and update dimension normalization to cover runtime-configurable vector table creation.
+- `embedding-resolution`: Add requirements for persisting resolved model identity to the database and detecting mismatches on subsequent startups.
+- `configuration`: Add `embeddings.vectorDimension` as a documented configurable parameter with Zod validation (`>= 1`).
+
+## Impact
+
+- **`src/store/DocumentStore.ts`**: Major changes to `initialize()`, new `ensureVectorTable()` method (from PR 330, modified), new metadata read/write methods, new vector invalidation method.
+- **`src/store/embeddings/`**: No structural changes, but `EmbeddingConfig` output is now persisted to the database.
+- **`src/utils/config.ts`**: Minor -- add `.min(1)` validation on `vectorDimension` (from PR 330).
+- **`db/migrations/`**: New migration to create `metadata` table. Migration 012 from PR 330 (drop `documents_vec`) is adopted.
+- **`src/cli/`**: Startup commands need to handle interactive confirmation prompts and non-interactive failure for model changes.
+- **User-facing docs**: `docs/guides/embedding-models.md` and `docs/setup/configuration.md` need updates explaining model change behavior and `vectorDimension` configuration.

--- a/openspec/changes/add-embedding-model-change-safety/specs/configuration/spec.md
+++ b/openspec/changes/add-embedding-model-change-safety/specs/configuration/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Vector Dimension Configuration
+The system SHALL support a configurable vector dimension via the `embeddings.vectorDimension` configuration key. This value determines the size of the `documents_vec` virtual table column and the target dimension for vector padding/truncation.
+
+The configuration key SHALL follow the standard configuration precedence:
+1. Built-in default: `1536` (lowest priority)
+2. Configuration file (`config.yaml`, key `embeddings.vectorDimension`)
+3. Environment variable (`DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION`)
+4. CLI arguments (highest priority)
+
+The Zod schema SHALL validate that `vectorDimension` is a positive integer (`>= 1`). Values of 0, negative numbers, or non-integers SHALL be rejected at configuration load time.
+
+#### Scenario: Default vector dimension
+- **WHEN** no `vectorDimension` override is specified
+- **THEN** the system SHALL use 1536 as the vector dimension
+
+#### Scenario: Custom vector dimension via environment variable
+- **WHEN** `DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION` is set to `768`
+- **THEN** the system SHALL use 768 as the vector dimension
+- **AND** the `documents_vec` table SHALL use `embedding FLOAT[768]`
+
+#### Scenario: Invalid vector dimension rejected
+- **WHEN** `DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION` is set to `0`
+- **THEN** the system SHALL reject the configuration with an error message
+- **AND** startup SHALL fail
+
+#### Scenario: Non-integer vector dimension rejected
+- **WHEN** `DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION` is set to `768.5`
+- **THEN** the system SHALL reject the configuration with an error message

--- a/openspec/changes/add-embedding-model-change-safety/specs/embedding-generation/spec.md
+++ b/openspec/changes/add-embedding-model-change-safety/specs/embedding-generation/spec.md
@@ -1,0 +1,70 @@
+## MODIFIED Requirements
+
+### Requirement: Vector Dimension Normalization
+The system SHALL normalize all embedding vectors to a fixed database dimension (`embeddings.vectorDimension`, default 1536) before storage:
+
+- **Oversized vector with MRL truncation enabled** (e.g., Gemini models via `FixedDimensionEmbeddings`): The system SHALL truncate the vector to the target dimension by keeping only the first N elements. This is valid for Matryoshka Representation Learning (MRL) models.
+- **Oversized vector without truncation**: The system SHALL raise a `DimensionError`.
+- **Undersized vector**: The system SHALL pad the vector with zeros to reach the target dimension.
+
+The target dimension (`embeddings.vectorDimension`) is configurable at runtime and determines the size of the `documents_vec` virtual table. When the dimension changes between startups, the model change detection system SHALL handle invalidation before any new vectors are stored.
+
+**Code reference:** `src/store/embeddings/FixedDimensionEmbeddings.ts:13-67`, `src/store/DocumentStore.ts:455-465`
+
+#### Scenario: Gemini model with MRL truncation
+- **WHEN** a Gemini embedding model returns 768-dimensional vectors
+- **AND** the database vector dimension is 1536
+- **THEN** the system SHALL zero-pad the vector to 1536 dimensions
+
+#### Scenario: Model returns oversized vector without MRL support
+- **WHEN** an embedding model returns 2048-dimensional vectors
+- **AND** MRL truncation is not enabled for the model
+- **AND** the database vector dimension is 1536
+- **THEN** the system SHALL raise a `DimensionError`
+
+#### Scenario: Model returns exact target dimensions
+- **WHEN** an embedding model returns 1536-dimensional vectors
+- **AND** the database vector dimension is 1536
+- **THEN** the system SHALL store the vector as-is without modification
+
+#### Scenario: Custom vector dimension configuration
+- **WHEN** `embeddings.vectorDimension` is set to 768
+- **AND** the embedding model returns 768-dimensional vectors
+- **THEN** the system SHALL store the vector as-is without modification
+- **AND** the `documents_vec` table SHALL use `embedding FLOAT[768]`
+
+### Requirement: Embedding Skip When Disabled
+When embeddings are disabled (no model configured, missing credentials, or initialization failure), the system SHALL skip all embedding generation without raising errors:
+
+- No embedding API calls SHALL be made
+- Document chunks SHALL be stored with `NULL` embedding values
+- The FTS5 full-text search index SHALL still be populated
+- Documents SHALL remain fully searchable via full-text search
+
+When the embedding model changes and vectors are invalidated, existing documents SHALL have their embeddings set to `NULL`. The system SHALL continue operating in FTS-only mode for those documents until they are re-scraped with the new model.
+
+**Code reference:** `src/store/DocumentStore.ts:483-486, 1166-1169, 1308`
+
+#### Scenario: No embedding model configured
+- **WHEN** no embedding model is configured and no `OPENAI_API_KEY` is set
+- **THEN** the system SHALL log that embedding initialization was skipped (FTS-only mode)
+- **AND** documents SHALL be stored without embeddings
+- **AND** documents SHALL be searchable via full-text search
+
+#### Scenario: Embedding initialization failure
+- **WHEN** the embedding model is configured but initialization fails (e.g., invalid API key, network error)
+- **THEN** the system SHALL log the error
+- **AND** the system SHALL continue operating in FTS-only mode
+- **AND** documents SHALL be stored without embeddings
+
+#### Scenario: Vectors invalidated after model change
+- **WHEN** a model change has been confirmed and vectors have been invalidated
+- **THEN** all existing documents SHALL have `NULL` embeddings
+- **AND** FTS search SHALL continue working for all documents
+- **AND** vector search SHALL return no results until libraries are re-scraped
+
+## REMOVED Requirements
+
+### Requirement: Known Gap Documentation
+**Reason**: The "known gap" note previously documented at the end of this spec ("The system does not track which embedding model was used for existing vectors...") is now resolved by the `embedding-model-change-safety` capability, which implements model tracking via database metadata and vector invalidation on model change.
+**Migration**: No code migration needed. The gap is closed by the new `embedding-model-change-safety` spec.

--- a/openspec/changes/add-embedding-model-change-safety/specs/embedding-model-change-safety/spec.md
+++ b/openspec/changes/add-embedding-model-change-safety/specs/embedding-model-change-safety/spec.md
@@ -1,0 +1,171 @@
+## ADDED Requirements
+
+### Requirement: Embedding Metadata Persistence
+The system SHALL persist the active embedding configuration in a `metadata` table in the SQLite database using two key-value pairs:
+
+- `embedding_model`: The full model specification string (e.g., `openai:text-embedding-3-small`)
+- `embedding_dimension`: The configured vector dimension as a string (e.g., `"1536"`)
+
+The `metadata` table SHALL be created by a database migration with the schema `CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)`.
+
+The metadata SHALL be written after successful embedding initialization during `DocumentStore.initialize()`. If embeddings are disabled (FTS-only mode), no embedding metadata SHALL be stored.
+
+#### Scenario: Metadata stored after successful embedding init
+- **WHEN** the embedding model `openai:text-embedding-3-small` with dimension 1536 initializes successfully
+- **THEN** the system SHALL store `embedding_model = "openai:text-embedding-3-small"` in the `metadata` table
+- **AND** the system SHALL store `embedding_dimension = "1536"` in the `metadata` table
+
+#### Scenario: No metadata stored in FTS-only mode
+- **WHEN** embeddings are disabled (no model configured or missing credentials)
+- **THEN** the system SHALL NOT store any embedding metadata
+- **AND** the `metadata` table SHALL remain empty (for embedding keys)
+
+### Requirement: First-Run Silent Initialization
+On first startup, or when upgrading from a database that does not yet contain embedding metadata keys, the system SHALL silently store the current embedding configuration without prompting the user. This establishes the baseline for future change detection.
+
+#### Scenario: First startup with new database
+- **WHEN** the `metadata` table exists but contains no `embedding_model` key
+- **AND** the configured embedding model is `openai:text-embedding-3-small` with dimension 1536
+- **THEN** the system SHALL store the current model and dimension in the metadata table without prompting
+- **AND** startup SHALL proceed normally
+
+#### Scenario: Upgrade from pre-metadata database
+- **WHEN** the `metadata` table is created by a new migration on an existing database
+- **AND** no `embedding_model` key exists yet
+- **THEN** the system SHALL treat this as a first-run scenario and silently initialize the metadata
+
+### Requirement: Model Change Detection
+During `DocumentStore.initialize()`, after applying migrations but before creating the vector table, the system SHALL compare the configured embedding model and dimension against the values stored in the `metadata` table. A change is detected when either:
+
+- The `embedding_model` value differs from `config.app.embeddingModel`, OR
+- The `embedding_dimension` value differs from `config.embeddings.vectorDimension`
+
+When a change is detected, the system SHALL throw an `EmbeddingModelChangedError` containing the previous and current model identifiers and dimensions. This error is structured to enable the CLI layer to decide how to handle it (prompt or fail).
+
+#### Scenario: Model changed, same dimension
+- **WHEN** the stored `embedding_model` is `openai:text-embedding-3-small`
+- **AND** the configured model is `openai:text-embedding-ada-002`
+- **AND** both models use dimension 1536
+- **THEN** the system SHALL detect a model change and throw `EmbeddingModelChangedError`
+
+#### Scenario: Dimension changed, same model
+- **WHEN** the stored `embedding_dimension` is `"1536"`
+- **AND** the configured dimension is `768`
+- **AND** the model has not changed
+- **THEN** the system SHALL detect a dimension change and throw `EmbeddingModelChangedError`
+
+#### Scenario: Both model and dimension changed
+- **WHEN** the stored model is `openai:text-embedding-3-small` with dimension `"1536"`
+- **AND** the configured model is `gemini:embedding-001` with dimension `768`
+- **THEN** the system SHALL detect the change and throw `EmbeddingModelChangedError`
+
+#### Scenario: No change detected
+- **WHEN** the stored `embedding_model` matches the configured model
+- **AND** the stored `embedding_dimension` matches the configured dimension
+- **THEN** startup SHALL proceed normally without any prompt or error
+
+#### Scenario: No stored metadata (first run)
+- **WHEN** no `embedding_model` key exists in the `metadata` table
+- **THEN** the system SHALL NOT treat this as a change
+- **AND** startup SHALL proceed normally (silent initialization applies)
+
+### Requirement: Non-Interactive Startup Failure
+When an `EmbeddingModelChangedError` is thrown and `process.stdout.isTTY` is falsy (non-interactive mode, e.g., MCP/stdio), the system SHALL fail startup entirely with a descriptive error message. The error message SHALL include:
+
+- The previous model and dimension
+- The current model and dimension
+- Instructions to start the server interactively (with a TTY) to confirm the change
+
+The system SHALL NOT fall back to FTS-only mode, SHALL NOT silently proceed, and SHALL NOT invalidate vectors without explicit confirmation.
+
+#### Scenario: Model change in MCP/stdio mode
+- **WHEN** a model change is detected
+- **AND** `process.stdout.isTTY` is falsy
+- **THEN** the system SHALL terminate startup with an error
+- **AND** the error message SHALL include the previous and current model/dimension values
+- **AND** the error message SHALL instruct the user to start interactively
+
+#### Scenario: Model change in piped output
+- **WHEN** a model change is detected
+- **AND** stdout is redirected to a pipe or file
+- **THEN** the system SHALL treat this as non-interactive and fail startup
+
+### Requirement: Interactive Confirmation Flow
+When an `EmbeddingModelChangedError` is thrown and `process.stdout.isTTY` is truthy (interactive mode), the CLI layer SHALL display a warning and prompt for explicit user confirmation before proceeding.
+
+The prompt flow SHALL be:
+1. Display the previous and current model/dimension values
+2. Explain the consequences: all existing embedding vectors will be invalidated and libraries must be re-scraped to restore vector search
+3. Prompt with `Proceed with model change? (y/N)` where the default is `N` (abort)
+4. Only `y` or `Y` SHALL be accepted as confirmation
+
+On confirmation, the system SHALL invoke vector invalidation and update the metadata, then retry initialization. On abort, the system SHALL exit with an error.
+
+#### Scenario: User confirms model change interactively
+- **WHEN** a model change is detected in interactive mode
+- **AND** the user responds `y` to the confirmation prompt
+- **THEN** the system SHALL invalidate all existing vectors
+- **AND** the system SHALL update the metadata with the new model and dimension
+- **AND** startup SHALL proceed
+
+#### Scenario: User aborts model change interactively
+- **WHEN** a model change is detected in interactive mode
+- **AND** the user responds `N` (or presses Enter for default)
+- **THEN** the system SHALL exit with an error
+- **AND** no vectors SHALL be invalidated
+- **AND** the metadata SHALL remain unchanged
+
+#### Scenario: User enters invalid input
+- **WHEN** a model change is detected in interactive mode
+- **AND** the user responds with anything other than `y`, `Y`, `n`, `N`, or Enter
+- **THEN** the system SHALL treat the response as a rejection (same as `N`)
+
+### Requirement: Vector Invalidation on Confirmed Change
+When a model or dimension change is confirmed (either via interactive prompt or future escape mechanisms), the system SHALL invalidate all existing embedding vectors:
+
+1. Execute `UPDATE documents SET embedding = NULL` to clear all stored embedding blobs
+2. Drop and recreate the `documents_vec` virtual table as empty (no backfill)
+3. Update the `metadata` table with the new `embedding_model` and `embedding_dimension` values
+4. Log a message indicating vectors have been invalidated and re-scraping is required
+
+These operations SHALL be performed atomically in a transaction (except for the virtual table DDL, which SQLite does not support in transactions; the table drop/create SHALL happen immediately after the UPDATE).
+
+After invalidation, the system SHALL continue startup. Documents remain fully searchable via full-text search. Vector search results will be empty until libraries are re-scraped.
+
+#### Scenario: Full vector invalidation
+- **WHEN** a model change is confirmed
+- **AND** 10,000 documents have existing embeddings
+- **THEN** all 10,000 `documents.embedding` values SHALL be set to NULL
+- **AND** `documents_vec` SHALL be recreated as empty
+- **AND** the metadata SHALL be updated to the new model and dimension
+- **AND** FTS search SHALL continue working for all documents
+
+#### Scenario: Post-invalidation search behavior
+- **WHEN** vectors have been invalidated
+- **AND** the user performs a search
+- **THEN** the system SHALL fall back to FTS-only search
+- **AND** vector similarity search SHALL return no results (empty vec table)
+
+### Requirement: Runtime-Configurable Vector Table
+The `documents_vec` virtual table SHALL be created at runtime by `DocumentStore.ensureVectorTable()` using the configured `embeddings.vectorDimension` rather than being defined in a SQL migration. A migration SHALL drop any existing hard-coded `documents_vec` table to allow runtime recreation.
+
+The method SHALL:
+- Validate that the dimension is a positive integer (throw `StoreError` otherwise)
+- Check if `documents_vec` already exists with the correct dimension (no-op if matching)
+- If the table does not exist, create it with the configured dimension
+- NOT backfill vectors from the `documents` table (vectors are populated only during scraping)
+
+#### Scenario: First startup creates vector table
+- **WHEN** `documents_vec` does not exist
+- **AND** `vectorDimension` is configured as 1536
+- **THEN** the system SHALL create `documents_vec` with `embedding FLOAT[1536]`
+- **AND** the table SHALL be empty
+
+#### Scenario: Matching dimension is a no-op
+- **WHEN** `documents_vec` exists with dimension 1536
+- **AND** `vectorDimension` is configured as 1536
+- **THEN** `ensureVectorTable()` SHALL make no changes
+
+#### Scenario: Invalid dimension rejected
+- **WHEN** `vectorDimension` is 0 or negative
+- **THEN** the system SHALL throw a `StoreError`

--- a/openspec/changes/add-embedding-model-change-safety/specs/embedding-resolution/spec.md
+++ b/openspec/changes/add-embedding-model-change-safety/specs/embedding-resolution/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Embedding Identity Persistence
+After successful embedding initialization, the system SHALL persist the resolved embedding model identity to the database `metadata` table. This enables detection of model changes on subsequent startups. The persisted values SHALL be the model specification string as provided in configuration (e.g., `openai:text-embedding-3-small` or `gemini:embedding-001`) and the configured vector dimension.
+
+The persistence SHALL occur as the final step of `initializeEmbeddings()`, after dimension detection and validation have succeeded. If embedding initialization fails or is skipped (FTS-only mode), no metadata SHALL be written.
+
+#### Scenario: Model identity persisted after successful init
+- **WHEN** the embedding model `gemini:embedding-001` initializes successfully with dimension 768
+- **THEN** the system SHALL store `embedding_model = "gemini:embedding-001"` in the `metadata` table
+- **AND** the system SHALL store `embedding_dimension = "768"` in the `metadata` table
+
+#### Scenario: Model identity not persisted on init failure
+- **WHEN** the embedding model fails to initialize (e.g., network timeout)
+- **THEN** no embedding metadata SHALL be written to the `metadata` table
+- **AND** any previously stored metadata SHALL remain unchanged
+
+### Requirement: Startup Model Mismatch Detection
+During initialization, after migrations are applied, the system SHALL read the stored `embedding_model` and `embedding_dimension` from the `metadata` table and compare them against the current configuration. If either value differs, the system SHALL throw a structured `EmbeddingModelChangedError` before proceeding with vector table creation or embedding client initialization.
+
+This check SHALL occur only when both conditions are true:
+1. The `metadata` table contains an `embedding_model` key (not a first-run scenario)
+2. The current configuration specifies an embedding model (not FTS-only mode)
+
+#### Scenario: Mismatch detected before vec table creation
+- **WHEN** the stored model is `openai:text-embedding-3-small` (1536d)
+- **AND** the configured model is `gemini:embedding-001` (768d)
+- **THEN** the system SHALL throw `EmbeddingModelChangedError` before creating/modifying the `documents_vec` table
+- **AND** the vector table SHALL remain in its previous state until the change is confirmed or rejected
+
+#### Scenario: FTS-only mode skips mismatch check
+- **WHEN** the configured embedding model is empty or credentials are missing
+- **AND** the stored model is `openai:text-embedding-3-small`
+- **THEN** the system SHALL NOT throw an error
+- **AND** the system SHALL proceed in FTS-only mode
+- **AND** the stored metadata SHALL remain unchanged

--- a/openspec/changes/add-embedding-model-change-safety/tasks.md
+++ b/openspec/changes/add-embedding-model-change-safety/tasks.md
@@ -1,0 +1,75 @@
+## 1. Database Schema & Migrations
+
+- [x] 1.1 Remove PR 330's destructive `012-drop-documents-vec-for-runtime.sql` migration (unnecessary — `ensureVectorTable()` reconciles dimensions at runtime without data loss)
+- [x] 1.2 Create migration `013-create-metadata-table.sql` with `CREATE TABLE IF NOT EXISTS metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)`
+- [x] 1.3 Add `EmbeddingModelChangedError` to `src/store/errors.ts` with fields for `previousModel`, `previousDimension`, `currentModel`, `currentDimension`
+
+## 2. Metadata Persistence in DocumentStore
+
+- [x] 2.1 Add prepared statements for metadata CRUD: `getMetadata(key)`, `setMetadata(key, value)` in `DocumentStore.prepareStatements()`
+- [x] 2.2 Add `getEmbeddingMetadata()` method to read `embedding_model` and `embedding_dimension` from the metadata table
+- [x] 2.3 Add `setEmbeddingMetadata(model, dimension)` method to write/update both keys in the metadata table
+- [x] 2.4 Call `setEmbeddingMetadata()` at the end of successful `initializeEmbeddings()` to persist the active model identity
+
+## 3. Model Change Detection
+
+- [x] 3.1 Add `checkEmbeddingModelChange()` method to `DocumentStore` that compares stored metadata against current config and throws `EmbeddingModelChangedError` on mismatch
+- [x] 3.2 Handle first-run case: if no `embedding_model` key exists in metadata, skip the check (silent initialization)
+- [x] 3.3 Handle FTS-only case: if current config has no embedding model or credentials are missing, skip the check
+- [x] 3.4 Integrate `checkEmbeddingModelChange()` into `DocumentStore.initialize()` after migrations but before `ensureVectorTable()`
+
+## 4. Vector Invalidation
+
+- [x] 4.1 Add `invalidateAllVectors()` method to `DocumentStore` that executes `UPDATE documents SET embedding = NULL` and drops/recreates `documents_vec` as empty
+- [x] 4.2 Ensure `invalidateAllVectors()` updates the metadata table with the new model and dimension after clearing vectors
+- [x] 4.3 Add logging to `invalidateAllVectors()` indicating vectors have been cleared and re-scraping is required
+
+## 5. Fix ensureVectorTable() from PR 330
+
+- [x] 5.1 Remove the backfill `INSERT OR REPLACE INTO documents_vec ... FROM documents WHERE embedding IS NOT NULL` from `ensureVectorTable()`
+- [x] 5.2 Keep the dimension validation, existing-table detection, and drop/recreate logic from PR 330
+- [x] 5.3 Confirm no backfill in `ensureVectorTable()` — vectors are populated during scraping, not at startup
+
+## 6. Configuration Validation
+
+- [x] 6.1 Add `.min(1, "embedding dimension must be at least 1")` to the `vectorDimension` Zod schema in `src/utils/config.ts` (from PR 330, already present)
+- [x] 6.2 Verify that `DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION` env var is correctly auto-mapped via `mapEnvToConfig()`
+
+## 7. CLI Interactive Confirmation Flow
+
+- [x] 7.1 Add `EmbeddingModelChangedError` handling in the CLI startup path (likely `src/cli/utils.ts` or individual command handlers)
+- [x] 7.2 Implement TTY detection: check `process.stdout.isTTY` when catching `EmbeddingModelChangedError`
+- [x] 7.3 Implement non-interactive path: re-throw the error with a descriptive message instructing the user to start interactively
+- [x] 7.4 Implement interactive path: display warning with previous/current model+dimension, prompt `Proceed with model change? (y/N)`, handle user input
+- [x] 7.5 On user confirmation (`y`/`Y`): call `invalidateAllVectors()` on the DocumentStore, then retry initialization
+- [x] 7.6 On user rejection (any other input or Enter): exit with error, no changes made
+
+## 8. Update DocumentStore.initialize() Sequence
+
+- [x] 8.1 Reorder initialization steps: (1) load sqlite-vec, (2) apply migrations, (3) check embedding model metadata, (4) ensureVectorTable(), (5) prepare statements, (6) initialize embeddings, (7) persist metadata
+- [x] 8.2 Ensure `ensureVectorTable()` runs only after model change detection has passed (or after invalidation is complete)
+- [x] 8.3 Expose a method or mechanism for the CLI layer to call `invalidateAllVectors()` and retry `initialize()` after user confirmation
+
+## 9. Tests
+
+- [x] 9.1 Test metadata table creation via migration (metadata table exists after `applyMigrations`)
+- [x] 9.2 Test `getEmbeddingMetadata()` returns null when no keys exist (first-run)
+- [x] 9.3 Test `setEmbeddingMetadata()` writes and reads correctly
+- [x] 9.4 Test `checkEmbeddingModelChange()` throws `EmbeddingModelChangedError` when model differs
+- [x] 9.5 Test `checkEmbeddingModelChange()` throws `EmbeddingModelChangedError` when dimension differs
+- [x] 9.6 Test `checkEmbeddingModelChange()` does not throw when model and dimension match
+- [x] 9.7 Test `checkEmbeddingModelChange()` does not throw on first run (no stored metadata)
+- [x] 9.8 Test `checkEmbeddingModelChange()` does not throw when in FTS-only mode
+- [x] 9.9 Test `invalidateAllVectors()` sets all embeddings to NULL
+- [x] 9.10 Test `invalidateAllVectors()` recreates `documents_vec` as empty
+- [x] 9.11 Test `invalidateAllVectors()` updates metadata with new model and dimension
+- [x] 9.12 Test `ensureVectorTable()` creates table with configured dimension (no backfill)
+- [x] 9.13 Test `ensureVectorTable()` is no-op when dimension matches
+- [x] 9.14 Test Zod schema rejects `vectorDimension` of 0 or negative values
+- [x] 9.15 Update existing `applyMigrations.test.ts` tests from PR 330 to account for metadata table
+
+## 10. Documentation Updates
+
+- [x] 10.1 Update `docs/guides/embedding-models.md` with a section on model change behavior (warning, confirmation, re-scraping)
+- [x] 10.2 Update `docs/setup/configuration.md` to document `embeddings.vectorDimension` with its env var and validation rules
+- [x] 10.3 Update `docs/concepts/data-storage.md` to describe the metadata table and embedding model tracking

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arabold/docs-mcp-server",
-  "version": "2.0.4",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arabold/docs-mcp-server",
-      "version": "2.0.4",
+      "version": "2.1.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/cli/commands/default.test.ts
+++ b/src/cli/commands/default.test.ts
@@ -23,7 +23,15 @@ vi.mock("../../mcp/tools", () => ({
 }));
 
 vi.mock("../../store", () => ({
-  createLocalDocumentManagement: vi.fn(async () => ({ shutdown: vi.fn() })),
+  DocumentManagementService: vi.fn().mockImplementation(() => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn(),
+  })),
+}));
+vi.mock("../../store/errors", () => ({
+  EmbeddingModelChangedError: class EmbeddingModelChangedError extends Error {
+    name = "EmbeddingModelChangedError";
+  },
 }));
 vi.mock("../../pipeline", () => ({
   PipelineFactory: {

--- a/src/cli/commands/default.ts
+++ b/src/cli/commands/default.ts
@@ -7,7 +7,8 @@ import { startAppServer } from "../../app";
 import { startStdioServer } from "../../mcp/startStdioServer";
 import { initializeTools } from "../../mcp/tools";
 import { PipelineFactory, type PipelineOptions } from "../../pipeline";
-import { createLocalDocumentManagement } from "../../store";
+import { DocumentManagementService } from "../../store";
+import { EmbeddingModelChangedError } from "../../store/errors";
 import { TelemetryEvent, telemetry } from "../../telemetry";
 import { loadConfig } from "../../utils/config";
 import { LogLevel, logger, setLogLevel } from "../../utils/logger";
@@ -18,6 +19,7 @@ import {
   createAppServerConfig,
   ensurePlaywrightBrowsersInstalled,
   getEventBus,
+  handleEmbeddingModelChange,
   parseAuthConfig,
   resolveProtocol,
   validateAuthConfig,
@@ -140,7 +142,16 @@ export function createDefaultAction(cli: Argv) {
 
       const eventBus = getEventBus(argv as CliContext);
 
-      const docService = await createLocalDocumentManagement(eventBus, appConfig);
+      const docService = new DocumentManagementService(eventBus, appConfig);
+      try {
+        await docService.initialize();
+      } catch (error) {
+        if (error instanceof EmbeddingModelChangedError) {
+          await handleEmbeddingModelChange(error, docService);
+        } else {
+          throw error;
+        }
+      }
       const pipelineOptions: PipelineOptions = {
         recoverJobs: (argv.resume as boolean) || false,
         appConfig: appConfig,

--- a/src/cli/commands/mcp.test.ts
+++ b/src/cli/commands/mcp.test.ts
@@ -23,7 +23,19 @@ vi.mock("../../mcp/tools", () => ({
 }));
 
 vi.mock("../../store", () => ({
-  createDocumentManagement: vi.fn(async () => ({ shutdown: vi.fn() })),
+  DocumentManagementService: vi.fn().mockImplementation(() => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn(),
+  })),
+  DocumentManagementClient: vi.fn().mockImplementation(() => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn(),
+  })),
+}));
+vi.mock("../../store/errors", () => ({
+  EmbeddingModelChangedError: class EmbeddingModelChangedError extends Error {
+    name = "EmbeddingModelChangedError";
+  },
 }));
 vi.mock("../../pipeline", () => ({
   PipelineFactory: {
@@ -50,6 +62,7 @@ vi.mock("../utils", () => ({
   validateAuthConfig: vi.fn(),
   createAppServerConfig: vi.fn((config) => config),
   warnHttpUsage: vi.fn(),
+  handleEmbeddingModelChange: vi.fn(),
   CliContext: {},
   setupLogging: vi.fn(),
   setLogLevel: vi.fn(),

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -7,7 +7,8 @@ import { startAppServer } from "../../app";
 import { startStdioServer } from "../../mcp/startStdioServer";
 import { initializeTools } from "../../mcp/tools";
 import { PipelineFactory, type PipelineOptions } from "../../pipeline";
-import { createDocumentManagement, type DocumentManagementService } from "../../store";
+import { DocumentManagementClient, DocumentManagementService } from "../../store";
+import { EmbeddingModelChangedError } from "../../store/errors";
 import type { IDocumentManagement } from "../../store/trpc/interfaces";
 import { TelemetryEvent, telemetry } from "../../telemetry";
 import { loadConfig } from "../../utils/config";
@@ -18,6 +19,7 @@ import {
   type CliContext,
   createAppServerConfig,
   getEventBus,
+  handleEmbeddingModelChange,
   parseAuthConfig,
   resolveProtocol,
   validateAuthConfig,
@@ -139,11 +141,24 @@ export function createMcpCommand(cli: Argv) {
 
         const eventBus = getEventBus(argv as CliContext);
 
-        const docService: IDocumentManagement = await createDocumentManagement({
-          serverUrl,
-          eventBus,
-          appConfig: appConfig,
-        });
+        let docService: IDocumentManagement;
+        if (serverUrl) {
+          const client = new DocumentManagementClient(serverUrl);
+          await client.initialize();
+          docService = client;
+        } else {
+          const service = new DocumentManagementService(eventBus, appConfig);
+          try {
+            await service.initialize();
+          } catch (error) {
+            if (error instanceof EmbeddingModelChangedError) {
+              await handleEmbeddingModelChange(error, service);
+            } else {
+              throw error;
+            }
+          }
+          docService = service;
+        }
         const pipelineOptions: PipelineOptions = {
           recoverJobs: false, // MCP command doesn't support job recovery
           serverUrl,

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createLocalDocumentManagement } from "../store";
+import { DocumentManagementService } from "../store";
 import { resolveStorePath } from "../utils/paths";
 import { createCli } from "./index";
 import { resolveProtocol, validatePort, validateResumeFlag } from "./utils";
@@ -126,12 +126,17 @@ vi.mock("../store", async () => {
       capturedCreateArgs.push(opts);
       return { shutdown: vi.fn() } as any;
     }),
-    createLocalDocumentManagement: vi.fn().mockResolvedValue({
-      initialize: vi.fn(),
+    DocumentManagementService: vi.fn().mockImplementation(() => ({
+      initialize: vi.fn().mockResolvedValue(undefined),
       shutdown: vi.fn(),
-    }),
+    })),
   };
 });
+vi.mock("../store/errors", () => ({
+  EmbeddingModelChangedError: class EmbeddingModelChangedError extends Error {
+    name = "EmbeddingModelChangedError";
+  },
+}));
 
 vi.mock("../app", () => ({
   startAppServer: vi.fn().mockResolvedValue({
@@ -149,14 +154,14 @@ vi.mock("../mcp/startStdioServer", () => ({
 
 describe("Global option propagation", () => {
   let mockResolveStorePath: any;
-  let mockCreateLocalDocumentManagement: any;
+  let mockDocumentManagementService: any;
 
   beforeEach(async () => {
     vi.clearAllMocks();
 
     // Get references to the mocked functions
     mockResolveStorePath = vi.mocked(resolveStorePath);
-    mockCreateLocalDocumentManagement = vi.mocked(createLocalDocumentManagement);
+    mockDocumentManagementService = vi.mocked(DocumentManagementService);
   });
 
   it("should pass --store-path through preAction hook to default command", async () => {
@@ -183,8 +188,8 @@ describe("Global option propagation", () => {
     // Verify that resolveStorePath was called with the CLI option
     expect(mockResolveStorePath).toHaveBeenCalledWith(customStorePath);
 
-    // Verify that createLocalDocumentManagement was called with the resolved path
-    expect(mockCreateLocalDocumentManagement).toHaveBeenCalledWith(
+    // Verify that DocumentManagementService was constructed with the resolved path
+    expect(mockDocumentManagementService).toHaveBeenCalledWith(
       expect.objectContaining({
         emitter: expect.any(Object),
       }), // EventBusService instance
@@ -219,8 +224,8 @@ describe("Global option propagation", () => {
     // Verify that resolveStorePath was called with the env var value
     expect(mockResolveStorePath).toHaveBeenCalledWith(envStorePath);
 
-    // Verify that createLocalDocumentManagement was called with the resolved path
-    expect(mockCreateLocalDocumentManagement).toHaveBeenCalledWith(
+    // Verify that DocumentManagementService was constructed with the resolved path
+    expect(mockDocumentManagementService).toHaveBeenCalledWith(
       expect.objectContaining({
         emitter: expect.any(Object),
       }), // EventBusService instance
@@ -250,7 +255,7 @@ describe("Global option propagation", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    expect(mockCreateLocalDocumentManagement).toHaveBeenCalledWith(
+    expect(mockDocumentManagementService).toHaveBeenCalledWith(
       expect.any(Object),
       expect.objectContaining({
         app: expect.objectContaining({
@@ -274,7 +279,7 @@ describe("Global option propagation", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    expect(mockCreateLocalDocumentManagement).toHaveBeenCalledWith(
+    expect(mockDocumentManagementService).toHaveBeenCalledWith(
       expect.any(Object),
       expect.objectContaining({
         app: expect.objectContaining({

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -4,6 +4,7 @@
 
 import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import { createInterface } from "node:readline";
 import { chromium } from "playwright";
 import type { AppServerConfig } from "../app";
 import type { AuthConfig } from "../auth/types";
@@ -366,4 +367,76 @@ export function resolveEmbeddingContext(
     logger.debug(`Failed to resolve embedding configuration: ${error}`);
     return null;
   }
+}
+
+/**
+ * Prompts the user interactively to confirm an embedding model change.
+ * Returns true if the user confirms (y/Y), false otherwise.
+ */
+function promptModelChangeConfirmation(
+  previousModel: string,
+  previousDimension: string,
+  currentModel: string,
+  currentDimension: string,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    console.error(
+      `\n⚠️  Embedding model change detected:\n` +
+        `   Previous: ${previousModel} (${previousDimension} dimensions)\n` +
+        `   Current:  ${currentModel} (${currentDimension} dimensions)\n\n` +
+        `   All existing embedding vectors will be invalidated.\n` +
+        `   Libraries must be re-scraped to restore vector search.\n` +
+        `   Full-text search will continue working for all existing documents.\n`,
+    );
+
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stderr,
+    });
+
+    rl.question("   Proceed with model change? (y/N) ", (answer) => {
+      rl.close();
+      const confirmed = answer.trim().toLowerCase() === "y";
+      resolve(confirmed);
+    });
+  });
+}
+
+/**
+ * Handles EmbeddingModelChangedError during service initialization.
+ *
+ * - In non-interactive mode (no TTY): re-throws the error to fail startup.
+ * - In interactive mode (TTY): prompts the user for confirmation, then either
+ *   resolves the model change (invalidates vectors) or exits.
+ *
+ * @param error The EmbeddingModelChangedError thrown by DocumentStore.initialize()
+ * @param service The DocumentManagementService instance (already partially initialized)
+ * @throws Re-throws the error in non-interactive mode or if the user rejects the change
+ */
+export async function handleEmbeddingModelChange(
+  error: import("../store/errors").EmbeddingModelChangedError,
+  service: import("../store/DocumentManagementService").DocumentManagementService,
+): Promise<void> {
+  // Non-interactive: fail startup entirely
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw error;
+  }
+
+  // Interactive: prompt user for confirmation
+  const confirmed = await promptModelChangeConfirmation(
+    error.previousModel,
+    error.previousDimension,
+    error.currentModel,
+    error.currentDimension,
+  );
+
+  if (!confirmed) {
+    throw new Error(
+      "Embedding model change rejected. Startup aborted.\n" +
+        "Restore the previous embedding model configuration to continue without changes.",
+    );
+  }
+
+  // User confirmed: invalidate vectors and complete initialization
+  await service.resolveModelChange();
 }

--- a/src/store/DocumentManagementService.ts
+++ b/src/store/DocumentManagementService.ts
@@ -87,6 +87,14 @@ export class DocumentManagementService {
   }
 
   /**
+   * Resolves a confirmed embedding model change by invalidating all vectors
+   * and completing the initialization that was interrupted by EmbeddingModelChangedError.
+   */
+  async resolveModelChange(): Promise<void> {
+    await this.store.resolveModelChange();
+  }
+
+  /**
    * Shuts down the underlying document store and cleans up pipeline resources.
    */
 

--- a/src/store/DocumentStore.test.ts
+++ b/src/store/DocumentStore.test.ts
@@ -4,6 +4,7 @@ import type { Chunk } from "../splitter/types";
 import { loadConfig } from "../utils/config";
 import { DocumentStore } from "./DocumentStore";
 import { EmbeddingConfig } from "./embeddings/EmbeddingConfig";
+import { EmbeddingModelChangedError } from "./errors";
 import { VersionStatus } from "./types";
 
 // Mock only the embedding service to generate deterministic embeddings for testing
@@ -1514,6 +1515,288 @@ describe("DocumentStore - Common Functionality", () => {
         // etag can be null, but the field should exist
         expect(page).toHaveProperty("etag");
       }
+    });
+  });
+});
+
+/**
+ * Tests for embedding model change safety:
+ * metadata persistence, change detection, vector invalidation, ensureVectorTable.
+ */
+describe("DocumentStore - Embedding Model Change Safety", () => {
+  let store: DocumentStore;
+  let originalApiKey: string | undefined;
+
+  beforeEach(() => {
+    // Set dummy API key so areCredentialsAvailable("openai") returns true
+    // and initializeEmbeddings() proceeds (the actual API call is mocked)
+    originalApiKey = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "test-key-for-model-change-safety";
+  });
+
+  afterEach(async () => {
+    if (store) {
+      await store.shutdown();
+    }
+    // Restore original env
+    if (originalApiKey === undefined) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = originalApiKey;
+    }
+  });
+
+  /**
+   * Helper: create and initialize a store with the given embedding model spec.
+   * Returns the store for further assertions.
+   */
+  async function createStore(
+    modelSpec: string,
+    dimension?: number,
+  ): Promise<DocumentStore> {
+    const cfg = loadConfig();
+    if (modelSpec) {
+      const embeddingConfig = EmbeddingConfig.parseEmbeddingConfig(modelSpec);
+      cfg.app.embeddingModel = embeddingConfig.modelSpec;
+    } else {
+      cfg.app.embeddingModel = "";
+    }
+    if (dimension !== undefined) {
+      cfg.embeddings.vectorDimension = dimension;
+    }
+    const s = new DocumentStore(":memory:", cfg);
+    await s.initialize();
+    return s;
+  }
+
+  // 9.2 Test getEmbeddingMetadata returns null when no keys exist (first-run)
+  describe("getEmbeddingMetadata", () => {
+    it("should return null for both fields on first run before any embedding init", async () => {
+      // Create store in FTS-only mode so initializeEmbeddings skips metadata write
+      store = await createStore("");
+      const metadata = store.getEmbeddingMetadata();
+      expect(metadata.model).toBeNull();
+      expect(metadata.dimension).toBeNull();
+    });
+  });
+
+  // 9.3 Test setEmbeddingMetadata writes and reads correctly
+  describe("setEmbeddingMetadata", () => {
+    it("should write and read model and dimension correctly", async () => {
+      store = await createStore("");
+      store.setEmbeddingMetadata("openai:text-embedding-3-small", 1536);
+
+      const metadata = store.getEmbeddingMetadata();
+      expect(metadata.model).toBe("openai:text-embedding-3-small");
+      expect(metadata.dimension).toBe("1536");
+    });
+
+    it("should overwrite existing metadata on subsequent calls", async () => {
+      store = await createStore("");
+      store.setEmbeddingMetadata("openai:text-embedding-3-small", 1536);
+      store.setEmbeddingMetadata("openai:text-embedding-ada-002", 768);
+
+      const metadata = store.getEmbeddingMetadata();
+      expect(metadata.model).toBe("openai:text-embedding-ada-002");
+      expect(metadata.dimension).toBe("768");
+    });
+  });
+
+  // 9.4 Test checkEmbeddingModelChange throws when model differs
+  describe("checkEmbeddingModelChange", () => {
+    it("should throw EmbeddingModelChangedError when model differs", async () => {
+      // First init with model A
+      store = await createStore("openai:text-embedding-3-small");
+      await store.shutdown();
+
+      // Get the DB reference before shutdown wipes it — we need a fresh store on the same DB
+      // Since we use :memory:, we must simulate by manually setting metadata
+      store = await createStore("openai:text-embedding-3-small");
+
+      // Manually set stored metadata to a different model
+      store.setEmbeddingMetadata("openai:text-embedding-ada-002", 1536);
+
+      // Now checkEmbeddingModelChange should detect the mismatch
+      expect(() => store.checkEmbeddingModelChange()).toThrow(EmbeddingModelChangedError);
+    });
+
+    // 9.5 Test checkEmbeddingModelChange throws when dimension differs
+    it("should throw EmbeddingModelChangedError when dimension differs", async () => {
+      store = await createStore("openai:text-embedding-3-small");
+
+      // Set stored metadata with same model but different dimension
+      store.setEmbeddingMetadata("openai:text-embedding-3-small", 768);
+
+      expect(() => store.checkEmbeddingModelChange()).toThrow(EmbeddingModelChangedError);
+    });
+
+    // 9.6 Test checkEmbeddingModelChange does not throw when model and dimension match
+    it("should not throw when model and dimension match", async () => {
+      store = await createStore("openai:text-embedding-3-small");
+
+      // Metadata was persisted by initializeEmbeddings — check should pass
+      expect(() => store.checkEmbeddingModelChange()).not.toThrow();
+    });
+
+    // 9.7 Test checkEmbeddingModelChange does not throw on first run (no stored metadata)
+    it("should not throw on first run when no metadata exists", async () => {
+      // Create store but clear metadata to simulate first run
+      store = await createStore("openai:text-embedding-3-small");
+
+      // @ts-expect-error Accessing private property for testing
+      store.db.exec("DELETE FROM metadata");
+
+      expect(() => store.checkEmbeddingModelChange()).not.toThrow();
+    });
+
+    // 9.8 Test checkEmbeddingModelChange does not throw in FTS-only mode
+    it("should not throw when in FTS-only mode (no embedding model)", async () => {
+      store = await createStore("");
+
+      // Even if metadata exists from a prior run, FTS-only skips the check
+      store.setEmbeddingMetadata("openai:text-embedding-3-small", 1536);
+
+      expect(() => store.checkEmbeddingModelChange()).not.toThrow();
+    });
+  });
+
+  // 9.9, 9.10, 9.11 Test invalidateAllVectors
+  describe("invalidateAllVectors", () => {
+    it("should set all embeddings to NULL", async () => {
+      store = await createStore("openai:text-embedding-3-small");
+
+      // Add a document so we have an embedding to invalidate
+      await store.addDocuments(
+        "testlib",
+        "1.0.0",
+        1,
+        createScrapeResult(
+          "Test Doc",
+          "https://example.com/test",
+          "Some test content for embedding invalidation",
+        ),
+      );
+
+      // Verify embedding exists
+      // @ts-expect-error Accessing private property for testing
+      const before = store.db
+        .prepare("SELECT COUNT(*) as cnt FROM documents WHERE embedding IS NOT NULL")
+        .get() as { cnt: number };
+      expect(before.cnt).toBeGreaterThan(0);
+
+      store.invalidateAllVectors("openai:text-embedding-ada-002", 1536);
+
+      // @ts-expect-error Accessing private property for testing
+      const after = store.db
+        .prepare("SELECT COUNT(*) as cnt FROM documents WHERE embedding IS NOT NULL")
+        .get() as { cnt: number };
+      expect(after.cnt).toBe(0);
+    });
+
+    it("should recreate documents_vec as empty", async () => {
+      store = await createStore("openai:text-embedding-3-small");
+
+      // Add a document to populate documents_vec
+      await store.addDocuments(
+        "testlib",
+        "1.0.0",
+        1,
+        createScrapeResult(
+          "Test Doc",
+          "https://example.com/test",
+          "Content for vec table test",
+        ),
+      );
+
+      // @ts-expect-error Accessing private property for testing
+      const vecBefore = store.db
+        .prepare("SELECT COUNT(*) as cnt FROM documents_vec")
+        .get() as { cnt: number };
+      expect(vecBefore.cnt).toBeGreaterThan(0);
+
+      store.invalidateAllVectors("openai:text-embedding-ada-002", 768);
+
+      // Vec table should exist but be empty
+      // @ts-expect-error Accessing private property for testing
+      const vecAfter = store.db
+        .prepare("SELECT COUNT(*) as cnt FROM documents_vec")
+        .get() as { cnt: number };
+      expect(vecAfter.cnt).toBe(0);
+
+      // And the new dimension should be reflected in the DDL
+      // @ts-expect-error Accessing private property for testing
+      const ddl = store.db
+        .prepare(
+          "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'documents_vec'",
+        )
+        .get() as { sql: string };
+      expect(ddl.sql).toContain("768");
+    });
+
+    it("should update metadata with new model and dimension", async () => {
+      store = await createStore("openai:text-embedding-3-small");
+
+      store.invalidateAllVectors("openai:text-embedding-ada-002", 768);
+
+      const metadata = store.getEmbeddingMetadata();
+      expect(metadata.model).toBe("openai:text-embedding-ada-002");
+      expect(metadata.dimension).toBe("768");
+    });
+  });
+
+  // 9.12, 9.13 Test ensureVectorTable
+  describe("ensureVectorTable", () => {
+    it("should create table with configured dimension and no backfill", async () => {
+      store = await createStore("openai:text-embedding-3-small");
+
+      // Verify documents_vec exists with the correct dimension
+      // @ts-expect-error Accessing private property for testing
+      const ddl = store.db
+        .prepare(
+          "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'documents_vec'",
+        )
+        .get() as { sql: string };
+      expect(ddl).toBeDefined();
+      expect(ddl.sql).toContain("1536");
+
+      // Table should be empty (no backfill)
+      // @ts-expect-error Accessing private property for testing
+      const count = store.db
+        .prepare("SELECT COUNT(*) as cnt FROM documents_vec")
+        .get() as { cnt: number };
+      expect(count.cnt).toBe(0);
+    });
+
+    it("should be a no-op when dimension matches existing table", async () => {
+      store = await createStore("openai:text-embedding-3-small");
+
+      // Add a document to populate vec table
+      await store.addDocuments(
+        "testlib",
+        "1.0.0",
+        1,
+        createScrapeResult(
+          "Test Doc",
+          "https://example.com/test",
+          "Content for no-op test",
+        ),
+      );
+
+      // @ts-expect-error Accessing private property for testing
+      const vecBefore = store.db
+        .prepare("SELECT COUNT(*) as cnt FROM documents_vec")
+        .get() as { cnt: number };
+      expect(vecBefore.cnt).toBeGreaterThan(0);
+
+      // Calling ensureVectorTable again should be a no-op (dimension matches)
+      // @ts-expect-error Accessing private method for testing
+      store.ensureVectorTable();
+
+      // @ts-expect-error Accessing private property for testing
+      const vecAfter = store.db
+        .prepare("SELECT COUNT(*) as cnt FROM documents_vec")
+        .get() as { cnt: number };
+      expect(vecAfter.cnt).toBe(vecBefore.cnt);
     });
   });
 });

--- a/src/store/DocumentStore.ts
+++ b/src/store/DocumentStore.ts
@@ -14,7 +14,12 @@ import {
   UnsupportedProviderError,
 } from "./embeddings/EmbeddingFactory";
 import { FixedDimensionEmbeddings } from "./embeddings/FixedDimensionEmbeddings";
-import { ConnectionError, DimensionError, StoreError } from "./errors";
+import {
+  ConnectionError,
+  DimensionError,
+  EmbeddingModelChangedError,
+  StoreError,
+} from "./errors";
 import type { DbChunkMetadata, DbChunkRank, StoredScraperOptions } from "./types";
 import {
   type DbChunk,
@@ -465,6 +470,119 @@ export class DocumentStore {
   }
 
   /**
+   * Reads the stored embedding model and dimension from the metadata table.
+   * Returns null for each value that doesn't exist (e.g., first run or pre-metadata database).
+   */
+  getEmbeddingMetadata(): { model: string | null; dimension: string | null } {
+    // Uses inline db.prepare() so this method works before prepareStatements() is called.
+    // This is necessary because checkEmbeddingModelChange() runs before ensureVectorTable(),
+    // and prepareStatements() cannot run until documents_vec exists (triggers reference it).
+    const modelRow = this.db
+      .prepare<[string]>("SELECT value FROM metadata WHERE key = ?")
+      .get("embedding_model") as { value: string } | undefined;
+    const dimensionRow = this.db
+      .prepare<[string]>("SELECT value FROM metadata WHERE key = ?")
+      .get("embedding_dimension") as { value: string } | undefined;
+    return {
+      model: modelRow?.value ?? null,
+      dimension: dimensionRow?.value ?? null,
+    };
+  }
+
+  /**
+   * Persists the active embedding model and dimension to the metadata table.
+   * Uses upsert (INSERT ON CONFLICT UPDATE) so it works for both first-run and subsequent updates.
+   * Uses inline db.prepare() so this method works before prepareStatements() is called.
+   */
+  setEmbeddingMetadata(model: string, dimension: number): void {
+    const stmt = this.db.prepare<[string, string]>(
+      "INSERT INTO metadata (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    );
+    stmt.run("embedding_model", model);
+    stmt.run("embedding_dimension", String(dimension));
+  }
+
+  /**
+   * Compares the configured embedding model and dimension against stored metadata.
+   * Throws EmbeddingModelChangedError if either has changed since the last run.
+   *
+   * Skipped when:
+   * - No metadata exists (first run / upgrade from pre-metadata DB → silent initialization)
+   * - No embedding model is configured (FTS-only mode)
+   * - Credentials are unavailable for the configured provider (will fall back to FTS-only)
+   */
+  checkEmbeddingModelChange(): void {
+    // Skip if no embedding config (FTS-only mode)
+    if (!this.embeddingConfig) {
+      return;
+    }
+
+    // Skip if credentials are unavailable (will fall back to FTS-only in initializeEmbeddings)
+    if (!areCredentialsAvailable(this.embeddingConfig.provider)) {
+      return;
+    }
+
+    const stored = this.getEmbeddingMetadata();
+
+    // First run: no stored metadata → skip check (silent initialization)
+    if (stored.model === null) {
+      return;
+    }
+
+    const currentModel = this.config.app.embeddingModel;
+    const currentDimension = String(this.config.embeddings.vectorDimension);
+
+    const modelChanged = stored.model !== currentModel;
+    const dimensionChanged =
+      stored.dimension !== null && stored.dimension !== currentDimension;
+
+    if (modelChanged || dimensionChanged) {
+      throw new EmbeddingModelChangedError(
+        stored.model,
+        stored.dimension ?? "unknown",
+        currentModel,
+        currentDimension,
+      );
+    }
+  }
+
+  /**
+   * Invalidates all existing embedding vectors after a confirmed model/dimension change.
+   * Sets all document embeddings to NULL, drops and recreates the vec table as empty,
+   * and updates the metadata with the new model and dimension.
+   *
+   * After invalidation, FTS search continues working; vector search returns no results
+   * until libraries are re-scraped.
+   */
+  invalidateAllVectors(newModel: string, newDimension: number): void {
+    logger.warn(
+      `⚠️  Invalidating all embedding vectors due to model/dimension change.\n` +
+        `   All libraries must be re-scraped to restore vector search.\n` +
+        `   Full-text search remains available for all existing documents.`,
+    );
+
+    // Clear all stored embedding blobs
+    this.db.exec("UPDATE documents SET embedding = NULL");
+
+    // Drop and recreate vec table as empty with the new dimension
+    this.db.exec("DROP TABLE IF EXISTS documents_vec");
+    this.db.exec(`
+      CREATE VIRTUAL TABLE documents_vec USING vec0(
+        library_id INTEGER NOT NULL,
+        version_id INTEGER NOT NULL,
+        embedding FLOAT[${newDimension}]
+      );
+    `);
+
+    // Update metadata to reflect the new configuration
+    this.setEmbeddingMetadata(newModel, newDimension);
+
+    logger.info(
+      `✅ Embedding vectors invalidated. Metadata updated to: ${newModel} (${newDimension}d)`,
+    );
+  }
+
+  /**
    * Initialize the embeddings client using the provided config.
    * If no embedding config is provided (null or undefined), embeddings will not be initialized.
    * This allows DocumentStore to be used without embeddings for FTS-only operations.
@@ -555,6 +673,9 @@ export class DocumentStore {
       logger.debug(
         `Embeddings initialized: ${config.provider}:${config.model} (${this.modelDimension}d)`,
       );
+
+      // Persist the active embedding model identity for change detection on next startup
+      this.setEmbeddingMetadata(config.modelSpec, this.dbDimension);
     } catch (error) {
       // Handle model-related errors with helpful messages
       if (error instanceof Error) {
@@ -698,19 +819,28 @@ export class DocumentStore {
       // 1. Load extensions first (moved before migrations)
       sqliteVec.load(this.db);
 
-      // 2. Apply migrations (after extensions are loaded)
+      // 2. Apply migrations (after extensions are loaded, includes metadata table creation)
       await applyMigrations(this.db, {
         maxRetries: this.config.db.migrationMaxRetries,
         retryDelayMs: this.config.db.migrationRetryDelayMs,
       });
 
-      // 3. Create vector table at runtime with configurable dimension (migration 012 drops it for us to recreate)
+      // 3. Check embedding model/dimension metadata for changes
+      //    Uses inline db.prepare() so it works before prepareStatements().
+      //    Throws EmbeddingModelChangedError if mismatch detected.
+      //    The CLI layer catches this to prompt (TTY) or fail (non-interactive).
+      this.checkEmbeddingModelChange();
+
+      // 4. Create vector table at runtime with configurable dimension
+      //    Must run before prepareStatements() because triggers on `documents`
+      //    reference `documents_vec`.
       this.ensureVectorTable();
 
-      // 4. Initialize prepared statements
+      // 5. Initialize prepared statements (after vec table exists)
       this.prepareStatements();
 
-      // 5. Initialize embeddings client (await to catch errors)
+      // 6. Initialize embeddings client (await to catch errors)
+      //    On success, persists model identity to metadata table.
       await this.initializeEmbeddings();
     } catch (error) {
       // Re-throw StoreError, ModelConfigurationError, and UnsupportedProviderError directly
@@ -726,6 +856,34 @@ export class DocumentStore {
   }
 
   /**
+   * Resolves a model change by invalidating all vectors and completing initialization.
+   * Called by the CLI layer after the user confirms a model/dimension change.
+   * Assumes initialize() was previously called and threw EmbeddingModelChangedError,
+   * meaning steps 1-2 (load extensions, apply migrations) completed successfully.
+   * Steps 3+ (ensureVectorTable, prepareStatements, initializeEmbeddings) are
+   * completed here after invalidation.
+   */
+  async resolveModelChange(): Promise<void> {
+    const currentModel = this.config.app.embeddingModel;
+    const currentDimension = this.config.embeddings.vectorDimension;
+
+    // Invalidate all existing vectors and update metadata
+    this.invalidateAllVectors(currentModel, currentDimension);
+
+    // Complete the remaining initialization steps that were skipped when
+    // checkEmbeddingModelChange() threw in initialize():
+
+    // Re-create vector table (no-op since invalidateAllVectors already did it with correct dimension)
+    this.ensureVectorTable();
+
+    // Initialize prepared statements (must run after vec table exists)
+    this.prepareStatements();
+
+    // Initialize embeddings client (will also persist metadata on success)
+    await this.initializeEmbeddings();
+  }
+
+  /**
    * Gracefully closes database connections
    */
   async shutdown(): Promise<void> {
@@ -734,9 +892,15 @@ export class DocumentStore {
 
   /**
    * Creates or reconciles the documents_vec virtual table with configurable dimension.
-   * Called after migrations; migration 012 drops the table so we recreate it from config here.
+   * Called after migrations and model change detection. The table is initially created
+   * by migration 003 with a fixed 1536 dimension; this method reconciles it at runtime
+   * if the configured dimension differs.
    * Idempotent: if the table already exists with the same dimension, no-op; if dimension
    * changed in config, drops and recreates so any embedding provider (e.g. 1536 or 3584) works.
+   *
+   * Note: No backfill of existing embeddings is performed. Vectors are populated during
+   * scraping, not at startup. Old vectors from a different dimension or model are incompatible
+   * and are handled by the model change detection system (checkEmbeddingModelChange).
    */
   private ensureVectorTable(): void {
     const dim = this.config.embeddings.vectorDimension;
@@ -767,14 +931,6 @@ export class DocumentStore {
         version_id INTEGER NOT NULL,
         embedding FLOAT[${dim}]
       );
-    `);
-    this.db.exec(`
-      INSERT OR REPLACE INTO documents_vec (rowid, library_id, version_id, embedding)
-      SELECT d.id, v.library_id, v.id, json_extract(d.embedding, '$')
-      FROM documents d
-      JOIN pages p ON d.page_id = p.id
-      JOIN versions v ON p.version_id = v.id
-      WHERE d.embedding IS NOT NULL;
     `);
   }
 

--- a/src/store/applyMigrations.test.ts
+++ b/src/store/applyMigrations.test.ts
@@ -30,9 +30,11 @@ describe("Database Migrations", () => {
     const tableNames = (tables as TableRow[]).map((t) => t.name);
     expect(tableNames).toContain("documents");
     expect(tableNames).toContain("documents_fts");
-    // documents_vec is dropped by migration 012 and created at runtime by DocumentStore.ensureVectorTable()
-    expect(tableNames).not.toContain("documents_vec");
+    // documents_vec is created by migration 003 (with fixed 1536 dimension);
+    // DocumentStore.ensureVectorTable() reconciles it at runtime if the configured dimension differs
+    expect(tableNames).toContain("documents_vec");
     expect(tableNames).toContain("libraries");
+    expect(tableNames).toContain("metadata");
     expect(tableNames).toContain("pages");
 
     // Check columns for 'documents'
@@ -101,30 +103,19 @@ describe("Database Migrations", () => {
       .get() as { sql: string } | undefined;
     expect(ftsTableInfo?.sql).toContain("VIRTUAL TABLE documents_fts USING fts5");
 
-    // documents_vec is created at runtime by DocumentStore.ensureVectorTable() with config dimension; not present after migrations
+    // documents_vec is created by migration 003 (with fixed 1536 dimension) and survives through all
+    // subsequent migrations. DocumentStore.ensureVectorTable() reconciles it at runtime if needed.
     const vecTableInfo = db
       .prepare(
         "SELECT sql FROM sqlite_master WHERE type='table' AND name='documents_vec';",
       )
       .get() as { sql: string } | undefined;
-    expect(vecTableInfo).toBeUndefined();
+    expect(vecTableInfo).toBeDefined();
   });
 
-  /** Create documents_vec with fixed dimension for tests that need vector search without full DocumentStore init */
-  function createVectorTableForTest(testDb: DatabaseType, dimension: number): void {
-    testDb.exec(`
-      CREATE VIRTUAL TABLE documents_vec USING vec0(
-        library_id INTEGER NOT NULL,
-        version_id INTEGER NOT NULL,
-        embedding FLOAT[${dimension}]
-      );
-    `);
-  }
-
   it("should handle vector search with empty results gracefully", () => {
-    // Apply all migrations (documents_vec is dropped by 012; create it for this test)
+    // Apply all migrations (documents_vec exists from migration 003 with 1536d)
     expect(() => applyMigrations(db)).not.toThrow();
-    createVectorTableForTest(db, 1536);
 
     // Insert a library and version but no documents
     db.prepare("INSERT INTO libraries (name) VALUES (?)").run("empty-lib");
@@ -172,9 +163,8 @@ describe("Database Migrations", () => {
   });
 
   it("should perform vector search and return similar vectors correctly", () => {
-    // Apply all migrations (documents_vec is dropped by 012; create it for this test)
+    // Apply all migrations (documents_vec exists from migration 003 with 1536d)
     expect(() => applyMigrations(db)).not.toThrow();
-    createVectorTableForTest(db, 1536);
 
     // Insert test library and version
     db.prepare("INSERT INTO libraries (name) VALUES (?)").run("test-lib");
@@ -381,9 +371,8 @@ describe("Database Migrations", () => {
   });
 
   it("should perform FTS search and return relevant text matches correctly", () => {
-    // Apply all migrations (documents_vec dropped by 012; create it so triggers from 011 can run on document insert)
+    // Apply all migrations (documents_vec exists from migration 003; triggers from 011 sync on document insert)
     expect(() => applyMigrations(db)).not.toThrow();
-    createVectorTableForTest(db, 1536);
 
     // Insert test library and version
     db.prepare("INSERT INTO libraries (name) VALUES (?)").run("docs-lib");

--- a/src/store/errors.ts
+++ b/src/store/errors.ts
@@ -87,6 +87,32 @@ export class DocumentNotFoundError extends StoreError {
 }
 
 /**
+ * Error thrown when the configured embedding model or vector dimension differs from the
+ * values stored in the database metadata. This indicates that existing vectors are
+ * incompatible with the new configuration and must be invalidated before proceeding.
+ *
+ * The CLI layer catches this error to either prompt the user interactively (TTY) or
+ * fail startup entirely (non-interactive/MCP/stdio mode).
+ */
+export class EmbeddingModelChangedError extends StoreError {
+  constructor(
+    public readonly previousModel: string,
+    public readonly previousDimension: string,
+    public readonly currentModel: string,
+    public readonly currentDimension: string,
+  ) {
+    super(
+      `Embedding model change detected:\n` +
+        `  Previous: ${previousModel} (${previousDimension} dimensions)\n` +
+        `  Current:  ${currentModel} (${currentDimension} dimensions)\n\n` +
+        `All existing vectors are incompatible and must be invalidated.\n` +
+        `To confirm this change, start the server interactively (with a TTY connected)\n` +
+        `and follow the prompts.`,
+    );
+  }
+}
+
+/**
  * Error thrown when required credentials for an embedding provider are missing.
  * This allows the system to gracefully degrade to FTS-only search when vectorization is unavailable.
  */

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -480,4 +480,18 @@ describe("Auto-generated Environment Variable Overrides", () => {
 
     expect(config.scraper.document.maxSize).toBe(52428800);
   });
+
+  it("rejects vectorDimension of 0 or negative values", () => {
+    // vectorDimension = 0 should fail Zod .min(1) validation
+    process.env.DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION = "0";
+    expect(() =>
+      loadConfig({}, { configPath: path.join(tmpDir, "dim-zero.yaml") }),
+    ).toThrow();
+
+    // vectorDimension = -1 should also fail
+    process.env.DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION = "-1";
+    expect(() =>
+      loadConfig({}, { configPath: path.join(tmpDir, "dim-neg.yaml") }),
+    ).toThrow();
+  });
 });


### PR DESCRIPTION
We use an OpenAI-compatible embeddings API (Scaleway) with the model `bge-multilingual-gemma2`, which outputs **3584-dimensional** vectors. The current schema fixes the vector table to 1536 dimensions in migrations, which causes a dimension mismatch and prevents using this (and other non-1536) models.

This PR makes the vector dimension configurable:

- **Migration 012:** Drops `documents_vec` so it is no longer created with a fixed dimension in migrations.
- **Runtime:** After migrations, `DocumentStore.ensureVectorTable()` creates `documents_vec` using `config.embeddings.vectorDimension` (already exposed via `DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION`) and runs the same backfill as in migration 011. Existing triggers continue to apply.

Users can set `DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION=3584` (or the dimension of their model) when using Scaleway or any other provider whose embedding dimension is not 1536. The default remains 1536 for existing setups.