### PR TITLE
fix(scraper): normalize presentational wrappers inside links

### DIFF
--- a/src/scraper/middleware/HtmlNormalizationMiddleware.test.ts
+++ b/src/scraper/middleware/HtmlNormalizationMiddleware.test.ts
@@ -280,6 +280,68 @@ describe("HtmlNormalizationMiddleware", () => {
       expect($(links[0]).attr("href")).toBe("https://example.com/::invalid::url");
       expect($("a")).toHaveLength(1);
     });
+
+    it("should simplify single div wrappers inside links", async () => {
+      const context = createContext(`
+        <a href="/reference/react/useDeferredValue">
+          <div><span>Previous</span><span>useDeferredValue</span></div>
+        </a>
+      `);
+
+      await middleware.process(context, async () => {});
+
+      const $ = context.dom!;
+      const linkHtml = $("a").html()?.trim();
+
+      expect(linkHtml).toBe("<span>Previous</span> <span>useDeferredValue</span>");
+    });
+
+    it("should simplify single paragraph wrappers inside links", async () => {
+      const context = createContext(`
+        <a href="/docs"><p>Read docs</p></a>
+      `);
+
+      await middleware.process(context, async () => {});
+
+      const $ = context.dom!;
+      expect($("a").html()).toBe("Read docs");
+    });
+
+    it("should preserve inline formatting while simplifying link wrappers", async () => {
+      const context = createContext(`
+        <a href="/docs"><div><strong>Bold</strong> and <em>italic</em></div></a>
+      `);
+
+      await middleware.process(context, async () => {});
+
+      const $ = context.dom!;
+      expect($("a strong")).toHaveLength(1);
+      expect($("a em")).toHaveLength(1);
+      expect($("a").html()).toBe("<strong>Bold</strong> and <em>italic</em>");
+    });
+
+    it("should preserve image wrappers inside links", async () => {
+      const context = createContext(`
+        <a href="/image"><div><img src="hero.png" alt="Hero"></div></a>
+      `);
+
+      await middleware.process(context, async () => {});
+
+      const $ = context.dom!;
+      expect($("a > div > img")).toHaveLength(1);
+    });
+
+    it("should preserve multiple block wrappers inside links", async () => {
+      const context = createContext(`
+        <a href="/two"><div>One</div><div>Two</div></a>
+      `);
+
+      await middleware.process(context, async () => {});
+
+      const $ = context.dom!;
+      expect($("a > div")).toHaveLength(2);
+      expect($("a").text()).toBe("OneTwo");
+    });
   });
 
   describe("tracking image removal", () => {

--- a/src/scraper/middleware/HtmlNormalizationMiddleware.ts
+++ b/src/scraper/middleware/HtmlNormalizationMiddleware.ts
@@ -17,6 +17,8 @@ import type { ContentProcessorMiddleware, MiddlewareContext } from "./types";
  * non-functional links while preserving contextually valuable text content.
  */
 export class HtmlNormalizationMiddleware implements ContentProcessorMiddleware {
+  private readonly presentationalAnchorWrapperTags = new Set(["div", "p"]);
+
   // Known tracking/analytics domains and patterns to filter out
   private readonly trackingPatterns = [
     "adroll.com",
@@ -60,6 +62,9 @@ export class HtmlNormalizationMiddleware implements ContentProcessorMiddleware {
 
       // Normalize and clean links
       this.normalizeLinks($, baseUrl);
+
+      // Simplify purely presentational wrappers inside links before markdown conversion
+      this.simplifyAnchorContent($);
 
       logger.debug(`Successfully normalized HTML content for ${context.source}`);
     } catch (error) {
@@ -173,6 +178,105 @@ export class HtmlNormalizationMiddleware implements ContentProcessorMiddleware {
         }
       }
     });
+  }
+
+  /**
+   * Removes single presentational block wrappers inside anchors so Turndown does not
+   * emit multi-line link labels for layout-only structures.
+   */
+  private simplifyAnchorContent($: cheerio.CheerioAPI): void {
+    $("a").each((_index, element) => {
+      const $link = $(element);
+      let simplified = true;
+
+      while (simplified) {
+        simplified = false;
+
+        const significantChildren = $link
+          .contents()
+          .toArray()
+          .filter((node) => node.type !== "text" || (node.data || "").trim().length > 0);
+
+        if (significantChildren.length !== 1) {
+          continue;
+        }
+
+        const wrapperNode = significantChildren[0];
+        if (wrapperNode.type !== "tag") {
+          continue;
+        }
+
+        const tagName = wrapperNode.tagName.toLowerCase();
+        if (!this.presentationalAnchorWrapperTags.has(tagName)) {
+          continue;
+        }
+
+        const $wrapper = $(wrapperNode);
+        if (this.hasProtectedDescendants($wrapper)) {
+          continue;
+        }
+
+        this.insertSpacesBetweenSiblingTextFragments($, $wrapper);
+        $wrapper.replaceWith($wrapper.contents());
+        simplified = true;
+      }
+    });
+  }
+
+  private hasProtectedDescendants($element: cheerio.Cheerio<AnyNode>): boolean {
+    return $element.find("img, pre, table, ul, ol, li, blockquote").length > 0;
+  }
+
+  private insertSpacesBetweenSiblingTextFragments(
+    $: cheerio.CheerioAPI,
+    $element: cheerio.Cheerio<AnyNode>,
+  ): void {
+    const children = $element.contents().toArray();
+
+    for (let index = 1; index < children.length; index++) {
+      const previousNode = children[index - 1];
+      const currentNode = children[index];
+
+      if (
+        !this.nodeHasVisibleText($, previousNode) ||
+        !this.nodeHasVisibleText($, currentNode)
+      ) {
+        continue;
+      }
+
+      if (this.hasWhitespaceBoundary($, previousNode, currentNode)) {
+        continue;
+      }
+
+      $(currentNode).before(" ");
+    }
+  }
+
+  private nodeHasVisibleText($: cheerio.CheerioAPI, node: AnyNode): boolean {
+    if (node.type === "text") {
+      return (node.data || "").trim().length > 0;
+    }
+
+    return $(node).text().trim().length > 0;
+  }
+
+  private hasWhitespaceBoundary(
+    $: cheerio.CheerioAPI,
+    previousNode: AnyNode,
+    currentNode: AnyNode,
+  ): boolean {
+    const previousText = this.getNodeText($, previousNode);
+    const currentText = this.getNodeText($, currentNode);
+
+    return /\s$/.test(previousText) || /^\s/.test(currentText);
+  }
+
+  private getNodeText($: cheerio.CheerioAPI, node: AnyNode): string {
+    if (node.type === "text") {
+      return node.data || "";
+    }
+
+    return $(node).text();
   }
 
   /**

--- a/src/scraper/middleware/HtmlToMarkdownMiddleware.test.ts
+++ b/src/scraper/middleware/HtmlToMarkdownMiddleware.test.ts
@@ -237,4 +237,75 @@ Mixed: [Another Valid](http://another.com) and bad one.`;
     expect(context.content).toBe(expectedMarkdown);
     expect(context.errors).toHaveLength(0);
   });
+
+  it("should normalize block-level anchor whitespace into a single readable link label", async () => {
+    const middleware = new HtmlToMarkdownMiddleware();
+    const html = `
+      <html><body>
+        <a href="https://react.dev/reference/react/useDeferredValue">
+          <div>
+            <span>Previous</span>
+            <span>useDeferredValue</span>
+          </div>
+        </a>
+      </body></html>`;
+    const context = createMockContext(html);
+    const next = vi.fn().mockResolvedValue(undefined);
+
+    await middleware.process(context, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(context.content).toBe(
+      "[Previous useDeferredValue](https://react.dev/reference/react/useDeferredValue)",
+    );
+    expect(context.errors).toHaveLength(0);
+  });
+
+  it("should preserve nested markdown formatting inside links", async () => {
+    const middleware = new HtmlToMarkdownMiddleware();
+    const html = `
+      <html><body>
+        <a href="https://example.com/docs"><div><strong>Bold</strong> and <em>italic</em></div></a>
+      </body></html>`;
+    const context = createMockContext(html);
+    const next = vi.fn().mockResolvedValue(undefined);
+
+    await middleware.process(context, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(context.content).toBe("[**Bold** and _italic_](https://example.com/docs)");
+    expect(context.errors).toHaveLength(0);
+  });
+
+  it("should preserve inline code formatting inside links", async () => {
+    const middleware = new HtmlToMarkdownMiddleware();
+    const html = `
+      <html><body>
+        <a href="https://example.com/api"><div><code>useEffect</code><span> API</span></div></a>
+      </body></html>`;
+    const context = createMockContext(html);
+    const next = vi.fn().mockResolvedValue(undefined);
+
+    await middleware.process(context, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(context.content).toBe("[`useEffect` API](https://example.com/api)");
+    expect(context.errors).toHaveLength(0);
+  });
+
+  it("should preserve image links while collapsing wrapper whitespace", async () => {
+    const middleware = new HtmlToMarkdownMiddleware();
+    const html = `
+      <html><body>
+        <a href="https://example.com/image"><div><img src="hero.png" alt="Hero"></div></a>
+      </body></html>`;
+    const context = createMockContext(html);
+    const next = vi.fn().mockResolvedValue(undefined);
+
+    await middleware.process(context, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(context.content).toBe("[![Hero](hero.png)](https://example.com/image)");
+    expect(context.errors).toHaveLength(0);
+  });
 });

--- a/src/scraper/middleware/HtmlToMarkdownMiddleware.ts
+++ b/src/scraper/middleware/HtmlToMarkdownMiddleware.ts
@@ -1,7 +1,8 @@
 // @ts-expect-error
 import { gfm } from "@joplin/turndown-plugin-gfm";
 import TurndownService from "turndown";
-import { logger } from "../../utils/logger"; // Added logger
+import { logger } from "../../utils/logger";
+import { fullTrim } from "../../utils/string";
 import type { ContentProcessorMiddleware, MiddlewareContext } from "./types";
 
 /**
@@ -31,7 +32,7 @@ export class HtmlToMarkdownMiddleware implements ContentProcessorMiddleware {
     // Preserve code blocks and syntax (replicated from HtmlProcessor)
     this.turndownService.addRule("pre", {
       filter: ["pre"],
-      replacement: (_content, node) => {
+      replacement: (_content: string, node: Node) => {
         const element = node as unknown as HTMLElement;
         let language = element.getAttribute("data-language") || "";
         if (!language) {
@@ -64,17 +65,24 @@ export class HtmlToMarkdownMiddleware implements ContentProcessorMiddleware {
     });
     this.turndownService.addRule("anchor", {
       filter: ["a"],
-      replacement: (content, node) => {
-        const href = (node as HTMLElement).getAttribute("href");
-        if (!content || content === "#") {
+      replacement: (content: string, node: Node) => {
+        const element = node as HTMLElement;
+        const href = element.getAttribute("href");
+        const normalizedContent = this.normalizeLinkContent(content);
+
+        if (!normalizedContent || normalizedContent === "#") {
           return ""; // Remove if content is # or empty
         }
         if (!href) {
-          return content; // Preserve content if href is missing or empty
+          return normalizedContent; // Preserve content if href is missing or empty
         }
-        return `[${content}](${href})`; // Standard link conversion
+        return `[${normalizedContent}](${href})`; // Standard link conversion
       },
     });
+  }
+
+  private normalizeLinkContent(content: string): string {
+    return fullTrim(content).replace(/[ \t]*[\r\n]+[ \t]*/g, " ");
   }
 
   /**


### PR DESCRIPTION
## Summary
- normalize single presentational block wrappers inside links before markdown conversion so layout-only HTML does not create multiline link labels
- keep markdown formatting intact for nested emphasis, code, and image links while collapsing noisy anchor whitespace
- add regression coverage for React-style pager links and related wrapper permutations in normalization and markdown middleware tests