### PR TITLE
fix: add remark-parse dependency for npx

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1",
     "remark-html": "^16.0.1",
+    "remark-parse": "^11.0.0",
     "semver": "^7.7.3",
     "sqlite-vec": "^0.1.7-alpha.2",
     "superjson": "^2.2.6",


### PR DESCRIPTION
## Summary
- add missing runtime dependency on remark-parse to fix npx usage
- resolves issue #338 where remark-parse was not declared

## Testing
- not run (dependency change only)