### PR TITLE
fix(embeddings): allow Gemini models with MRL truncation to bypass dimension check

### DIFF
--- a/src/store/DocumentStore.ts
+++ b/src/store/DocumentStore.ts
@@ -13,6 +13,7 @@ import {
   ModelConfigurationError,
   UnsupportedProviderError,
 } from "./embeddings/EmbeddingFactory";
+import { FixedDimensionEmbeddings } from "./embeddings/FixedDimensionEmbeddings";
 import { ConnectionError, DimensionError, StoreError } from "./errors";
 import type { DbChunkMetadata, DbChunkRank, StoredScraperOptions } from "./types";
 import {
@@ -533,6 +534,16 @@ export class DocumentStore {
 
         // Cache the discovered dimensions for future use
         EmbeddingConfig.setKnownModelDimensions(config.model, this.modelDimension);
+      }
+
+      // For models wrapped in FixedDimensionEmbeddings with truncation enabled
+      // (e.g., Gemini with MRL support), the effective output dimension is capped
+      // at the target dimension. Use the effective dimension for validation.
+      if (
+        this.embeddings instanceof FixedDimensionEmbeddings &&
+        this.embeddings.allowTruncate
+      ) {
+        this.modelDimension = Math.min(this.modelDimension, this.dbDimension);
       }
 
       if (this.modelDimension > this.dbDimension) {

--- a/src/store/embeddings/EmbeddingConfig.ts
+++ b/src/store/embeddings/EmbeddingConfig.ts
@@ -82,6 +82,7 @@ export class EmbeddingConfig {
     // Google Gemini models (with MRL support)
     "text-embedding-preview-0409": 768,
     "embedding-001": 768,
+    "gemini-embedding-2-preview": 3072,
 
     // AWS Bedrock models
     // Amazon Titan models

--- a/src/store/embeddings/FixedDimensionEmbeddings.test.ts
+++ b/src/store/embeddings/FixedDimensionEmbeddings.test.ts
@@ -70,6 +70,40 @@ describe("FixedDimensionEmbeddings", () => {
     await expect(() => wrapper.embedQuery("test")).rejects.toThrow(DimensionError);
   });
 
+  test("should truncate Gemini-sized vectors (3072d) to target dimension when allowTruncate is true", async () => {
+    const geminiDimension = 3072;
+    const base = new MockBaseEmbeddings(geminiDimension);
+    const wrapper = new FixedDimensionEmbeddings(
+      base,
+      targetDimension,
+      "gemini:gemini-embedding-001",
+      true,
+    );
+
+    const vector = await wrapper.embedQuery("test");
+    expect(vector.length).toBe(targetDimension);
+    expect(vector).toEqual(Array(targetDimension).fill(1));
+  });
+
+  test("should expose allowTruncate as a public property", () => {
+    const base = new MockBaseEmbeddings(targetDimension);
+    const withTruncate = new FixedDimensionEmbeddings(
+      base,
+      targetDimension,
+      "gemini:model",
+      true,
+    );
+    const withoutTruncate = new FixedDimensionEmbeddings(
+      base,
+      targetDimension,
+      "test:model",
+      false,
+    );
+
+    expect(withTruncate.allowTruncate).toBe(true);
+    expect(withoutTruncate.allowTruncate).toBe(false);
+  });
+
   test("should process multiple documents correctly", async () => {
     const shortDimension = 1024;
     const base = new MockBaseEmbeddings(shortDimension);

--- a/src/store/embeddings/FixedDimensionEmbeddings.ts
+++ b/src/store/embeddings/FixedDimensionEmbeddings.ts
@@ -18,7 +18,7 @@ export class FixedDimensionEmbeddings extends Embeddings {
     private readonly embeddings: Embeddings,
     private readonly targetDimension: number,
     providerAndModel: string,
-    private readonly allowTruncate: boolean = false,
+    public readonly allowTruncate: boolean = false,
   ) {
     super({});
     // Parse provider and model from string (e.g., "gemini:embedding-001" or just "text-embedding-3-small")


### PR DESCRIPTION
## Summary

Fixes #363

Gemini embedding models (e.g., `gemini-embedding-001`, `gemini-embedding-2-preview`) produce 3072-dimensional vectors but support MRL (Matryoshka Representation Learning), allowing safe truncation to smaller dimensions like 1536.

The `FixedDimensionEmbeddings` wrapper in `EmbeddingFactory` already handled this truncation correctly, but `DocumentStore.initializeEmbeddings()` rejected the model based on its native dimensions from the known dimensions lookup table — before the wrapper ever got a chance to run.

## Changes

- **`DocumentStore.ts`**: Added a check before dimension validation — if the embedding model is wrapped in `FixedDimensionEmbeddings` with `allowTruncate=true`, cap the effective `modelDimension` to `dbDimension` so the dimension check passes.
- **`FixedDimensionEmbeddings.ts`**: Changed `allowTruncate` from `private` to `public` so `DocumentStore` can inspect it during initialization.
- **`EmbeddingConfig.ts`**: Added `gemini-embedding-2-preview` (3072d) to the known dimensions table.
- **`FixedDimensionEmbeddings.test.ts`**: Added tests for Gemini-sized (3072d → 1536d) truncation and `allowTruncate` visibility.