### PR TITLE
fix: relax engines constraint from exact Node 22.0.0 to >=22

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "vitest": "^3.2.4"
   },
   "engines": {
-    "node": "=22.0.0"
+    "node": ">=22"
   },
   "overrides": {
     "npm": "10.9.3"


### PR DESCRIPTION
## Summary

- Fixes the `engines.node` field in `package.json` from `=22.0.0` (exact match) to `>=22`, allowing the package to run on any Node 22+ version.

## Problem

Running `npx @arabold/docs-mcp-server@latest` fails on any Node version other than exactly `22.0.0`, including newer 22.x patches and Node 24. This contradicts the documented "Node.js 22+" requirement in the README and `.nvmrc`.

## Note on native module ABI errors

Users who switch Node versions (e.g., from 24 to 22) may also encounter `ERR_DLOPEN_FAILED` errors from `better-sqlite3` due to stale npx cache. This is an npx caching issue (not a package bug) and is resolved by clearing the cache:

```bash
rm -rf ~/.npm/_npx/<hash>
npx @arabold/docs-mcp-server@latest
```

Closes #331