### PR TITLE
fix: correct chunk size warning to compare body only and account for merge separator

### DIFF
--- a/docs/concepts/content-processing.md
+++ b/docs/concepts/content-processing.md
@@ -133,6 +133,19 @@ Segment content into semantic chunks while preserving document structure:
 - Handles oversized content while preserving document structure
 - Ensures optimal chunk sizes for embedding generation
 
+Chunk sizes are controlled by three character-based thresholds:
+
+| Setting | Role |
+|:--------|:-----|
+| `minChunkSize` | Floor for merging -- chunks below this are combined with neighbors |
+| `preferredChunkSize` | Soft target -- the optimizer splits when merging would exceed this |
+| `maxChunkSize` | Hard ceiling -- no chunk body will exceed this value |
+
+All sizes are measured in **characters** (`string.length`), not tokens. Before embedding,
+a metadata header (page title, URL, section path) is prepended to each chunk, so the total
+text sent to the embedding model is slightly larger than the chunk body. The actual token
+count depends on the embedding model's tokenizer.
+
 ## Content Processing Flow
 
 ```mermaid

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -200,9 +200,16 @@ Settings for chunking text for vector search.
 
 | Option | Default | Description |
 |:-------|:--------|:------------|
-| `minChunkSize` | `500` | Minimum characters per chunk. |
-| `preferredChunkSize` | `1500` | Target characters per chunk. |
-| `maxChunkSize` | `5000` | Maximum characters per chunk. |
+| `minChunkSize` | `500` | Minimum characters per chunk body. Chunks below this threshold are merged with adjacent chunks by the greedy optimizer. |
+| `preferredChunkSize` | `1500` | Soft target for chunk body size in characters. The greedy optimizer splits when combining two chunks would exceed this value, provided both sides are already above `minChunkSize`. |
+| `maxChunkSize` | `5000` | Hard upper limit for chunk body size in characters. No chunk body will exceed this value. |
+
+> **Note:** These size limits apply to the **text body** of each chunk. Before embedding,
+> a small metadata header (page title, URL, section path) is prepended to each chunk,
+> adding to the total character count sent to the embedding model. Because characters are
+> not tokens, the actual token count depends on your embedding model's tokenizer. If your
+> model has a small context window (e.g., some local models), consider lowering
+> `maxChunkSize` to leave headroom for metadata and token expansion.
 
 ### Embeddings (`embeddings`)
 

--- a/src/splitter/GreedySplitter.ts
+++ b/src/splitter/GreedySplitter.ts
@@ -54,7 +54,10 @@ export class GreedySplitter implements DocumentSplitter {
       }
 
       if (currentChunk) {
-        const combinedSize = currentChunk.content.length + nextChunk.content.length;
+        // Account for the newline separator that may be added when merging (see merge below)
+        const separatorSize = currentChunk.content.endsWith("\n") ? 0 : 1;
+        const combinedSize =
+          currentChunk.content.length + separatorSize + nextChunk.content.length;
 
         // HARD LIMIT: Never exceed max chunk size
         if (combinedSize > this.maxChunkSize) {

--- a/src/store/DocumentStore.ts
+++ b/src/store/DocumentStore.ts
@@ -1150,12 +1150,15 @@ export class DocumentStore {
           return `${header}${chunk.content}`;
         });
 
-        // Validate chunk sizes before creating embeddings
-        for (let i = 0; i < texts.length; i++) {
-          const textSize = texts[i].length;
-          if (textSize > this.splitterMaxChunkSize) {
+        // Validate chunk body sizes before creating embeddings.
+        // Note: We compare the chunk body (without the metadata header) against maxChunkSize,
+        // because the splitter's size budget applies to the content body only. The metadata
+        // header (title, URL, path) is expected overhead added after splitting.
+        for (let i = 0; i < chunks.length; i++) {
+          const bodySize = chunks[i].content.length;
+          if (bodySize > this.splitterMaxChunkSize) {
             logger.warn(
-              `⚠️  Chunk ${i + 1}/${texts.length} exceeds max size: ${textSize} > ${this.splitterMaxChunkSize} chars (URL: ${url})`,
+              `⚠️  Chunk ${i + 1}/${chunks.length} body exceeds max size: ${bodySize} > ${this.splitterMaxChunkSize} chars (URL: ${url})`,
             );
           }
         }


### PR DESCRIPTION
## Summary

- **Fix misleading chunk size warning** (`DocumentStore.ts`): The validation now compares the chunk *body* size (without the prepended metadata header) against `maxChunkSize`. Previously, the `<title>/<url>/<path>` header (~120-300 chars) was included in the comparison, causing spurious "exceeds max size" warnings even when the splitter respected the limit. This was the primary cause of the warnings reported in #314.
- **Fix off-by-one in GreedySplitter merge** (`GreedySplitter.ts`): The `combinedSize` calculation now accounts for the `\n` separator conditionally added during chunk merging, preventing merged chunks from exceeding `maxChunkSize` by 1 character.
- **Document chunk size semantics** (`docs/setup/configuration.md`, `docs/concepts/content-processing.md`): Clarifies that `maxChunkSize` applies to the text body only, metadata adds overhead before embedding, and characters are not tokens — users with small-context embedding models should lower `maxChunkSize` accordingly.

Closes #314