### PR TITLE
feat: add fetch access controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ See **[Embedding Models](docs/guides/embedding-models.md)** for configuring **Ol
 ### Key Concepts & Architecture
 -   **[Deployment Modes](docs/infrastructure/deployment-modes.md)**: Standalone vs. Distributed (Docker Compose).
 -   **[Authentication](docs/infrastructure/authentication.md)**: Securing your server with OAuth2/OIDC.
+-   **[Security](docs/infrastructure/security.md)**: Trust boundaries, deployment hardening, and outbound access controls.
 -   **[Telemetry](docs/infrastructure/telemetry.md)**: Privacy-first usage data collection.
 -   **[Architecture](ARCHITECTURE.md)**: Deep dive into the system design.
 

--- a/docs/infrastructure/authentication.md
+++ b/docs/infrastructure/authentication.md
@@ -423,6 +423,19 @@ DEBUG=mcp:auth npx docs-mcp-server --auth-enabled --auth-issuer-url "..."
 - Implement proper CORS policies for web clients
 - Use secure OAuth2 flows (Authorization Code with PKCE)
 
+### Outbound Access Controls
+
+Authentication controls who can use MCP and HTTP endpoints. It does not, by itself, restrict where scraper-driven fetches can connect after a request is authenticated.
+
+The scraper now applies outbound access controls by default:
+
+- Private, loopback, link-local, and other special-use network targets are blocked unless explicitly allowlisted or `scraper.security.network.allowPrivateNetworks` is enabled.
+- Local `file://` access is constrained by `scraper.security.fileAccess` and defaults to `$DOCUMENTS` only.
+- Hidden files and symlinks are blocked by default.
+- `allowInvalidTls` only changes certificate validation after the target has already passed the network policy. It does not bypass host or CIDR restrictions.
+
+For deployment hardening guidance, see [Infrastructure Security](./security.md).
+
 ### Access Control
 
 - All authenticated users receive full access to all endpoints

--- a/docs/infrastructure/security.md
+++ b/docs/infrastructure/security.md
@@ -1,0 +1,200 @@
+# Infrastructure Security
+
+## Overview
+
+The Docs MCP Server intentionally fetches remote URLs and local files. That capability is useful for documentation indexing, but it also creates trust-boundary decisions for deployments that are shared, internet-exposed, or connected to sensitive internal networks.
+
+This document describes the security model for scraper-driven access and the deployment controls that matter most in practice.
+
+## Trust Boundaries
+
+The server has three independent security surfaces:
+
+1. Inbound access to MCP, web, and API endpoints.
+2. Outbound network access performed by URL fetching and browser-based scraping.
+3. Local file access performed by direct `file://` fetches and local crawling.
+
+OAuth2 protects inbound MCP and HTTP usage. Scraper security settings protect outbound access and local file reads. These concerns are related but separate.
+
+## Deployment Hardening
+
+Use the following defaults for any shared or remotely reachable deployment:
+
+- Enable authentication for exposed MCP and web endpoints.
+- Keep the server behind TLS termination.
+- Restrict worker and internal API networking at the infrastructure layer.
+- Leave `scraper.security.network.allowPrivateNetworks` disabled unless you have an explicit internal use case.
+- Keep `scraper.security.fileAccess.mode` at `allowedRoots` or `disabled` unless the host is fully trusted.
+- Do not rely on broad local home-directory access for service accounts or containers.
+
+## Outbound Network Access Policy
+
+By default, scraper-driven HTTP and browser requests may reach public internet targets but may not reach private or special-use network targets.
+
+Blocked by default:
+
+- Loopback addresses
+- RFC1918 private IPv4 ranges
+- Link-local ranges
+- Other special-use IPv4 and IPv6 ranges covered by the shared policy
+
+Allowed by default:
+
+- Public internet HTTP and HTTPS targets
+
+Override options:
+
+- `mode: allowlist`: switch to a strict outbound allowlist. Only `allowedHosts` and `allowedCidrs` are reachable; everything else is denied. `allowPrivateNetworks` is ignored in this mode.
+- `allowedHosts`: host patterns to permit. Entries may be literal hostnames, minimatch globs (`*.example.com`, `docs.*`), or regular expressions wrapped in `/.../`. Matching is case-insensitive and runs against the bare hostname only.
+- `allowedCidrs`: address-bound exceptions for resolved or direct IP targets.
+- `allowPrivateNetworks: true` (open mode only): broad opt-in for private and special-use network access.
+
+Important semantics:
+
+- `allowedHosts` does not allow direct IP access to the same service.
+- `allowedCidrs` allows by resolved or direct address, not by hostname label alone.
+- `allowedHosts` is authoritative for the named host. If you allowlist `docs.internal.example`, requests to that hostname remain allowed even when it resolves to a private or special-use address. This is an explicit trust decision in that hostname and its DNS answers.
+- For hostnames that are **not** in `allowedHosts`, DNS answers are evaluated strictly: in `open` mode any unresolved mix that includes a blocked special-use address is rejected unless each blocked address is also covered by `allowedCidrs`; in `allowlist` mode every resolved address must fall inside `allowedCidrs`.
+- Glob patterns like `*.example.com` match any subdomain but do not match the bare apex `example.com`. List both if you want both.
+- Redirect targets are revalidated independently — a request that matched `allowedHosts` for its original target does not authorize a redirect to a different host.
+- Browser subrequests use the same policy as non-browser HTTP fetches.
+
+## TLS Verification Policy
+
+HTTPS certificate validation stays enabled by default.
+
+`allowInvalidTls: true` is a broad override that allows invalid or self-signed certificates for HTTPS requests that are already permitted by the network policy.
+
+Important semantics:
+
+- It does not bypass `allowedHosts`, `allowedCidrs`, or private-network restrictions.
+- It applies broadly, so treat it as an environment-level trust decision.
+- If you need narrower trust, prefer proper certificates or a future custom-certificate workflow rather than enabling broad invalid TLS trust.
+
+## Local File Access Policy
+
+Local file access defaults to `allowedRoots` mode with `$DOCUMENTS` as the only configured root.
+
+That default is a convenience for single-user local workflows, not a recommendation for hosted or remotely reachable deployments. If the server is shared, containerized, or exposed beyond one trusted workstation, prefer an application-specific directory such as `/srv/docs` or disable `file://` access entirely.
+
+Modes:
+
+- `disabled`: all user-requested `file://` access is blocked
+- `allowedRoots`: only configured roots are allowed
+- `unrestricted`: local file access is fully trusted
+
+Allowed-root entries may be literal absolute paths or one of these tokens:
+
+- `$HOME` — the user's home directory. Broad: includes dotfiles such as `.ssh`, `.aws`, `.config`. Use intentionally.
+- `$DOCUMENTS` — the platform's documents directory. The default root.
+- `$DOWNLOADS` — the platform's downloads directory.
+- `$DESKTOP` — the platform's desktop directory.
+- `$CWD` — the process working directory.
+
+Traversal defaults:
+
+- Hidden files and hidden directories are blocked by default
+- Symlinks are blocked by default
+- Archive-member paths are validated against the real archive file, not the synthetic combined virtual path
+
+Important semantics:
+
+- `allowedRoots: []` in `allowedRoots` mode means no user-requested local file access is allowed.
+- `$DOCUMENTS`, `$DOWNLOADS`, and `$DESKTOP` are convenience tokens — they probe for `<home>/<Folder>` and grant no access if the directory is missing on the current platform or account.
+- `$HOME` and `$CWD` resolve to a concrete path even when unusual; `$HOME` in particular exposes dotfile-bearing directories.
+- Hidden paths remain blocked even when explicitly requested unless `includeHidden` is enabled.
+
+## Archive Workflows
+
+Supported web archive scraping downloads an accepted remote archive to a temporary file and then processes it through the local file path.
+
+That handoff remains allowed without requiring the temp directory to be added to user-configured roots. The exception is intentionally narrow:
+
+- It applies only after the original network URL passes the network policy.
+- It applies only to the downloaded archive artifact and its virtual members.
+- Unrelated temp files remain subject to the normal local file policy.
+
+## Example Configurations
+
+Conservative shared deployment:
+
+```yaml
+scraper:
+  security:
+    network:
+      mode: open
+      allowPrivateNetworks: false
+      allowedHosts: []
+      allowedCidrs: []
+      allowInvalidTls: false
+    fileAccess:
+      mode: allowedRoots
+      allowedRoots:
+        - $DOCUMENTS
+      followSymlinks: false
+      includeHidden: false
+```
+
+Selective internal docs deployment:
+
+```yaml
+scraper:
+  security:
+    network:
+      mode: open
+      allowPrivateNetworks: false
+      allowedHosts:
+        - "*.internal.example"
+      allowedCidrs:
+        - 10.42.0.0/16
+      allowInvalidTls: true
+    fileAccess:
+      mode: allowedRoots
+      allowedRoots:
+        - /srv/docs
+      followSymlinks: false
+      includeHidden: false
+```
+
+Strict outbound allowlist for a hosted MCP deployment:
+
+```yaml
+scraper:
+  security:
+    network:
+      mode: allowlist
+      allowedHosts:
+        - docs.python.org
+        - "*.rust-lang.org"
+      allowedCidrs: []
+      allowInvalidTls: false
+    fileAccess:
+      mode: disabled
+      allowedRoots: []
+      followSymlinks: false
+      includeHidden: false
+```
+
+Fully trusted local workstation:
+
+```yaml
+scraper:
+  security:
+    network:
+      mode: open
+      allowPrivateNetworks: true
+      allowInvalidTls: false
+    fileAccess:
+      mode: unrestricted
+      allowedRoots: []
+      followSymlinks: true
+      includeHidden: true
+```
+
+## Operational Guidance
+
+- Start with the defaults and add the smallest explicit exception that satisfies the use case.
+- Prefer `allowedHosts` and `allowedCidrs` over `allowPrivateNetworks: true`.
+- Prefer valid certificates over `allowInvalidTls: true`.
+- Prefer narrow `allowedRoots` over `unrestricted` file access.
+- Review these settings when moving from local development to shared infrastructure.

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -24,6 +24,19 @@ scraper:
   preserveHashes: false
   document:
     maxSize: 10485760  # 10MB
+  security:
+    network:
+      mode: open
+      allowPrivateNetworks: false
+      allowedHosts: []
+      allowedCidrs: []
+      allowInvalidTls: false
+    fileAccess:
+      mode: allowedRoots
+      allowedRoots:
+        - $DOCUMENTS
+      followSymlinks: false
+      includeHidden: false
 
 splitter:
   preferredChunkSize: 1500
@@ -75,6 +88,17 @@ export DOCS_MCP_SPLITTER_PREFERRED_CHUNK_SIZE=2000
 
 # Override app settings
 export DOCS_MCP_APP_TELEMETRY_ENABLED=false
+
+# Override scraper security settings
+export DOCS_MCP_SCRAPER_SECURITY_NETWORK_ALLOW_INVALID_TLS=true
+export DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_FOLLOW_SYMLINKS=true
+```
+
+Array-valued settings accept JSON or YAML-style inline arrays:
+
+```bash
+export DOCS_MCP_SCRAPER_SECURITY_NETWORK_ALLOWED_HOSTS='["docs.internal.example","wiki.corp.local"]'
+export DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_ALLOWED_ROOTS='["$DOCUMENTS", "/srv/docs"]'
 ```
 
 Some settings also have **legacy aliases** for convenience:
@@ -189,6 +213,114 @@ Leave it disabled for normal sites, where hashes usually point to anchors within
 - Rendering: if `preserveHashes` is enabled and `scrapeMode` is `fetch`, the job is upgraded to `playwright` automatically.
 
 > **Migration Note:** In versions prior to 1.37, `document.maxSize` was a top-level setting. It has been moved to `scraper.document.maxSize`. Update your config files accordingly.
+
+### Scraper Security (`scraper.security`)
+
+Outbound network access and local file access defaults are intentionally conservative so internet-exposed deployments do not automatically gain access to private networks or broad local file trees.
+
+#### Network (`scraper.security.network`)
+
+| Option | Default | Description |
+|:-------|:--------|:------------|
+| `mode` | `open` | Network policy posture. `open` permits public targets and blocks private/special-use targets unless explicitly allowed. `allowlist` permits only the targets matched by `allowedHosts` or `allowedCidrs`. |
+| `allowPrivateNetworks` | `false` | In `open` mode, when `true` allows loopback, RFC1918 private ranges, link-local, and other special-use targets. Ignored in `allowlist` mode. |
+| `allowedHosts` | `[]` | Host patterns to permit. Entries may be literal hostnames (`docs.internal.example`), minimatch globs (`*.example.com`, `docs.*`), or regular expressions wrapped in `/.../`. Patterns match the bare hostname only, case-insensitively. |
+| `allowedCidrs` | `[]` | CIDR ranges to permit. Match against direct-IP targets and resolved host addresses. |
+| `allowInvalidTls` | `false` | Broad HTTPS certificate-verification override. This only applies after the target has already passed network access checks; it does not bypass the network allowlist. |
+
+In `open` mode, empty `allowedHosts` and `allowedCidrs` mean no private or special-use targets are permitted while `allowPrivateNetworks` remains `false`. In `allowlist` mode, empty lists mean no targets are permitted at all.
+
+`allowedHosts` is authoritative for the named hostname: allowlisting `docs.internal.example` trusts that hostname and its DNS answers, even when the service lives on a private network. `allowedCidrs` remains the only way to authorize direct IP requests or hostname lookups that do not themselves match `allowedHosts`. For non-allowlisted hostnames, mixed DNS answers are handled strictly — `open` mode rejects any hostname that resolves to an unapproved special-use address, and `allowlist` mode requires every resolved address to fall inside `allowedCidrs`.
+
+#### File Access (`scraper.security.fileAccess`)
+
+| Option | Default | Description |
+|:-------|:--------|:------------|
+| `mode` | `allowedRoots` | Local file access mode: `disabled`, `allowedRoots`, or `unrestricted`. |
+| `allowedRoots` | `[$DOCUMENTS]` | Allowlisted local roots when `mode` is `allowedRoots`. Empty means no user-requested `file://` access is permitted. Supports literal paths and the tokens `$HOME`, `$DOCUMENTS`, `$DOWNLOADS`, `$DESKTOP`, `$CWD`. |
+| `followSymlinks` | `false` | Blocks symlinks by default. When enabled, resolved targets must still stay inside an allowed root. |
+| `includeHidden` | `false` | Blocks hidden files, hidden directories, and hidden archive members by default, even when explicitly requested. |
+
+Supported tokens in `allowedRoots`:
+
+- `$HOME` — the user's home directory. Broad: includes dotfiles such as `.ssh`, `.aws`, and `.config`. Use intentionally.
+- `$DOCUMENTS` — platform-specific documents directory. The default.
+- `$DOWNLOADS` — platform-specific downloads directory.
+- `$DESKTOP` — platform-specific desktop directory.
+- `$CWD` — the process working directory; useful for CLI invocations.
+
+`$DOCUMENTS`, `$DOWNLOADS`, and `$DESKTOP` resolve only when the corresponding `<home>/<Folder>` exists on the current platform or account; otherwise the token grants no access. `$HOME` and `$CWD` resolve to the literal path even when unusual, so they always grant access when configured.
+
+The default `[$DOCUMENTS]` root is aimed at trusted local use. For shared services, containers, or internet-exposed deployments, narrow `allowedRoots` to an application-owned directory or switch `mode` to `disabled`.
+
+Internally managed temporary archive files created during accepted web archive scraping remain allowed even when they sit outside user-configured roots. That exception is limited to the downloaded archive artifact and its virtual members.
+
+### Security Examples
+
+Selective internal network access with self-signed HTTPS:
+
+```yaml
+scraper:
+  security:
+    network:
+      mode: open
+      allowPrivateNetworks: false
+      allowedHosts:
+        - "*.internal.example"
+      allowedCidrs:
+        - 10.42.0.0/16
+      allowInvalidTls: true
+```
+
+Strict outbound allowlist (only the listed public docs sites are reachable):
+
+```yaml
+scraper:
+  security:
+    network:
+      mode: allowlist
+      allowedHosts:
+        - docs.python.org
+        - "*.rust-lang.org"
+        - /^docs\d+\.example\.com$/
+      allowedCidrs: []
+```
+
+Restricted local file access:
+
+```yaml
+scraper:
+  security:
+    fileAccess:
+      mode: allowedRoots
+      allowedRoots:
+        - $DOCUMENTS
+        - /srv/docs
+      followSymlinks: false
+      includeHidden: false
+```
+
+Fully trusted local deployment:
+
+```yaml
+scraper:
+  security:
+    network:
+      allowPrivateNetworks: true
+      allowInvalidTls: false
+    fileAccess:
+      mode: unrestricted
+      allowedRoots: []
+      followSymlinks: true
+      includeHidden: true
+```
+
+Be explicit with these overrides:
+
+- `allowPrivateNetworks: true` broadens network reach beyond public internet targets.
+- `allowInvalidTls: true` broadly trusts invalid HTTPS certificates, but it still does not bypass network allowlists.
+- `fileAccess.mode: allowedRoots` with `allowedRoots: []` denies all user-requested `file://` access.
+- Unresolved `$DOCUMENTS` tokens do not fall back to `$HOME` or any other implicit path.
 
 ### GitHub Authentication
 

--- a/openspec/changes/add-fetch-access-controls/.openspec.yaml
+++ b/openspec/changes/add-fetch-access-controls/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-29

--- a/openspec/changes/add-fetch-access-controls/design.md
+++ b/openspec/changes/add-fetch-access-controls/design.md
@@ -1,0 +1,216 @@
+## Context
+
+The server intentionally supports arbitrary HTTP(S) and `file://` fetching across CLI, MCP, and web-triggered scraping flows. Today, fetcher selection and local file traversal are centralized enough to apply consistent controls, but there is no policy layer that limits outbound network targets, constrains local file roots, or handles hidden paths and symlink escapes. The project already has a strong configuration model with schema-backed defaults and environment/CLI overrides, so access controls should be introduced as configuration-driven behavior rather than interface-specific flags.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add one shared outbound access policy that applies to `fetch_url` and scrape workflows regardless of entry point.
+- Default-deny private, loopback, link-local, and similar special-use network targets unless explicitly configured.
+- Add configurable local file access modes with allowed roots, `$DOCUMENTS` token expansion, and secure defaults for hidden paths and symlinks.
+- Produce clear user-facing errors when policy blocks access.
+- Preserve explicit opt-in paths for trusted local and self-hosted deployments.
+
+**Non-Goals:**
+- Add per-user or per-token authorization rules.
+- Implement a sandbox or OS-level file isolation boundary.
+- Detect every possible cloud metadata alias or enterprise-internal hostname pattern out of the box.
+- Redesign the scrape tool surface or add new transport-level authentication features.
+
+## Decisions
+
+### Introduce a shared scraper security policy under configuration
+
+Add a new `scraper.security` section to the typed config schema. This keeps policy close to the fetch/scrape subsystem and lets the existing precedence model handle config file, environment, and CLI overrides.
+
+Alternative considered: a top-level `security` block. Rejected because the affected behavior is currently isolated to scraper-driven URL and file access, and placing the settings under `scraper` avoids broadening the configuration surface prematurely.
+
+### Enforce policy centrally before network or file reads
+
+Introduce a reusable access-policy helper that validates URLs and resolved file paths before `AutoDetectFetcher`, `HttpFetcher`, `FileFetcher`, and local crawl entry points perform I/O. DNS-resolved IP revalidation and redirect-target validation will be mandatory enforcement behavior, not optional configuration knobs. For archive-member URLs such as `file:///path/to/archive.zip/docs/readme.md`, policy evaluation will be based on the resolved backing archive file path plus the virtual entry path, not on the nonexistent combined filesystem path.
+
+Alternative considered: only validating at the MCP tool boundary. Rejected because CLI and web-triggered scraping must behave consistently, and lower-level enforcement prevents bypass through internal call paths.
+
+### Apply network policy to browser-initiated subrequests
+
+Treat browser-based fetching as a series of outbound requests rather than a single navigation. The same network policy must apply to the initial page load, redirects, frames, iframes, scripts, stylesheets, images, XHR/fetch calls, and any other subresource request initiated during rendering so that a public page cannot pivot the renderer into private network access.
+
+Alternative considered: only validating the initial browser navigation target. Rejected because it leaves a clear SSRF-style gap for render-time secondary requests.
+
+### Network policy posture: `open` (default) vs `allowlist`
+
+Model network protection as a two-mode firewall posture under `network.mode`, mirroring the same `mode` shape used by `fileAccess.mode`:
+
+- `open` (default). Public internet targets are permitted. Private, loopback, link-local, and equivalent IPv6 special-use ranges are denied unless `allowPrivateNetworks` is `true` or the specific target matches `allowedHosts` or `allowedCidrs`. This covers the dominant use case of "allow all public docs, block local network."
+- `allowlist`. A request is permitted only when its hostname matches `allowedHosts` or its target/resolved IP falls within `allowedCidrs`. Everything else is denied. `allowPrivateNetworks` is ignored in this mode — the explicit allowlist is the complete authorization surface, so adding `allowPrivateNetworks: true` would only confuse the policy semantics.
+
+This choice deliberately follows the firewall "default policy + rules" convention used by AWS security groups, nftables, and similar tooling. The alternative of "presence of allowlist entries silently flips the mode" (the Kubernetes NetworkPolicy approach) is rejected because adding a single host exception should not silently transform every other authorization in the deployment.
+
+`allowedHosts` and `allowedCidrs` serve different purposes in both modes:
+
+- `allowedHosts` is hostname-bound. It permits requests whose hostname matches the configured pattern, including cases where that named host resolves to a private or special-use address. A request allowed via `allowedHosts` does not authorize a different hostname, a direct IP target, or a redirected hostname. This is an explicit trust decision in that hostname and its DNS answers, so operators should keep host entries narrow and prefer exact internal names over broad wildcards for sensitive deployments.
+- `allowedCidrs` is address-bound. It permits direct IP targets and hostnames whose resolved connection addresses all fall inside the configured subnet set. Like host entries, it is evaluated independently for redirects and secondary requests.
+
+The evaluation order is intentionally explicit:
+
+1. Direct IP targets are decided by `allowedCidrs` / `allowPrivateNetworks`; `allowedHosts` never applies.
+2. A hostname that matches `allowedHosts` is permitted for that exact hostname and short-circuits CIDR-based post-resolution checks.
+3. A hostname that does not match `allowedHosts` is evaluated after DNS resolution. In `open` mode, every resolved address must remain outside blocked special-use ranges unless covered by `allowedCidrs`. In `allowlist` mode, every resolved address must fall inside `allowedCidrs`.
+
+This means mixed public/private, mixed IPv4/IPv6, or otherwise multi-record DNS answers are denied unless every possible connection address is permitted by the active policy. Deployments that need a named internal service without pinning its subnet should allowlist that hostname explicitly and accept the trust boundary that comes with trusting its DNS.
+
+`allowedHosts` entries reuse the project's existing pattern syntax (the same one used by scrape `--include-pattern` / `--exclude-pattern`):
+
+- A bare entry like `docs.internal.example` is an exact-match.
+- A minimatch glob like `*.example.com` or `docs.*` matches the bare hostname (case-insensitive).
+- An entry wrapped in `/.../` is treated as a JavaScript regular expression for the rare cases globs cannot express.
+- The match is run against the hostname only, never the scheme or path. CIDR-shaped entries continue to live in `allowedCidrs`.
+
+Sharing one pattern syntax across all matching configuration was preferred over importing an external convention such as `NO_PROXY`'s `.example.com` form: users learning one syntax inside the project is more valuable than aligning with any single outside ecosystem, and reusing the existing matcher avoids a parallel implementation.
+
+Example default-secure network configuration:
+
+```yaml
+scraper:
+  security:
+    network:
+      mode: open
+      allowPrivateNetworks: false
+      allowedHosts: []
+      allowedCidrs: []
+```
+
+Example selective internal exception (still in `open` mode):
+
+```yaml
+scraper:
+  security:
+    network:
+      mode: open
+      allowPrivateNetworks: false
+      allowedHosts:
+        - "*.internal.example"
+      allowedCidrs:
+        - 10.42.0.0/16
+```
+
+Example strict outbound allowlist for a shared deployment:
+
+```yaml
+scraper:
+  security:
+    network:
+      mode: allowlist
+      allowedHosts:
+        - docs.python.org
+        - "*.rust-lang.org"
+        - /^docs\d+\.example\.com$/
+      allowedCidrs: []
+```
+
+Alternative considered: permissive defaults with warnings only. Rejected because the objective of this change is meaningful hardening for exposed deployments, and warnings do not reduce actual risk.
+
+Alternative considered: separate booleans such as `allowLoopback` and `allowLinkLocal`. Rejected because they create overlapping policy states and make it harder to explain how exceptions should be configured.
+
+### Keep TLS verification secure by default with a single override
+
+TLS certificate verification remains enabled by default for all HTTPS requests. Add `allowInvalidTls` as a single broad override for environments that need to reach services with self-signed or otherwise invalid certificates. TLS exceptions are evaluated only after the target has already been permitted by the network access policy.
+
+Example invalid TLS override:
+
+```yaml
+scraper:
+  security:
+    network:
+      allowPrivateNetworks: false
+      allowedHosts:
+        - docs.internal.example
+      allowInvalidTls: true
+```
+
+Alternative considered: hostname-scoped invalid TLS exceptions. Rejected because they add disproportionate policy complexity and do not map cleanly onto browser-based fetching behavior. A future custom-certificate feature would be a better way to support scoped trust.
+
+Alternative considered: placing TLS settings under `scraper.fetcher`. Rejected because certificate verification is a trust-boundary policy that must apply consistently across HTTP and browser-based fetch paths.
+
+### Add file access modes with allowlisted roots and secure traversal defaults
+
+Model local file access as `disabled`, `allowedRoots`, or `unrestricted`. In `allowedRoots` mode, expand configured tokens such as `$DOCUMENTS`, canonicalize paths, and require the effective target to remain inside an allowed root. Set `followSymlinks` and `includeHidden` to `false` by default. Hidden paths will be blocked even when explicitly named unless the user opts in.
+
+When `fileAccess.mode` is `allowedRoots`, an empty `allowedRoots` list means all user-requested `file://` access is denied. This does not block internally managed temporary archive handoff for accepted web archive roots.
+
+If `$DOCUMENTS` cannot be resolved on the current platform or runtime account, it will expand to no path and therefore grant no access by itself. Deployments that require local file access in containers or service accounts must configure explicit absolute paths.
+
+Example default file policy:
+
+```yaml
+scraper:
+  security:
+    fileAccess:
+      mode: allowedRoots
+      allowedRoots:
+        - $DOCUMENTS
+      followSymlinks: false
+      includeHidden: false
+```
+
+Example fully disabled local file access:
+
+```yaml
+scraper:
+  security:
+    fileAccess:
+      mode: disabled
+      allowedRoots: []
+      followSymlinks: false
+      includeHidden: false
+```
+
+Alternative considered: denylisting sensitive directories under `$HOME`. Rejected because denylisting is incomplete and easier to bypass than root allowlisting.
+
+The default `$DOCUMENTS` root is intentionally a local-workstation convenience, not a claim that remotely reachable deployments should expose user documents broadly. Shared or internet-facing deployments are expected to narrow `allowedRoots` to an application-specific directory or disable file access entirely.
+
+### Preserve internal temporary archive handoff
+
+Treat temporary files created by the application itself for supported web archive scraping as internal implementation artifacts rather than user-requested `file://` access. Policy enforcement will still apply to the original network URL, but once a web archive root has been accepted and downloaded, the handoff into local archive processing must not be blocked merely because the temp file lives outside configured user roots such as `$DOCUMENTS`. This exception is limited to the downloaded archive artifact produced for that accepted request and virtual members read from that archive during the same processing flow.
+
+Alternative considered: requiring the temp directory to be added to default allowed roots. Rejected because it couples user-facing file policy to OS temp locations and would either over-broaden local access or break existing archive behavior.
+
+### Support a small set of user-directory tokens
+
+Allowed-root entries may be either literal absolute paths or one of the following tokens. Tokens are expanded during policy evaluation; access is enforced against the concrete absolute path returned by expansion, so enforcement logic never depends on platform-specific home-directory conventions:
+
+- `$HOME` — the user's home directory. Broad: includes dotfiles such as `.ssh`, `.aws`, and `.config`. Provided as an opt-in for users who explicitly want it; documented as such so it is not selected by accident.
+- `$DOCUMENTS` — the platform's documents directory. The default allowed root.
+- `$DOWNLOADS` — the platform's downloads directory. Useful because many users drop docs there.
+- `$DESKTOP` — the platform's desktop directory.
+- `$CWD` — the process working directory. Useful for CLI use where a user has `cd`'d into a project.
+
+`$HOME` and `$CWD` resolve to a concrete path even when that path is empty or unusual; the other tokens probe for the conventional `<home>/<Folder>` location and resolve to `null` if it does not exist on the current platform or account, so the token denies rather than silently granting an unexpected path.
+
+Alternative considered: using `$HOME` as the default root. Rejected because it is too broad and includes common secret locations such as `.ssh`, `.aws`, and dot-config directories. `$HOME` remains available as an explicit opt-in.
+
+## Risks / Trade-offs
+
+- [Behavior break for existing internal-doc users] -> Provide explicit `allowedHosts` and `allowedCidrs` overrides and document migration clearly.
+- [Regression in supported web archive scraping] -> Exempt internally managed temp archive handoff from user file-root checks while preserving network policy on the original URL.
+- [DNS resolution and redirect validation complexity] -> Keep the first implementation limited to HTTP(S) plus redirect revalidation and well-defined CIDR checks, covered by focused tests.
+- [Browser subrequest enforcement complexity] -> Intercept all Playwright requests centrally and apply the same resolver/policy helper used by non-browser fetchers.
+- [Invalid TLS override broadens trust for all HTTPS targets] -> Keep TLS verification enabled by default and require explicit opt-in only when deployments accept the wider trust boundary.
+- [Platform-specific `$DOCUMENTS` resolution differences] -> Fall back to explicit paths when the token cannot be resolved reliably.
+- [Confusion around hidden path semantics] -> Treat `includeHidden: false` as a hard deny for both direct fetch and traversal, and document this explicitly.
+- [Symlink handling may surprise users with linked doc folders] -> Keep an opt-in `followSymlinks` flag and validate the resolved target stays within an allowed root.
+
+## Migration Plan
+
+1. Add the new config schema and defaults.
+2. Implement shared access-policy utilities and wire them into fetchers and local file traversal.
+3. Preserve archive workflows by validating virtual archive paths against the concrete archive file and by exempting internal temp archive handoff from user file-root checks.
+4. Update tests to cover blocked and allowed cases for top-level and browser-initiated network requests, hidden paths, symlinks, and archive workflows.
+5. Update user-facing documentation to explain defaults, array/env encoding, token expansion, and override patterns.
+6. Release with changelog notes highlighting that private-network access is now blocked by default and file access is restricted by policy.
+
+Rollback consists of removing the policy enforcement layer and reverting to the previous permissive defaults, but the preferred operational mitigation is to loosen the new config values rather than removing the feature.
+
+## Open Questions
+
+- Do we want CLI flags for temporary overrides in addition to config and environment variables, or is config-only sufficient for the first iteration?

--- a/openspec/changes/add-fetch-access-controls/proposal.md
+++ b/openspec/changes/add-fetch-access-controls/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The product intentionally fetches arbitrary web and local content, but today it does so without configurable network or file access restrictions. That is acceptable for trusted local workflows, yet it leaves shared or internet-exposed deployments without a first-class way to reduce SSRF-style risk, sensitive local file access, or accidental access to hidden content.
+
+## What Changes
+
+- Add configurable outbound access controls for HTTP(S) fetches used by `fetch_url` and scraping workflows, with two postures: `open` (current behavior — public allowed, private blocked with exceptions) and `allowlist` (only configured hosts/CIDRs permitted).
+- Default-deny access to private, loopback, link-local, and other special-use network targets in `open` mode unless explicitly allowed via host or CIDR allowlists.
+- Accept host allowlist entries as either literal hostnames, minimatch glob patterns, or `/.../`-wrapped regular expressions, sharing the same pattern syntax as scraper include/exclude lists.
+- Add configurable TLS verification controls for environments that need to allow invalid or self-signed HTTPS certificates, scoped strictly to targets already permitted by the network policy.
+- Add configurable local file access modes with allowed root directories, user-directory token expansion (`$HOME`, `$DOCUMENTS`, `$DOWNLOADS`, `$DESKTOP`, `$CWD`), and secure defaults for symlinks and hidden paths.
+- Preserve supported archive workflows by distinguishing user-requested local file access from internally managed temporary files and archive member resolution.
+- Enforce the same access policy across CLI, MCP, and web-triggered fetch/scrape operations.
+- Return clear validation errors when a URL or file path is blocked by policy, including guidance for enabling access.
+
+## Capabilities
+
+### New Capabilities
+- `outbound-access-control`: Define and enforce configurable network and local file access restrictions for one-shot fetches and scraping workflows.
+
+### Modified Capabilities
+- `configuration`: Add scraper security configuration for network restrictions, file access modes, allowed roots, symlink handling, and hidden path handling.
+
+## Impact
+
+- Affected code: scraper config schema and defaults, URL/file fetcher entry points, local file traversal, archive handoff paths, fetch and scrape tools, and related tests.
+- Affected interfaces: CLI, MCP, and web-backed scraping behavior will share the same enforcement rules.
+- Documentation impact: configuration and security docs will need updates to explain the new defaults and opt-in overrides.

--- a/openspec/changes/add-fetch-access-controls/specs/configuration/spec.md
+++ b/openspec/changes/add-fetch-access-controls/specs/configuration/spec.md
@@ -1,0 +1,149 @@
+## MODIFIED Requirements
+
+### Requirement: Generic Environment Variable Overrides
+The system SHALL support overriding any configuration setting via environment variables using a predictable naming convention. Environment-derived configuration values SHALL be normalized by trimming surrounding whitespace and stripping matching surrounding single or double quotes before schema parsing.
+
+#### Scenario: Environment Variable Naming Convention
+- **GIVEN** a config path `scraper.document.maxSize`
+- **WHEN** the environment variable `DOCS_MCP_SCRAPER_DOCUMENT_MAX_SIZE` is set
+- **THEN** its value SHALL override the config file and default values
+
+#### Scenario: Quoted configuration override from Docker Compose
+- **GIVEN** the environment variable `DOCS_MCP_EMBEDDING_MODEL` is provided as `"openai:nomic-embed-text"`
+- **WHEN** the configuration is loaded
+- **THEN** the resulting `app.embeddingModel` value SHALL be `openai:nomic-embed-text`
+
+#### Scenario: Whitespace-padded configuration override
+- **GIVEN** the environment variable `DOCS_MCP_SCRAPER_MAX_PAGES` is provided as `  "500"  `
+- **WHEN** the configuration is loaded
+- **THEN** the resulting `scraper.maxPages` value SHALL be parsed as `500`
+
+#### Scenario: CamelCase to Upper Snake Case Conversion
+- **GIVEN** a config path segment `maxNestingDepth`
+- **WHEN** converted to environment variable format
+- **THEN** it SHALL become `MAX_NESTING_DEPTH`
+
+#### Scenario: Deeply Nested Path Conversion
+- **GIVEN** a config path `splitter.json.maxNestingDepth`
+- **WHEN** converted to environment variable name
+- **THEN** it SHALL become `DOCS_MCP_SPLITTER_JSON_MAX_NESTING_DEPTH`
+
+#### Scenario: Nested security override naming
+- **GIVEN** a config path `scraper.security.fileAccess.followSymlinks`
+- **WHEN** converted to environment variable name
+- **THEN** it SHALL become `DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_FOLLOW_SYMLINKS`
+
+#### Scenario: Array override provided as JSON
+- **GIVEN** the environment variable `DOCS_MCP_SCRAPER_SECURITY_NETWORK_ALLOWED_HOSTS` is provided as `["docs.internal.example","wiki.corp.local"]`
+- **WHEN** the configuration is loaded
+- **THEN** the resulting `scraper.security.network.allowedHosts` value SHALL be parsed as a string array
+
+#### Scenario: Array override provided as inline array string
+- **GIVEN** the environment variable `DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_ALLOWED_ROOTS` is provided as `["$DOCUMENTS", "/srv/docs"]`
+- **WHEN** the configuration is loaded
+- **THEN** the resulting `scraper.security.fileAccess.allowedRoots` value SHALL be parsed as a string array
+
+### Requirement: Scraper Security Configuration
+The system SHALL expose configuration for outbound network and local file access controls under `scraper.security`.
+
+#### Scenario: Network mode defaults to open
+- **GIVEN** no custom security configuration is provided
+- **WHEN** the configuration is loaded
+- **THEN** `scraper.security.network.mode` SHALL default to `open`
+
+#### Scenario: Allowlist mode is selectable via configuration
+- **GIVEN** `scraper.security.network.mode` is `allowlist`
+- **WHEN** the configuration is loaded
+- **THEN** the outbound network policy SHALL permit only targets that match `allowedHosts` or `allowedCidrs`
+- **AND** `allowPrivateNetworks` SHALL not affect access decisions in allowlist mode
+
+#### Scenario: Allowed host patterns accept globs and regex
+- **GIVEN** `scraper.security.network.allowedHosts` contains `docs.internal.example`, `*.corp.local`, and `/^docs\d+\.example\.com$/`
+- **WHEN** the configuration is loaded
+- **THEN** entries SHALL be parsed as host patterns matching the bare hostname
+- **AND** literal entries SHALL match exactly, glob entries SHALL match via minimatch, and `/.../` entries SHALL match via JavaScript regular expressions
+
+#### Scenario: Private network access defaults to disabled
+- **GIVEN** no custom security configuration is provided
+- **WHEN** the configuration is loaded
+- **THEN** private network access for scraper-driven HTTP(S) fetches SHALL default to disabled
+
+#### Scenario: Host allowlist can permit a specific internal hostname
+- **GIVEN** `scraper.security.network.allowPrivateNetworks` is `false`
+- **AND** `scraper.security.network.allowedHosts` contains `docs.internal.example`
+- **WHEN** the configuration is loaded
+- **THEN** requests explicitly targeting `docs.internal.example` SHALL be eligible for access despite the default private-network restriction
+- **AND** direct IP requests SHALL still require `allowedCidrs` or `allowPrivateNetworks`
+
+#### Scenario: CIDR allowlist can permit a specific internal subnet
+- **GIVEN** `scraper.security.network.allowPrivateNetworks` is `false`
+- **AND** `scraper.security.network.allowedCidrs` contains `10.42.0.0/16`
+- **WHEN** the configuration is loaded
+- **THEN** requests whose resolved address falls within `10.42.0.0/16` SHALL be eligible for access despite the default private-network restriction
+
+#### Scenario: Empty network allowlists do not permit private targets
+- **GIVEN** `scraper.security.network.allowPrivateNetworks` is `false`
+- **AND** `scraper.security.network.allowedHosts` is empty
+- **AND** `scraper.security.network.allowedCidrs` is empty
+- **WHEN** the configuration is loaded
+- **THEN** no private or special-use network targets SHALL be permitted by configuration
+
+#### Scenario: Private network override enables broad internal access
+- **GIVEN** `scraper.security.network.allowPrivateNetworks` is `true`
+- **WHEN** the configuration is loaded
+- **THEN** private, loopback, link-local, and other special-use network targets SHALL be eligible for access
+
+#### Scenario: Invalid TLS verification defaults to disabled override
+- **GIVEN** no custom security configuration is provided
+- **WHEN** the configuration is loaded
+- **THEN** `scraper.security.network.allowInvalidTls` SHALL default to `false`
+
+#### Scenario: Broad invalid TLS override enables all HTTPS targets
+- **GIVEN** `scraper.security.network.allowInvalidTls` is `true`
+- **WHEN** the configuration is loaded
+- **THEN** HTTPS requests SHALL be eligible to bypass invalid certificate errors
+
+#### Scenario: File access mode defaults to allowed roots
+- **GIVEN** no custom security configuration is provided
+- **WHEN** the configuration is loaded
+- **THEN** local file access mode SHALL default to `allowedRoots`
+
+#### Scenario: Documents root is configured by default
+- **GIVEN** no custom security configuration is provided
+- **WHEN** the configuration is loaded
+- **THEN** the allowed file roots SHALL include `$DOCUMENTS`
+
+#### Scenario: Internal archive handoff does not require temp root configuration
+- **GIVEN** no custom security configuration is provided
+- **WHEN** the system processes a supported web archive root via an internal temporary file
+- **THEN** the default file access configuration SHALL not require the OS temporary directory to be added to `allowedRoots`
+
+#### Scenario: Empty file root allowlist denies user-requested file access
+- **GIVEN** `scraper.security.fileAccess.mode` is `allowedRoots`
+- **AND** `scraper.security.fileAccess.allowedRoots` is empty
+- **WHEN** the configuration is loaded
+- **THEN** user-requested `file://` access SHALL not be permitted by configuration
+
+#### Scenario: Unresolvable documents token grants no access
+- **GIVEN** `scraper.security.fileAccess.allowedRoots` contains `$DOCUMENTS`
+- **AND** the runtime cannot resolve a documents directory for the current platform or account
+- **WHEN** the configuration is loaded and file access policy is evaluated
+- **THEN** `$DOCUMENTS` SHALL not expand to an implicit fallback path
+- **AND** no access SHALL be granted from that token alone
+
+#### Scenario: Supported allowed-root tokens
+- **GIVEN** `scraper.security.fileAccess.allowedRoots` accepts tokens that expand at runtime
+- **WHEN** the configuration is loaded
+- **THEN** the supported tokens SHALL include `$HOME`, `$DOCUMENTS`, `$DOWNLOADS`, `$DESKTOP`, and `$CWD`
+- **AND** any other value SHALL be treated as a literal filesystem path
+- **AND** a token that cannot be resolved at runtime SHALL grant no access by itself
+
+#### Scenario: Hidden path access defaults to disabled
+- **GIVEN** no custom security configuration is provided
+- **WHEN** the configuration is loaded
+- **THEN** hidden file and directory access SHALL default to disabled
+
+#### Scenario: Symlink following defaults to disabled
+- **GIVEN** no custom security configuration is provided
+- **WHEN** the configuration is loaded
+- **THEN** symlink following for local file access SHALL default to disabled

--- a/openspec/changes/add-fetch-access-controls/specs/outbound-access-control/spec.md
+++ b/openspec/changes/add-fetch-access-controls/specs/outbound-access-control/spec.md
@@ -1,0 +1,267 @@
+## ADDED Requirements
+
+### Requirement: Outbound Network Targets Must Respect Access Policy
+The system SHALL enforce a shared outbound network access policy for one-shot URL fetches and scrape workflows before establishing HTTP(S) connections. Redirect-target validation and DNS-resolved IP validation SHALL always be applied during HTTP(S) access.
+
+The network policy SHALL operate in one of two modes selected by `scraper.security.network.mode`:
+
+- `open` (default): public internet targets are permitted; private, loopback, link-local, and other special-use network targets are denied unless `allowPrivateNetworks` is `true` or the target matches `allowedHosts` or `allowedCidrs`.
+- `allowlist`: a request is permitted only when its hostname matches `allowedHosts` or its target/resolved IP falls within `allowedCidrs`. In allowlist mode `allowPrivateNetworks` SHALL be ignored.
+
+Hostname matching SHALL use the same pattern syntax as scraper include/exclude patterns: a literal hostname is an exact-match entry; glob wildcards such as `*.example.com` and `docs.*` are supported via minimatch; an entry wrapped in `/.../` is treated as a JavaScript regular expression. Hostname matching SHALL be case-insensitive. Glob and regex patterns SHALL be matched against the bare hostname only, without scheme or path. CIDR allowlist entries SHALL be matched against the connecting IP, not against patterns.
+
+#### Scenario: Block loopback target by default
+- **WHEN** a user attempts to fetch `http://127.0.0.1:9999/test`
+- **THEN** the system SHALL reject the request before performing the fetch
+- **AND** the error SHALL state that the target is blocked by security policy
+
+#### Scenario: Block private network target by default
+- **WHEN** a user attempts to fetch a URL whose resolved address is within a private network range
+- **THEN** the system SHALL reject the request before performing the fetch
+- **AND** the error SHALL identify that private network access is disabled
+
+#### Scenario: Block loopback and special-use targets by default
+- **WHEN** a user attempts to fetch a URL whose resolved address is loopback, link-local, or another blocked special-use address
+- **THEN** the system SHALL reject the request before performing the fetch
+- **AND** the error SHALL identify that the target is blocked by network security policy
+
+#### Scenario: Allow configured internal target
+- **GIVEN** the configuration explicitly allows the target hostname or CIDR range
+- **WHEN** a user fetches an internal documentation URL within that allowlist
+- **THEN** the system SHALL permit the request
+
+#### Scenario: Allowlist exception while private networks remain disabled
+- **GIVEN** `allowPrivateNetworks` is `false`
+- **AND** the target matches `allowedHosts` or `allowedCidrs`
+- **WHEN** a user fetches that internal URL
+- **THEN** the system SHALL permit the request
+- **AND** other private or special-use targets SHALL remain blocked unless they also match the allowlist
+
+#### Scenario: Empty network allowlists deny all private targets
+- **GIVEN** `allowPrivateNetworks` is `false`
+- **AND** `allowedHosts` and `allowedCidrs` are both empty
+- **WHEN** a user fetches a private or special-use network target
+- **THEN** the system SHALL reject the request
+- **AND** public internet targets SHALL remain eligible for access
+
+#### Scenario: Host allowlist grants a hostname-bound exception
+- **GIVEN** `allowPrivateNetworks` is `false`
+- **AND** `allowedHosts` contains `docs.internal.example`
+- **WHEN** a user fetches `https://docs.internal.example/guide`
+- **THEN** the system SHALL permit the request even if the host resolves to a private or special-use address
+- **AND** that authorization SHALL apply only to the requested hostname, not to its direct IPs or any other hostname that resolves to the same service
+
+#### Scenario: Host allowlist does not permit direct IP access
+- **GIVEN** `allowPrivateNetworks` is `false`
+- **AND** `allowedHosts` contains `docs.internal.example`
+- **WHEN** a user fetches the direct IP address of that service
+- **THEN** the system SHALL reject the request unless the resolved target is also permitted by `allowedCidrs` or `allowPrivateNetworks`
+
+#### Scenario: Host allowlist does not permit redirected hostname by default
+- **GIVEN** `allowPrivateNetworks` is `false`
+- **AND** `allowedHosts` contains `docs.internal.example`
+- **WHEN** the request redirects to `wiki.internal.example`
+- **THEN** the redirected request SHALL be rejected unless the new target also matches `allowedHosts`, `allowedCidrs`, or `allowPrivateNetworks`
+
+#### Scenario: Glob host pattern matches subdomains
+- **GIVEN** `allowedHosts` contains `*.internal.example`
+- **WHEN** a user fetches `https://docs.internal.example/guide` or `https://wiki.team.internal.example/page`
+- **THEN** the system SHALL permit both requests
+- **AND** a request to the bare apex `https://internal.example/` SHALL not match the leading-wildcard pattern
+
+#### Scenario: Regex host pattern matches by anchored pattern
+- **GIVEN** `allowedHosts` contains `/^docs\d+\.example\.com$/`
+- **WHEN** a user fetches `https://docs42.example.com/path`
+- **THEN** the system SHALL permit the request
+
+#### Scenario: Allowlist mode requires explicit match for every target
+- **GIVEN** `network.mode` is `allowlist`
+- **AND** `allowedHosts` contains `docs.python.org` and `*.rust-lang.org`
+- **WHEN** a user fetches `https://docs.python.org/3/` or `https://docs.rust-lang.org/std/`
+- **THEN** the system SHALL permit both requests
+- **AND** a request to `https://news.ycombinator.com/` SHALL be rejected
+
+#### Scenario: Allowlist mode permits direct IPs only via CIDR
+- **GIVEN** `network.mode` is `allowlist`
+- **AND** `allowedCidrs` contains `10.42.0.0/16`
+- **WHEN** a user fetches `https://10.42.7.1/`
+- **THEN** the system SHALL permit the request
+- **AND** a request to `https://10.99.0.1/` SHALL be rejected
+
+#### Scenario: Allowlist mode denies all traffic when both lists are empty
+- **GIVEN** `network.mode` is `allowlist`
+- **AND** `allowedHosts` and `allowedCidrs` are both empty
+- **WHEN** a user fetches any HTTP(S) URL
+- **THEN** the system SHALL reject the request
+
+#### Scenario: Allowlist mode ignores allowPrivateNetworks
+- **GIVEN** `network.mode` is `allowlist`
+- **AND** `allowPrivateNetworks` is `true`
+- **WHEN** a user fetches a private or special-use target that does not match `allowedHosts` or `allowedCidrs`
+- **THEN** the system SHALL reject the request
+
+#### Scenario: Mixed DNS answers are rejected for non-allowlisted hostnames in open mode
+- **GIVEN** `network.mode` is `open`
+- **AND** `allowPrivateNetworks` is `false`
+- **AND** a hostname does not match `allowedHosts`
+- **AND** DNS returns both public and private or special-use addresses for that hostname
+- **WHEN** the system evaluates the access policy
+- **THEN** the system SHALL reject the request unless every blocked special-use address is also covered by `allowedCidrs`
+
+#### Scenario: CIDR-authorized hostname in allowlist mode requires every resolved address to be allowed
+- **GIVEN** `network.mode` is `allowlist`
+- **AND** a hostname does not match `allowedHosts`
+- **AND** DNS returns multiple addresses for that hostname
+- **WHEN** any resolved address falls outside `allowedCidrs`
+- **THEN** the system SHALL reject the request even if another resolved address is inside `allowedCidrs`
+
+### Requirement: TLS Verification Must Respect Network Security Policy
+The system SHALL verify TLS certificates for HTTPS requests by default across HTTP and browser-based fetch paths. TLS exception policy SHALL only affect certificate validation after the target has already been permitted by the outbound network access policy.
+
+#### Scenario: Reject invalid TLS certificate by default
+- **GIVEN** no TLS override is configured
+- **WHEN** a user fetches an HTTPS URL whose certificate is invalid or self-signed
+- **THEN** the system SHALL reject the request because TLS verification failed
+
+#### Scenario: Broad invalid TLS override enables all HTTPS targets
+- **GIVEN** `allowInvalidTls` is `true`
+- **AND** the target is already permitted by the outbound network access policy
+- **WHEN** a user fetches an HTTPS URL with an invalid certificate
+- **THEN** the system SHALL permit the request to proceed without rejecting the certificate
+
+#### Scenario: Invalid TLS override does not bypass the network allowlist
+- **GIVEN** `allowInvalidTls` is `true`
+- **AND** the target is not permitted by the outbound network access policy (because of private-network defaults or allowlist mode)
+- **WHEN** a user fetches that HTTPS URL
+- **THEN** the system SHALL reject the request based on network policy without consulting the TLS override
+
+### Requirement: Browser-Initiated Requests Must Respect Network Policy
+The system SHALL apply the same outbound network access policy to every HTTP(S) request initiated by browser-based fetching during rendering or page evaluation.
+
+#### Scenario: Block iframe request to private target during browser rendering
+- **GIVEN** browser-based fetching is used for a public page
+- **WHEN** the page attempts to load an iframe from a blocked private or special-use target
+- **THEN** the system SHALL block that request
+- **AND** the private target SHALL not receive the request
+
+#### Scenario: Block subresource request to private target during browser rendering
+- **GIVEN** browser-based fetching is used for a public page
+- **WHEN** the page attempts to load a script, stylesheet, image, or fetch/XHR request from a blocked private or special-use target
+- **THEN** the system SHALL block that request
+- **AND** the private target SHALL not receive the request
+
+#### Scenario: Apply allowlist exception to browser subrequest
+- **GIVEN** browser-based fetching is used
+- **AND** `allowPrivateNetworks` is `false`
+- **AND** the browser subrequest target matches `allowedHosts` or `allowedCidrs`
+- **WHEN** the page requests that internal resource
+- **THEN** the system SHALL permit the subrequest
+
+#### Scenario: Browser subrequest host allowlist remains hostname-bound
+- **GIVEN** browser-based fetching is used
+- **AND** `allowPrivateNetworks` is `false`
+- **AND** `allowedHosts` contains `docs.internal.example`
+- **WHEN** the page requests a subresource from the direct IP address of that service
+- **THEN** the system SHALL reject the subrequest unless the address is also permitted by `allowedCidrs` or `allowPrivateNetworks`
+
+#### Scenario: Browser subrequest respects broad invalid TLS override
+- **GIVEN** browser-based fetching is used
+- **AND** `allowInvalidTls` is `true`
+- **WHEN** the page requests an HTTPS subresource with an invalid certificate
+- **THEN** the system SHALL permit the subrequest to proceed without rejecting the certificate
+
+#### Scenario: Block redirect to restricted network target
+- **WHEN** a public URL redirects to a target blocked by the outbound access policy
+- **THEN** the system SHALL reject the redirect target
+- **AND** the final request SHALL not be sent to the blocked target
+
+### Requirement: Local File Access Must Respect Configured File Policy
+The system SHALL enforce one shared local file access policy for direct `file://` fetches and local scraping workflows.
+
+#### Scenario: Reject file access when disabled
+- **GIVEN** file access mode is `disabled`
+- **WHEN** a user attempts to fetch or scrape a `file://` URL
+- **THEN** the system SHALL reject the request before reading the file system
+
+#### Scenario: Allow file access within configured root
+- **GIVEN** file access mode is `allowedRoots`
+- **AND** the target file resolves within a configured allowed root
+- **WHEN** a user fetches or scrapes that `file://` URL
+- **THEN** the system SHALL permit the request
+
+#### Scenario: Reject file access outside configured root
+- **GIVEN** file access mode is `allowedRoots`
+- **AND** the target file resolves outside all configured allowed roots
+- **WHEN** a user fetches or scrapes that `file://` URL
+- **THEN** the system SHALL reject the request before reading the file contents
+
+#### Scenario: Validate archive member against backing archive path
+- **GIVEN** file access mode is `allowedRoots`
+- **AND** a user requests a virtual archive member path such as `file:///allowed/docs.zip/guide/intro.md`
+- **WHEN** the access policy is evaluated
+- **THEN** the system SHALL resolve containment against the concrete archive file path `file:///allowed/docs.zip`
+- **AND** it SHALL not reject the request solely because the virtual member path does not exist on the physical file system
+
+#### Scenario: Expand documents token for allowed root
+- **GIVEN** file access mode is `allowedRoots`
+- **AND** an allowed root is configured as `$DOCUMENTS`
+- **WHEN** the access policy is evaluated
+- **THEN** the system SHALL resolve `$DOCUMENTS` to the platform-specific documents directory before checking path containment
+
+#### Scenario: Expand additional user-directory tokens for allowed roots
+- **GIVEN** an allowed root is configured as one of `$HOME`, `$DOWNLOADS`, `$DESKTOP`, or `$CWD`
+- **WHEN** the access policy is evaluated
+- **THEN** `$HOME` SHALL resolve to the user's home directory
+- **AND** `$DOWNLOADS` SHALL resolve to the platform-specific downloads directory when that directory exists, otherwise grant no access
+- **AND** `$DESKTOP` SHALL resolve to the platform-specific desktop directory when that directory exists, otherwise grant no access
+- **AND** `$CWD` SHALL resolve to the process working directory
+
+#### Scenario: Empty file root allowlist denies user-requested file access
+- **GIVEN** file access mode is `allowedRoots`
+- **AND** `allowedRoots` is empty
+- **WHEN** a user attempts to fetch or scrape a `file://` URL
+- **THEN** the system SHALL reject the request before reading the file system
+
+#### Scenario: Permit internally managed temp archive handoff
+- **GIVEN** a supported web archive root URL has passed outbound network policy checks
+- **WHEN** the system downloads the archive to an internal temporary file for processing
+- **THEN** the handoff into local archive processing SHALL be permitted even if the temp file is outside configured user file roots
+- **AND** this exception SHALL apply only to application-managed temporary files created for that accepted archive workflow
+
+#### Scenario: Temp archive exception does not permit unrelated temp files
+- **GIVEN** file access mode is `allowedRoots`
+- **AND** a temporary file was not created as the accepted archive artifact for the current web archive workflow
+- **WHEN** local file policy is evaluated for that temp file
+- **THEN** the normal file access policy SHALL apply
+
+### Requirement: Hidden Paths and Symlinks Must Be Explicitly Opted In
+The system SHALL treat hidden paths and symlink traversal as restricted by default for local file access.
+
+#### Scenario: Block hidden file by default
+- **GIVEN** hidden path access is disabled
+- **WHEN** a user attempts to fetch or scrape a hidden file or a path inside a hidden directory below the matched allowed root
+- **THEN** the system SHALL reject or skip the path according to the calling workflow
+
+#### Scenario: Permit access under an allowed root whose absolute path contains a hidden ancestor
+- **GIVEN** an allowed root such as `/srv/.config/docs` is configured
+- **AND** hidden path access is disabled
+- **WHEN** a user fetches or scrapes a non-hidden file inside that root (for example `/srv/.config/docs/guide.md`)
+- **THEN** the system SHALL permit the request
+- **AND** the hidden-segment check SHALL only apply to segments strictly below the matched root
+- **AND** hidden segments inside the root (for example `.git`) SHALL still be blocked unless `includeHidden` is enabled
+
+#### Scenario: Skip hidden entries during directory traversal by default
+- **GIVEN** hidden path access is disabled
+- **WHEN** the system enumerates entries inside an allowed local directory
+- **THEN** hidden files and hidden directories SHALL not be added to the crawl queue
+
+#### Scenario: Block symlink traversal by default
+- **GIVEN** symlink following is disabled
+- **WHEN** a requested file or enumerated directory entry is a symlink
+- **THEN** the system SHALL reject or skip the symlinked path according to the calling workflow
+
+#### Scenario: Allow symlink when enabled and contained
+- **GIVEN** symlink following is enabled
+- **AND** the symlink target resolves within a configured allowed root
+- **WHEN** a user fetches or scrapes the symlinked path
+- **THEN** the system SHALL permit access to the resolved target

--- a/openspec/changes/add-fetch-access-controls/tasks.md
+++ b/openspec/changes/add-fetch-access-controls/tasks.md
@@ -1,0 +1,56 @@
+## 1. Configuration Model
+
+- [x] 1.1 Add `scraper.security` to the typed config schema and defaults, including network restrictions and file access settings.
+- [x] 1.2 Implement config parsing for `network.mode`, `network.allowedHosts`, `network.allowedCidrs`, `network.allowInvalidTls`, `fileAccess.mode`, `allowedRoots`, `followSymlinks`, and `includeHidden`, including JSON/YAML-style array env values and user-directory token support.
+- [x] 1.3 Extend configuration tests to cover default values, nested environment variable overrides, array env parsing, invalid-TLS settings, and unresolvable user-directory token behavior.
+- [x] 1.4 Make `loadConfig` resilient to a structurally invalid saved config (fall back to defaults and overwrite) so users do not get stuck after an upgrade.
+- [x] 1.5 Fix `deepMerge` to treat arrays as scalars (source replaces target) so list-shaped config values survive a write/read round-trip.
+
+## 2. Shared Access Policy
+
+- [x] 2.1 Add a shared URL and file access policy helper that evaluates HTTP(S) targets, CIDR/host allowlists, and file path containment.
+- [x] 2.2 Enforce the shared policy in `AutoDetectFetcher` and HTTP fetch flows, including mandatory redirect-target and DNS-resolved IP revalidation.
+- [x] 2.3 Enforce the shared policy in local file fetch and local scrape entry points before any file system reads occur, including virtual archive paths.
+- [x] 2.4 Preserve supported web archive root processing by allowing internally managed temp archive handoff after the original network URL has passed policy checks.
+- [x] 2.5 Define and implement hostname-bound `allowedHosts` exceptions and address-bound `allowedCidrs` exceptions, including redirect handling for new targets.
+- [x] 2.6 Define and implement TLS verification policy with secure defaults and broad `allowInvalidTls` override behavior.
+- [x] 2.7 Ensure TLS exceptions are evaluated only after network policy allows the target.
+- [x] 2.8 Implement `network.mode` with `open` (current behavior) and `allowlist` (only configured hosts/CIDRs permitted; `allowPrivateNetworks` ignored) postures.
+- [x] 2.9 Match `allowedHosts` entries via the shared scraper pattern syntax (literal, minimatch glob, or `/.../` regex), against the bare hostname only.
+- [x] 2.10 Expand user-directory tokens `$HOME`, `$DOCUMENTS`, `$DOWNLOADS`, `$DESKTOP`, and `$CWD` for file-access allowed roots, returning null when a token cannot be resolved.
+
+## 3. Browser Enforcement
+
+- [x] 3.1 Enforce the shared outbound policy on all Playwright-initiated requests, including frames, iframes, scripts, stylesheets, images, and fetch/XHR calls.
+- [x] 3.2 Ensure browser subrequests apply the same hostname-bound `allowedHosts`, address-bound `allowedCidrs`, and broad invalid-TLS semantics as non-browser HTTP fetches.
+
+## 4. Local File Traversal Hardening
+
+- [x] 4.1 Update local file traversal to block or skip hidden files and directories when `includeHidden` is disabled.
+- [x] 4.2 Update local file traversal to reject symlinks by default and allow them only when `followSymlinks` is enabled and the resolved target remains inside an allowed root.
+- [x] 4.3 Ensure direct `file://` fetches use the same hidden-path and symlink rules as directory crawling.
+- [x] 4.4 Validate archive-member `file://` paths against the concrete archive file path instead of the nonexistent combined virtual path.
+- [x] 4.5 Limit the internal temp-archive exception to the accepted downloaded archive artifact and its virtual members.
+
+## 5. Verification
+
+- [x] 5.1 Add tests for blocked loopback, private-network, and redirect-to-private HTTP(S) requests.
+- [x] 5.2 Add tests for allowed internal targets when hosts or CIDRs are explicitly configured while `allowPrivateNetworks` remains disabled.
+- [x] 5.3 Add tests for hostname-bound host allowlists, CIDR-based IP allowlists, and redirects or direct-IP requests that must remain blocked unless separately allowed.
+- [x] 5.4 Add tests for invalid TLS rejection by default and broad invalid-TLS override behavior.
+- [x] 5.5 Add tests proving invalid-TLS override does not bypass network allowlists.
+- [x] 5.6 Add tests for browser-based blocked subrequests and allowed browser subrequests under explicit allowlists, including invalid-TLS behavior.
+- [x] 5.7 Add tests for allowed-root file access, blocked outside-root access, hidden path blocking, and symlink containment.
+- [x] 5.8 Add tests for supported web archive root scraping via temp files, virtual archive-member paths within allowed roots, and unrelated temp-file rejection.
+- [x] 5.9 Add tests for `network.mode` allowlist semantics: hostname glob matches, regex matches, CIDR-only direct-IP matches, empty-list deny-all, and that `allowPrivateNetworks` is ignored.
+- [x] 5.10 Add tests for the additional user-directory tokens (`$HOME`, `$DOWNLOADS`, `$DESKTOP`, `$CWD`), including the case where the underlying directory is absent.
+- [x] 5.11 Add tests confirming that an allowlisted hostname is trusted for its DNS answers (resolves to a private IP without `allowedCidrs` still succeeds) and that for non-allowlisted hostnames in allowlist mode every resolved address must lie inside `allowedCidrs`.
+- [x] 5.12 Add tests confirming that the hidden-segment check only applies to segments below the matched allowed root: a root whose absolute path contains a hidden ancestor (e.g. `/srv/.config/docs`) permits its contents, while hidden segments inside the root (e.g. `.git`) remain blocked.
+
+## 6. Documentation
+
+- [x] 6.1 Update user-facing configuration documentation to describe the new security defaults and override mechanisms.
+- [x] 6.2 Update security/authentication documentation to explain the trust model, private-network defaults, and local file restrictions.
+- [x] 6.3 Add a dedicated `docs/infrastructure/security.md` document covering trust boundaries, deployment hardening, outbound access controls, and local file access policy.
+- [x] 6.4 Document sample security configurations, environment-variable array encoding, empty network/file allowlist behavior, and counterintuitive semantics such as broad access from `allowPrivateNetworks: true`, broad TLS trust from `allowInvalidTls: true`, and unresolved `$DOCUMENTS` tokens.
+- [x] 6.5 Document that invalid-TLS override does not bypass network allowlists.

--- a/src/scraper/fetcher/AutoDetectFetcher.ts
+++ b/src/scraper/fetcher/AutoDetectFetcher.ts
@@ -22,11 +22,12 @@ import type { ContentFetcher, FetchOptions, RawContent } from "./types";
 export class AutoDetectFetcher implements ContentFetcher {
   private readonly httpFetcher: HttpFetcher;
   private readonly browserFetcher: BrowserFetcher;
-  private readonly fileFetcher = new FileFetcher();
+  private readonly fileFetcher: FileFetcher;
 
   constructor(scraperConfig: AppConfig["scraper"]) {
     this.httpFetcher = new HttpFetcher(scraperConfig);
     this.browserFetcher = new BrowserFetcher(scraperConfig);
+    this.fileFetcher = new FileFetcher(scraperConfig);
   }
 
   /**

--- a/src/scraper/fetcher/BrowserFetcher.test.ts
+++ b/src/scraper/fetcher/BrowserFetcher.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { loadConfig } from "../../utils/config";
+
+vi.mock("playwright", () => ({
+  chromium: {
+    launch: vi.fn(),
+  },
+}));
+
+import { chromium } from "playwright";
+import { BrowserFetcher } from "./BrowserFetcher";
+
+describe("BrowserFetcher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses broad invalid TLS override for the browser context", async () => {
+    const setViewportSize = vi.fn().mockResolvedValue(undefined);
+    const setExtraHTTPHeaders = vi.fn().mockResolvedValue(undefined);
+    const route = vi.fn().mockResolvedValue(undefined);
+    const unroute = vi.fn().mockResolvedValue(undefined);
+    const closePage = vi.fn().mockResolvedValue(undefined);
+    const page = {
+      setViewportSize,
+      setExtraHTTPHeaders,
+      route,
+      unroute,
+      close: closePage,
+      goto: vi.fn().mockResolvedValue({
+        status: () => 200,
+        headers: () => ({ "content-type": "text/html" }),
+      }),
+      url: vi.fn().mockReturnValue("https://example.com"),
+      content: vi.fn().mockResolvedValue("<html><body>ok</body></html>"),
+    };
+    const closeContext = vi.fn().mockResolvedValue(undefined);
+    const newContext = vi.fn().mockResolvedValue({
+      newPage: vi.fn().mockResolvedValue(page),
+      close: closeContext,
+    });
+    const browser = {
+      newContext,
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(chromium.launch).mockResolvedValue(browser as never);
+
+    const config = loadConfig().scraper;
+    config.security.network.allowInvalidTls = true;
+    const fetcher = new BrowserFetcher(config);
+
+    await fetcher.fetch("http://example.com");
+
+    expect(newContext).toHaveBeenCalledWith(
+      expect.objectContaining({ ignoreHTTPSErrors: true }),
+    );
+  });
+
+  it("restores fingerprint headers and desktop viewport", async () => {
+    const setViewportSize = vi.fn().mockResolvedValue(undefined);
+    const setExtraHTTPHeaders = vi.fn().mockResolvedValue(undefined);
+    const page = {
+      setViewportSize,
+      setExtraHTTPHeaders,
+      route: vi.fn().mockResolvedValue(undefined),
+      unroute: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+      goto: vi.fn().mockResolvedValue({
+        status: () => 200,
+        headers: () => ({ "content-type": "text/html" }),
+      }),
+      url: vi.fn().mockReturnValue("https://example.com"),
+      content: vi.fn().mockResolvedValue("<html><body>ok</body></html>"),
+    };
+    const browser = {
+      newContext: vi.fn().mockResolvedValue({
+        newPage: vi.fn().mockResolvedValue(page),
+        close: vi.fn().mockResolvedValue(undefined),
+      }),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(chromium.launch).mockResolvedValue(browser as never);
+
+    const fetcher = new BrowserFetcher(loadConfig().scraper);
+    await fetcher.fetch("https://example.com", { headers: { "X-Test": "1" } });
+
+    expect(setViewportSize).toHaveBeenCalledWith({ width: 1920, height: 1080 });
+    expect(setExtraHTTPHeaders).toHaveBeenCalledWith(
+      expect.objectContaining({ "X-Test": "1" }),
+    );
+  });
+});

--- a/src/scraper/fetcher/BrowserFetcher.ts
+++ b/src/scraper/fetcher/BrowserFetcher.ts
@@ -1,4 +1,5 @@
 import { type Browser, chromium, type Page } from "playwright";
+import { ScraperAccessPolicy } from "../../utils/accessPolicy";
 import type { AppConfig } from "../../utils/config";
 import { ScraperError } from "../../utils/errors";
 import { logger } from "../../utils/logger";
@@ -17,38 +18,68 @@ import {
  */
 export class BrowserFetcher implements ContentFetcher {
   private browser: Browser | null = null;
-  private page: Page | null = null;
   private fingerprintGenerator: FingerprintGenerator;
   private readonly defaultTimeoutMs: number;
+  private readonly accessPolicy: ScraperAccessPolicy;
 
   constructor(scraperConfig: AppConfig["scraper"]) {
     this.defaultTimeoutMs = scraperConfig.browserTimeoutMs;
     this.fingerprintGenerator = new FingerprintGenerator();
+    this.accessPolicy = new ScraperAccessPolicy(scraperConfig.security);
   }
 
   canFetch(source: string): boolean {
     return source.startsWith("http://") || source.startsWith("https://");
   }
 
-  async fetch(source: string, options?: FetchOptions): Promise<RawContent> {
+  private async isRequestAllowed(url: string): Promise<boolean> {
     try {
-      await this.ensureBrowserReady();
+      await this.accessPolicy.assertNetworkUrlAllowed(url);
+      return true;
+    } catch {
+      return false;
+    }
+  }
 
-      if (!this.page) {
-        throw new ScraperError("Failed to create browser page", false);
-      }
+  async fetch(source: string, options?: FetchOptions): Promise<RawContent> {
+    let page: Page | null = null;
+    let browserContext: { newPage(): Promise<Page>; close(): Promise<void> } | null =
+      null;
+
+    try {
+      await this.accessPolicy.assertNetworkUrlAllowed(source);
+
+      const browser = await this.ensureBrowserReady();
+      const fingerprintHeaders = this.fingerprintGenerator.generateHeaders();
+      browserContext = await browser.newContext({
+        ignoreHTTPSErrors: this.accessPolicy.shouldAllowInvalidTls(
+          "https://browser-context.local",
+        ),
+      });
+      page = await browserContext.newPage();
+      await page.setViewportSize({ width: 1920, height: 1080 });
+
+      await page.route("**/*", async (route) => {
+        const requestUrl = route.request().url();
+        if (!(await this.isRequestAllowed(requestUrl))) {
+          return await route.abort("blockedbyclient");
+        }
+
+        return await route.continue();
+      });
 
       // Set custom headers if provided
-      if (options?.headers) {
-        await this.page.setExtraHTTPHeaders(options.headers);
-      }
+      await page.setExtraHTTPHeaders({
+        ...fingerprintHeaders,
+        ...options?.headers,
+      });
 
       // Set timeout
       const timeout = options?.timeout || this.defaultTimeoutMs;
 
       // Navigate to the page and wait for it to load
       logger.debug(`Navigating to ${source} with browser...`);
-      const response = await this.page.goto(source, {
+      const response = await page.goto(source, {
         waitUntil: "networkidle",
         timeout,
       });
@@ -70,10 +101,11 @@ export class BrowserFetcher implements ContentFetcher {
       }
 
       // Get the final URL after any redirects
-      const finalUrl = this.page.url();
+      const finalUrl = page.url();
+      await this.accessPolicy.assertNetworkUrlAllowed(finalUrl);
 
       // Get the page content
-      const content = await this.page.content();
+      const content = await page.content();
       const contentBuffer = Buffer.from(content, "utf-8");
 
       // Determine content type
@@ -103,6 +135,10 @@ export class BrowserFetcher implements ContentFetcher {
         false,
         error instanceof Error ? error : undefined,
       );
+    } finally {
+      await page?.unroute("**/*").catch(() => undefined);
+      await page?.close().catch(() => undefined);
+      await browserContext?.close().catch(() => undefined);
     }
   }
 
@@ -114,22 +150,13 @@ export class BrowserFetcher implements ContentFetcher {
     });
   }
 
-  private async ensureBrowserReady(): Promise<void> {
+  private async ensureBrowserReady(): Promise<Browser> {
     if (!this.browser) {
       logger.debug("Launching browser...");
       this.browser = await BrowserFetcher.launchBrowser();
     }
 
-    if (!this.page) {
-      this.page = await this.browser.newPage();
-
-      // Generate and set realistic browser headers
-      const dynamicHeaders = this.fingerprintGenerator.generateHeaders();
-      await this.page.setExtraHTTPHeaders(dynamicHeaders);
-
-      // Set viewport
-      await this.page.setViewportSize({ width: 1920, height: 1080 });
-    }
+    return this.browser;
   }
 
   /**
@@ -138,17 +165,6 @@ export class BrowserFetcher implements ContentFetcher {
    */
   async close(): Promise<void> {
     // Close page first
-    if (this.page) {
-      try {
-        await this.page.close();
-      } catch (error) {
-        logger.warn(`⚠️  Error closing browser page: ${error}`);
-      } finally {
-        this.page = null;
-      }
-    }
-
-    // Then close browser
     if (this.browser) {
       try {
         await this.browser.close();

--- a/src/scraper/fetcher/FileFetcher.ts
+++ b/src/scraper/fetcher/FileFetcher.ts
@@ -1,5 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
+import { fileUrlToPathLoose, ScraperAccessPolicy } from "../../utils/accessPolicy";
+import type { AppConfig } from "../../utils/config";
 import { ScraperError } from "../../utils/errors";
 import { MimeTypeUtils } from "../../utils/mimeTypeUtils";
 import {
@@ -13,6 +15,14 @@ import {
  * Fetches content from local file system.
  */
 export class FileFetcher implements ContentFetcher {
+  private readonly accessPolicy: ScraperAccessPolicy | null;
+
+  constructor(scraperConfig?: AppConfig["scraper"]) {
+    this.accessPolicy = scraperConfig
+      ? new ScraperAccessPolicy(scraperConfig.security)
+      : null;
+  }
+
   canFetch(source: string): boolean {
     return source.startsWith("file://");
   }
@@ -23,16 +33,14 @@ export class FileFetcher implements ContentFetcher {
    * Supports conditional fetching via ETag comparison for efficient refresh operations.
    */
   async fetch(source: string, options?: FetchOptions): Promise<RawContent> {
-    // Remove the file:// protocol prefix and handle both file:// and file:/// formats
-    let filePath = source.replace(/^file:\/\/\/?/, "");
-
-    // Decode percent-encoded characters
-    filePath = decodeURIComponent(filePath);
-
-    // Ensure absolute path on Unix-like systems (if not already absolute)
-    if (!filePath.startsWith("/") && process.platform !== "win32") {
-      filePath = `/${filePath}`;
-    }
+    const filePath = this.accessPolicy
+      ? (
+          await this.accessPolicy.resolveFileAccess(
+            source,
+            options?.internalAllowedFileRoots,
+          )
+        ).filePath
+      : fileUrlToPathLoose(source);
 
     try {
       const stats = await fs.stat(filePath);

--- a/src/scraper/fetcher/HttpFetcher.test.ts
+++ b/src/scraper/fetcher/HttpFetcher.test.ts
@@ -353,7 +353,9 @@ describe("HttpFetcher", () => {
 
     await fetcher.fetch("https://example.com");
 
-    // Test behavior: verify that axios is called with required properties
+    // Test behavior: verify that axios is called with required properties.
+    // Redirects are handled manually so every target can pass the access
+    // policy before connect, so axios is always invoked with maxRedirects: 0.
     expect(mockedAxios.get).toHaveBeenCalledWith(
       "https://example.com",
       expect.objectContaining({
@@ -366,7 +368,7 @@ describe("HttpFetcher", () => {
           "Accept-Encoding": "gzip, deflate, br",
         }),
         timeout: undefined,
-        maxRedirects: 5,
+        maxRedirects: 0,
         signal: undefined,
         decompress: true,
       }),
@@ -391,7 +393,7 @@ describe("HttpFetcher", () => {
         responseType: "arraybuffer",
         headers: expect.objectContaining(headers),
         timeout: undefined,
-        maxRedirects: 5,
+        maxRedirects: 0,
         signal: undefined,
         decompress: true,
       }),
@@ -413,10 +415,13 @@ describe("HttpFetcher", () => {
       expect(result.content).toEqual(
         Buffer.from("<html><body><h1>Hello</h1></body></html>", "utf-8"),
       );
+      // Redirects are followed manually so axios is always invoked with
+      // maxRedirects: 0; the follow-by-default behavior is exercised inside
+      // HttpFetcher's own loop.
       expect(mockedAxios.get).toHaveBeenCalledWith(
         "https://example.com",
         expect.objectContaining({
-          maxRedirects: 5, // Should allow redirects by default
+          maxRedirects: 0,
         }),
       );
     });
@@ -440,7 +445,7 @@ describe("HttpFetcher", () => {
       expect(mockedAxios.get).toHaveBeenCalledWith(
         "https://example.com",
         expect.objectContaining({
-          maxRedirects: 5, // Should allow redirects
+          maxRedirects: 0,
         }),
       );
     });

--- a/src/scraper/fetcher/HttpFetcher.ts
+++ b/src/scraper/fetcher/HttpFetcher.ts
@@ -1,5 +1,7 @@
+import https from "node:https";
 import axios, { type AxiosError, type AxiosRequestConfig } from "axios";
 import { CancellationError } from "../../pipeline/errors";
+import { ScraperAccessPolicy } from "../../utils/accessPolicy";
 import type { AppConfig } from "../../utils/config";
 import {
   ChallengeError,
@@ -16,6 +18,13 @@ import {
   FetchStatus,
   type RawContent,
 } from "./types";
+
+/**
+ * Maximum number of redirects to follow in a single fetch. Matches the legacy
+ * axios default; kept here as a named constant because redirects are now
+ * followed manually so every hop can be revalidated against the access policy.
+ */
+const MAX_REDIRECTS = 5;
 
 /**
  * Fetches content from remote sources using HTTP/HTTPS.
@@ -55,11 +64,13 @@ export class HttpFetcher implements ContentFetcher {
   ];
 
   private fingerprintGenerator: FingerprintGenerator;
+  private readonly accessPolicy: ScraperAccessPolicy;
 
   constructor(scraperConfig: AppConfig["scraper"]) {
     this.maxRetriesDefault = scraperConfig.fetcher.maxRetries;
     this.baseDelayDefaultMs = scraperConfig.fetcher.baseDelayMs;
     this.fingerprintGenerator = new FingerprintGenerator();
+    this.accessPolicy = new ScraperAccessPolicy(scraperConfig.security);
   }
 
   canFetch(source: string): boolean {
@@ -98,104 +109,155 @@ export class HttpFetcher implements ContentFetcher {
     baseDelay: number = this.baseDelayDefaultMs,
     followRedirects: boolean = true,
   ): Promise<RawContent> {
+    await this.accessPolicy.assertNetworkUrlAllowed(source);
+
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       try {
-        const fingerprint = this.fingerprintGenerator.generateHeaders();
-        const headers: Record<string, string> = {
-          ...fingerprint,
-          ...options?.headers, // User-provided headers override generated ones
-        };
+        let currentUrl = source;
+        let redirectCount = 0;
 
-        // Add If-None-Match header for conditional requests if ETag is provided
-        if (options?.etag) {
-          headers["If-None-Match"] = options.etag;
-          logger.debug(
-            `Conditional request for ${source} with If-None-Match: ${options.etag}`,
-          );
-        }
+        while (true) {
+          const fingerprint = this.fingerprintGenerator.generateHeaders();
+          const headers: Record<string, string> = {
+            ...fingerprint,
+            ...options?.headers, // User-provided headers override generated ones
+          };
 
-        const config: AxiosRequestConfig = {
-          responseType: "arraybuffer",
-          headers: {
-            ...headers,
-            // Override Accept-Encoding to exclude zstd which Axios doesn't handle automatically
-            // This prevents servers from sending zstd-compressed content that would appear as binary garbage
-            "Accept-Encoding": "gzip, deflate, br",
-          },
-          timeout: options?.timeout,
-          signal: options?.signal, // Pass signal to axios
-          // Axios follows redirects by default, we need to explicitly disable it if needed
-          maxRedirects: followRedirects ? 5 : 0,
-          decompress: true,
-          // Allow 304 responses to be handled as successful responses
-          validateStatus: (status) => {
-            return (status >= 200 && status < 300) || status === 304;
-          },
-        };
+          // Add If-None-Match header for conditional requests if ETag is provided
+          if (options?.etag) {
+            headers["If-None-Match"] = options.etag;
+            logger.debug(
+              `Conditional request for ${source} with If-None-Match: ${options.etag}`,
+            );
+          }
 
-        const response = await axios.get(source, config);
+          const config: AxiosRequestConfig = {
+            responseType: "arraybuffer",
+            headers: {
+              ...headers,
+              // Override Accept-Encoding to exclude zstd which Axios doesn't handle automatically
+              // This prevents servers from sending zstd-compressed content that would appear as binary garbage
+              "Accept-Encoding": "gzip, deflate, br",
+            },
+            timeout: options?.timeout,
+            signal: options?.signal, // Pass signal to axios
+            // Redirects are handled manually so every target can be revalidated before connect.
+            maxRedirects: 0,
+            decompress: true,
+            // Allow 304 responses to be handled as successful responses
+            validateStatus: (status) => {
+              return (status >= 200 && status < 400) || status === 304;
+            },
+          };
 
-        // Handle 304 Not Modified responses for conditional requests
-        if (response.status === 304) {
-          logger.debug(`HTTP 304 Not Modified for ${source}`);
+          if (this.accessPolicy.shouldAllowInvalidTls(currentUrl)) {
+            config.httpsAgent = new https.Agent({ rejectUnauthorized: false });
+          }
+
+          const response = await axios.get(currentUrl, config);
+
+          // 304 Not Modified is a conditional response, not a redirect. Handle
+          // it before the 30x redirect branch so the missing Location header
+          // does not trip the redirect check.
+          if (response.status === 304) {
+            logger.debug(`HTTP 304 Not Modified for ${currentUrl}`);
+            return {
+              content: Buffer.from(""),
+              mimeType: "text/plain",
+              source: currentUrl,
+              status: FetchStatus.NOT_MODIFIED,
+            } satisfies RawContent;
+          }
+
+          if (response.status >= 300 && response.status < 400) {
+            const location = response.headers.location;
+            if (!location) {
+              throw new ScraperError(
+                `Redirect response for ${currentUrl} did not include a location header`,
+                false,
+              );
+            }
+
+            if (!followRedirects) {
+              throw new RedirectError(currentUrl, location, response.status);
+            }
+
+            if (redirectCount >= MAX_REDIRECTS) {
+              throw new ScraperError(
+                `Too many redirects while fetching ${source}`,
+                false,
+              );
+            }
+
+            const redirectUrl = new URL(location, currentUrl).href;
+            await this.accessPolicy.assertNetworkUrlAllowed(redirectUrl);
+
+            currentUrl = redirectUrl;
+            redirectCount += 1;
+            continue;
+          }
+
+          const contentTypeHeader = response.headers["content-type"];
+          const { mimeType, charset } = MimeTypeUtils.parseContentType(contentTypeHeader);
+          const contentEncoding = response.headers["content-encoding"];
+
+          // Convert ArrayBuffer to Buffer properly
+          let content: Buffer;
+          if (response.data instanceof ArrayBuffer) {
+            content = Buffer.from(response.data);
+          } else if (Buffer.isBuffer(response.data)) {
+            content = response.data;
+          } else if (typeof response.data === "string") {
+            content = Buffer.from(response.data, "utf-8");
+          } else {
+            // Fallback for other data types
+            content = Buffer.from(response.data);
+          }
+
+          // Determine the final effective URL after redirects (if any)
+          const finalUrl =
+            // Node follow-redirects style
+            response.request?.res?.responseUrl ||
+            // Some adapters may expose directly
+            response.request?.responseUrl ||
+            // Fallback to axios recorded config URL
+            response.config?.url ||
+            currentUrl;
+
+          await this.accessPolicy.assertNetworkUrlAllowed(finalUrl);
+
+          // Extract ETag header for caching
+          const etag = response.headers.etag || response.headers.ETag;
+          if (etag) {
+            logger.debug(`Received ETag for ${finalUrl}: ${etag}`);
+          }
+
+          // Extract Last-Modified header for caching
+          const lastModified = response.headers["last-modified"];
+          const lastModifiedISO = lastModified
+            ? new Date(lastModified).toISOString()
+            : undefined;
+
           return {
-            content: Buffer.from(""),
-            mimeType: "text/plain",
-            source: source,
-            status: FetchStatus.NOT_MODIFIED,
+            content,
+            mimeType,
+            charset,
+            encoding: contentEncoding,
+            source: finalUrl,
+            etag,
+            lastModified: lastModifiedISO,
+            status: FetchStatus.SUCCESS,
           } satisfies RawContent;
         }
-
-        const contentTypeHeader = response.headers["content-type"];
-        const { mimeType, charset } = MimeTypeUtils.parseContentType(contentTypeHeader);
-        const contentEncoding = response.headers["content-encoding"];
-
-        // Convert ArrayBuffer to Buffer properly
-        let content: Buffer;
-        if (response.data instanceof ArrayBuffer) {
-          content = Buffer.from(response.data);
-        } else if (Buffer.isBuffer(response.data)) {
-          content = response.data;
-        } else if (typeof response.data === "string") {
-          content = Buffer.from(response.data, "utf-8");
-        } else {
-          // Fallback for other data types
-          content = Buffer.from(response.data);
-        }
-
-        // Determine the final effective URL after redirects (if any)
-        const finalUrl =
-          // Node follow-redirects style
-          response.request?.res?.responseUrl ||
-          // Some adapters may expose directly
-          response.request?.responseUrl ||
-          // Fallback to axios recorded config URL
-          response.config?.url ||
-          source;
-
-        // Extract ETag header for caching
-        const etag = response.headers.etag || response.headers.ETag;
-        if (etag) {
-          logger.debug(`Received ETag for ${source}: ${etag}`);
-        }
-
-        // Extract Last-Modified header for caching
-        const lastModified = response.headers["last-modified"];
-        const lastModifiedISO = lastModified
-          ? new Date(lastModified).toISOString()
-          : undefined;
-
-        return {
-          content,
-          mimeType,
-          charset,
-          encoding: contentEncoding,
-          source: finalUrl,
-          etag,
-          lastModified: lastModifiedISO,
-          status: FetchStatus.SUCCESS,
-        } satisfies RawContent;
       } catch (error: unknown) {
+        if (error instanceof RedirectError || error instanceof ChallengeError) {
+          throw error;
+        }
+
+        if (error instanceof ScraperError && !error.isRetryable) {
+          throw error;
+        }
+
         const axiosError = error as AxiosError;
         const status = axiosError.response?.status;
         const code = axiosError.code;

--- a/src/scraper/fetcher/types.ts
+++ b/src/scraper/fetcher/types.ts
@@ -90,6 +90,8 @@ export interface FetchOptions {
    * and may return a 304 Not Modified response if content hasn't changed.
    */
   etag?: string | null;
+  /** Internal-only allowlist roots for application-managed temporary files. */
+  internalAllowedFileRoots?: string[];
 }
 
 /**

--- a/src/scraper/middleware/HtmlPlaywrightMiddleware.test.ts
+++ b/src/scraper/middleware/HtmlPlaywrightMiddleware.test.ts
@@ -176,6 +176,21 @@ describe("HtmlPlaywrightMiddleware", () => {
       document: {
         maxSize: 10 * 1024 * 1024,
       },
+      security: {
+        network: {
+          mode: "open" as const,
+          allowPrivateNetworks: false,
+          allowedHosts: [],
+          allowedCidrs: [],
+          allowInvalidTls: false,
+        },
+        fileAccess: {
+          mode: "unrestricted" as const,
+          allowedRoots: [],
+          followSymlinks: false,
+          includeHidden: false,
+        },
+      },
     };
     playwrightMiddleware = new HtmlPlaywrightMiddleware(mockScraperConfig);
   });
@@ -946,6 +961,21 @@ describe("Route handling race condition protection", () => {
       },
       document: {
         maxSize: 10 * 1024 * 1024,
+      },
+      security: {
+        network: {
+          mode: "open" as const,
+          allowPrivateNetworks: false,
+          allowedHosts: [],
+          allowedCidrs: [],
+          allowInvalidTls: false,
+        },
+        fileAccess: {
+          mode: "unrestricted" as const,
+          allowedRoots: [],
+          followSymlinks: false,
+          includeHidden: false,
+        },
       },
     };
     playwrightMiddleware = new HtmlPlaywrightMiddleware(mockScraperConfig);

--- a/src/scraper/middleware/HtmlPlaywrightMiddleware.ts
+++ b/src/scraper/middleware/HtmlPlaywrightMiddleware.ts
@@ -1,4 +1,5 @@
 import type { Browser, BrowserContext, ElementHandle, Frame, Page } from "playwright";
+import { ScraperAccessPolicy } from "../../utils/accessPolicy";
 import { type AppConfig, defaults } from "../../utils/config";
 import { logger } from "../../utils/logger";
 import { MimeTypeUtils } from "../../utils/mimeTypeUtils";
@@ -44,6 +45,7 @@ interface CachedResource {
 export class HtmlPlaywrightMiddleware implements ContentProcessorMiddleware {
   private browser: Browser | null = null;
   private readonly config: AppConfig["scraper"];
+  private readonly accessPolicy: ScraperAccessPolicy;
 
   // Static LRU cache for all fetched resources, shared across instances
   private static readonly resourceCache = new SimpleMemoryCache<string, CachedResource>(
@@ -52,6 +54,16 @@ export class HtmlPlaywrightMiddleware implements ContentProcessorMiddleware {
 
   constructor(config: AppConfig["scraper"]) {
     this.config = config;
+    this.accessPolicy = new ScraperAccessPolicy(config.security);
+  }
+
+  private async isRequestAllowed(url: string): Promise<boolean> {
+    try {
+      await this.accessPolicy.assertNetworkUrlAllowed(url);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /**
@@ -536,6 +548,10 @@ export class HtmlPlaywrightMiddleware implements ContentProcessorMiddleware {
       })();
       const resourceType = route.request().resourceType();
 
+      if (!(await this.isRequestAllowed(reqUrl))) {
+        return await route.abort("blockedbyclient");
+      }
+
       // Abort non-essential resources
       if (["image", "font", "media"].includes(resourceType)) {
         try {
@@ -690,6 +706,10 @@ export class HtmlPlaywrightMiddleware implements ContentProcessorMiddleware {
 
     let framePage: Page | null = null;
     try {
+      if (!(await this.isRequestAllowed(resolvedUrl))) {
+        return "";
+      }
+
       // Create a new page in the same browser context for consistency
       framePage = await parentPage.context().newPage();
 
@@ -862,9 +882,18 @@ export class HtmlPlaywrightMiddleware implements ContentProcessorMiddleware {
 
       // Always create a browser context (with or without credentials)
       if (credentials) {
-        browserContext = await browser.newContext({ httpCredentials: credentials });
+        browserContext = await browser.newContext({
+          httpCredentials: credentials,
+          ignoreHTTPSErrors: this.accessPolicy.shouldAllowInvalidTls(
+            "https://browser-context.local",
+          ),
+        });
       } else {
-        browserContext = await browser.newContext();
+        browserContext = await browser.newContext({
+          ignoreHTTPSErrors: this.accessPolicy.shouldAllowInvalidTls(
+            "https://browser-context.local",
+          ),
+        });
       }
       page = await browserContext.newPage();
 
@@ -915,6 +944,10 @@ export class HtmlPlaywrightMiddleware implements ContentProcessorMiddleware {
           }
         })();
         const resourceType = route.request().resourceType();
+
+        if (!(await this.isRequestAllowed(reqUrl))) {
+          return await route.abort("blockedbyclient");
+        }
 
         // Abort non-essential resources
         if (["image", "font", "media"].includes(resourceType)) {

--- a/src/scraper/strategies/BaseScraperStrategy.ts
+++ b/src/scraper/strategies/BaseScraperStrategy.ts
@@ -1,6 +1,8 @@
+import path from "node:path";
 import { URL } from "node:url";
 import { CancellationError } from "../../pipeline/errors";
 import type { ProgressCallback } from "../../types";
+import { fileUrlToPathLoose } from "../../utils/accessPolicy";
 import type { AppConfig } from "../../utils/config";
 import { ScraperError } from "../../utils/errors";
 import { logger } from "../../utils/logger";
@@ -44,6 +46,8 @@ export interface ProcessItemResult {
   content?: PipelineResult;
   /** Extracted links from the content. This may be an empty array if no links were found or if the content was not processed. */
   links?: string[];
+  /** Internal-only allowlist roots to carry to discovered queue items. */
+  internalAllowedFileRoots?: string[];
   /** Any non-critical errors encountered during processing. This may be an empty array if no errors were encountered or if the content was not processed. */
   status: FetchStatus;
 }
@@ -99,9 +103,28 @@ export abstract class BaseScraperStrategy implements ScraperStrategy {
   /**
    * Determines if a URL should be processed based on scope and include/exclude patterns in ScraperOptions.
    * Scope is checked first, then patterns.
+   *
+   * `internalAllowedFileRoots` opts a queue item out of the protocol-strict
+   * scope check: when a web URL has been accepted as an archive root and the
+   * archive expands into `file://` members, those members are continuations of
+   * the same accepted scrape and should not be rejected because they crossed
+   * from `https:` to `file:`. The bypass is intentionally narrow — the
+   * `file://` target must resolve inside one of the internal roots — so
+   * arbitrary links injected into archive content cannot escape the archive
+   * sandbox via this path. Downstream `resolveFileAccess` enforces the same
+   * rule, but rejecting early here keeps unrelated `file://` URLs out of the
+   * crawl queue entirely.
    */
-  protected shouldProcessUrl(url: string, options: ScraperOptions): boolean {
-    if (options.scope) {
+  protected shouldProcessUrl(
+    url: string,
+    options: ScraperOptions,
+    context: { internalAllowedFileRoots?: string[] } = {},
+  ): boolean {
+    const isInternalArchiveMember =
+      url.startsWith("file://") &&
+      isFileUrlInsideRoots(url, context.internalAllowedFileRoots);
+
+    if (options.scope && !isInternalArchiveMember) {
       try {
         const base = this.canonicalBaseUrl ?? new URL(options.url);
         const target = new URL(url);
@@ -327,6 +350,8 @@ export abstract class BaseScraperStrategy implements ScraperStrategy {
           // Extract discovered links - use the final URL as the base for resolving relative links
           const nextItems = result.links || [];
           const linkBaseUrl = finalUrl ? new URL(finalUrl) : baseUrl;
+          const internalAllowedFileRoots =
+            result.internalAllowedFileRoots ?? item.internalAllowedFileRoots;
 
           this.recordChildPageCompletion(item, result);
           ensureFailureRateWithinThreshold();
@@ -337,12 +362,17 @@ export abstract class BaseScraperStrategy implements ScraperStrategy {
               try {
                 const targetUrl = new URL(value, linkBaseUrl);
                 // Filter using shouldProcessUrl
-                if (!this.shouldProcessUrl(targetUrl.href, options)) {
+                if (
+                  !this.shouldProcessUrl(targetUrl.href, options, {
+                    internalAllowedFileRoots,
+                  })
+                ) {
                   return null;
                 }
                 return {
                   url: targetUrl.href,
                   depth: item.depth + 1,
+                  ...(internalAllowedFileRoots ? { internalAllowedFileRoots } : {}),
                 } satisfies QueueItem;
               } catch (_error) {
                 // Invalid URL or path
@@ -504,4 +534,26 @@ export abstract class BaseScraperStrategy implements ScraperStrategy {
   async cleanup(): Promise<void> {
     // No-op by default
   }
+}
+
+/**
+ * Returns true if `url` is a `file://` URL whose resolved filesystem path lies
+ * inside one of the supplied internal roots. Used by the queue-time scope
+ * bypass for archive-member URLs so that arbitrary `file://` links injected
+ * into archive content cannot escape the archive sandbox.
+ */
+function isFileUrlInsideRoots(url: string, roots: string[] | undefined): boolean {
+  if (!roots || roots.length === 0) return false;
+  let target: string;
+  try {
+    target = path.resolve(fileUrlToPathLoose(url));
+  } catch {
+    return false;
+  }
+  return roots.some((root) => {
+    const resolvedRoot = path.resolve(root);
+    if (resolvedRoot === target) return true;
+    const relative = path.relative(resolvedRoot, target);
+    return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
+  });
 }

--- a/src/scraper/strategies/LocalFileStrategy.test.ts
+++ b/src/scraper/strategies/LocalFileStrategy.test.ts
@@ -9,7 +9,20 @@ vi.mock("node:fs/promises", () => ({ default: vol.promises }));
 vi.mock("node:fs");
 
 describe("LocalFileStrategy", () => {
-  const appConfig = loadConfig();
+  const appConfig = {
+    ...loadConfig(),
+    scraper: {
+      ...loadConfig().scraper,
+      security: {
+        ...loadConfig().scraper.security,
+        fileAccess: {
+          ...loadConfig().scraper.security.fileAccess,
+          mode: "unrestricted" as const,
+          allowedRoots: [],
+        },
+      },
+    },
+  };
 
   beforeEach(() => {
     vol.reset();

--- a/src/scraper/strategies/LocalFileStrategy.ts
+++ b/src/scraper/strategies/LocalFileStrategy.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { ScraperAccessPolicy } from "../../utils/accessPolicy";
 import { type ArchiveAdapter, getArchiveAdapter } from "../../utils/archive";
 import type { AppConfig } from "../../utils/config";
 import { logger } from "../../utils/logger";
@@ -24,12 +25,15 @@ import { BaseScraperStrategy, type ProcessItemResult } from "./BaseScraperStrate
  * Supports include/exclude filters and percent-encoded paths.
  */
 export class LocalFileStrategy extends BaseScraperStrategy {
-  private readonly fileFetcher = new FileFetcher();
+  private readonly fileFetcher: FileFetcher;
   private readonly pipelines: ContentPipeline[];
+  private readonly accessPolicy: ScraperAccessPolicy;
 
   constructor(config: AppConfig) {
     super(config);
+    this.fileFetcher = new FileFetcher(config.scraper);
     this.pipelines = PipelineFactory.createStandardPipelines(config);
+    this.accessPolicy = new ScraperAccessPolicy(config.scraper.security);
   }
 
   canHandle(url: string): boolean {
@@ -41,14 +45,11 @@ export class LocalFileStrategy extends BaseScraperStrategy {
     options: ScraperOptions,
     _signal?: AbortSignal,
   ): Promise<ProcessItemResult> {
-    // Parse the file URL properly to handle both file:// and file:/// formats
-    let filePath = item.url.replace(/^file:\/\/\/?/, "");
-    filePath = decodeURIComponent(filePath);
-
-    // Ensure absolute path on Unix-like systems (if not already absolute)
-    if (!filePath.startsWith("/") && process.platform !== "win32") {
-      filePath = `/${filePath}`;
-    }
+    const resolvedAccess = await this.accessPolicy.resolveFileAccess(
+      item.url,
+      options.internalAllowedFileRoots,
+    );
+    const filePath = resolvedAccess.filePath;
 
     let stats: Awaited<ReturnType<typeof fs.stat>> | null = null;
     let archivePath: string | null = null;
@@ -84,20 +85,33 @@ export class LocalFileStrategy extends BaseScraperStrategy {
       // Handle physical directory
       if (stats?.isDirectory()) {
         const contents = await fs.readdir(filePath);
+        const visibleContents = this.config.scraper.security.fileAccess.includeHidden
+          ? contents
+          : contents.filter((name) => !name.startsWith("."));
         // Only return links that pass shouldProcessUrl
-        const links = contents
-          .map((name) => {
+        const linkEntries = await Promise.all(
+          visibleContents.map(async (name) => {
+            const entryPath = path.join(filePath, name);
+            if (!this.config.scraper.security.fileAccess.followSymlinks) {
+              const entryStats = await fs.lstat(entryPath).catch(() => null);
+              if (entryStats?.isSymbolicLink()) {
+                return null;
+              }
+            }
+
             // Construct valid file URL using URL class to ensure proper encoding and structure
-            const url = new URL(
-              `file://${path.join(filePath, name).replace(/\\/g, "/")}`,
-            );
+            const url = new URL(`file://${entryPath.replace(/\\/g, "/")}`);
             // Ensure we always have file:/// format (empty host)
             if (url.hostname !== "") {
               url.pathname = `/${url.hostname}${url.pathname}`;
               url.hostname = "";
             }
+
             return url.href;
-          })
+          }),
+        );
+        const links = linkEntries
+          .filter((url): url is string => Boolean(url))
           .filter((url) => {
             const allowed = this.shouldProcessUrl(url, options);
             if (!allowed) {
@@ -107,7 +121,7 @@ export class LocalFileStrategy extends BaseScraperStrategy {
           });
 
         logger.debug(
-          `Found ${links.length} files in ${filePath} (from ${contents.length} entries)`,
+          `Found ${links.length} files in ${filePath} (from ${visibleContents.length} entries)`,
         );
         return { url: item.url, links, status: FetchStatus.SUCCESS };
       }
@@ -138,7 +152,10 @@ export class LocalFileStrategy extends BaseScraperStrategy {
                 virtualUrl.hostname = "";
               }
 
-              if (this.shouldProcessUrl(virtualUrl.href, options)) {
+              if (
+                this.shouldProcessUrl(virtualUrl.href, options) &&
+                this.isVisibleArchiveEntry(entry.path)
+              ) {
                 links.push(virtualUrl.href);
               }
             }
@@ -233,6 +250,17 @@ export class LocalFileStrategy extends BaseScraperStrategy {
       }
     }
     return { archive: null, inner: null, adapter: null };
+  }
+
+  private isVisibleArchiveEntry(entryPath: string): boolean {
+    if (this.config.scraper.security.fileAccess.includeHidden) {
+      return true;
+    }
+
+    return !entryPath
+      .split(/[\\/]+/)
+      .filter(Boolean)
+      .some((segment) => segment.startsWith("."));
   }
 
   private async processArchiveEntry(

--- a/src/scraper/strategies/WebScraperStrategy.test.ts
+++ b/src/scraper/strategies/WebScraperStrategy.test.ts
@@ -2,8 +2,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProgressCallback } from "../../types";
 import { type AppConfig, loadConfig } from "../../utils/config";
 import { FetchStatus } from "../fetcher/types";
-import type { ScrapeResult, ScraperOptions, ScraperProgressEvent } from "../types";
+import type {
+  QueueItem,
+  ScrapeResult,
+  ScraperOptions,
+  ScraperProgressEvent,
+} from "../types";
 import { ScrapeMode } from "../types"; // Import ScrapeMode
+import type { ProcessItemResult } from "./BaseScraperStrategy";
 import { WebScraperStrategy } from "./WebScraperStrategy";
 
 // Mock dependencies
@@ -64,6 +70,98 @@ describe("WebScraperStrategy", () => {
     expect(strategy.canHandle("file:///path/to/file.txt")).toBe(false);
     expect(strategy.canHandle("invalid://example.com")).toBe(false);
     expect(strategy.canHandle("any_string")).toBe(false);
+  }, 10000);
+
+  it("should carry internal archive roots to discovered temp archive members", async () => {
+    const testStrategy = strategy as unknown as {
+      processBatch(
+        batch: QueueItem[],
+        baseUrl: URL,
+        options: ScraperOptions,
+        progressCallback: ProgressCallback<ScraperProgressEvent>,
+        signal?: AbortSignal,
+      ): Promise<QueueItem[]>;
+      processItem(
+        item: QueueItem,
+        options: ScraperOptions,
+        signal?: AbortSignal,
+      ): Promise<ProcessItemResult>;
+      visited: Set<string>;
+      effectiveTotal: number;
+    };
+    testStrategy.visited.add("https://example.com/archive.zip");
+    testStrategy.effectiveTotal = 1;
+
+    const processItemSpy = vi.spyOn(testStrategy, "processItem").mockResolvedValue({
+      url: "https://example.com/archive.zip",
+      links: ["file:///tmp/scraper-docs.zip/guide.md"],
+      internalAllowedFileRoots: ["/tmp/scraper-docs.zip"],
+      status: FetchStatus.SUCCESS,
+    });
+
+    const nextItems = await testStrategy.processBatch(
+      [{ url: "https://example.com/archive.zip", depth: 0 }],
+      new URL("https://example.com/archive.zip"),
+      { ...options, url: "https://example.com/archive.zip" },
+      vi.fn(),
+    );
+
+    expect(nextItems).toEqual([
+      {
+        url: "file:///tmp/scraper-docs.zip/guide.md",
+        depth: 1,
+        internalAllowedFileRoots: ["/tmp/scraper-docs.zip"],
+      },
+    ]);
+
+    processItemSpy.mockRestore();
+  }, 10000);
+
+  it("should reject file:// links that escape the archive's internal roots", async () => {
+    const testStrategy = strategy as unknown as {
+      processBatch(
+        batch: QueueItem[],
+        baseUrl: URL,
+        options: ScraperOptions,
+        progressCallback: ProgressCallback<ScraperProgressEvent>,
+        signal?: AbortSignal,
+      ): Promise<QueueItem[]>;
+      processItem(
+        item: QueueItem,
+        options: ScraperOptions,
+        signal?: AbortSignal,
+      ): Promise<ProcessItemResult>;
+      visited: Set<string>;
+      effectiveTotal: number;
+    };
+    testStrategy.visited.add("https://example.com/archive.zip");
+    testStrategy.effectiveTotal = 1;
+
+    const processItemSpy = vi.spyOn(testStrategy, "processItem").mockResolvedValue({
+      url: "https://example.com/archive.zip",
+      // Hostile link injected in archive content that points outside the
+      // accepted internal archive root. Must NOT be enqueued.
+      links: ["file:///etc/passwd", "file:///tmp/scraper-docs.zip/guide.md"],
+      internalAllowedFileRoots: ["/tmp/scraper-docs.zip"],
+      status: FetchStatus.SUCCESS,
+    });
+
+    const nextItems = await testStrategy.processBatch(
+      [{ url: "https://example.com/archive.zip", depth: 0 }],
+      new URL("https://example.com/archive.zip"),
+      { ...options, url: "https://example.com/archive.zip", scope: "subpages" },
+      vi.fn(),
+    );
+
+    expect(nextItems).toEqual([
+      {
+        url: "file:///tmp/scraper-docs.zip/guide.md",
+        depth: 1,
+        internalAllowedFileRoots: ["/tmp/scraper-docs.zip"],
+      },
+    ]);
+
+    processItemSpy.mockRestore();
   }, 10000);
 
   it("should use HttpFetcher to fetch content and process result", async () => {

--- a/src/scraper/strategies/WebScraperStrategy.ts
+++ b/src/scraper/strategies/WebScraperStrategy.ts
@@ -108,6 +108,9 @@ export class WebScraperStrategy extends BaseScraperStrategy {
         followRedirects: options.followRedirects,
         headers: options.headers, // Forward custom headers
         etag: item.etag, // Pass ETag for conditional requests
+        ...(item.internalAllowedFileRoots
+          ? { internalAllowedFileRoots: item.internalAllowedFileRoots }
+          : {}),
       };
 
       // Use AutoDetectFetcher which handles fallbacks automatically
@@ -263,8 +266,16 @@ export class WebScraperStrategy extends BaseScraperStrategy {
     // Delegate to LocalFileStrategy
     const localUrl = `file://${tempFile}`;
     const localItem = { ...item, url: localUrl };
+    const localOptions = {
+      ...options,
+      internalAllowedFileRoots: [...(options.internalAllowedFileRoots ?? []), tempFile],
+    };
 
-    const result = await this.localFileStrategy.processItem(localItem, options, signal);
+    const result = await this.localFileStrategy.processItem(
+      localItem,
+      localOptions,
+      signal,
+    );
 
     // We need to fix up the links to point back to something meaningful?
     // If we process a zip, we get file:///tmp/.../file.txt
@@ -279,6 +290,8 @@ export class WebScraperStrategy extends BaseScraperStrategy {
     return {
       ...result,
       url: item.url, // Keep original URL as the source of this item
+      links: result.links,
+      internalAllowedFileRoots: [tempFile],
       // links are file://...
     };
   }

--- a/src/scraper/types.ts
+++ b/src/scraper/types.ts
@@ -9,6 +9,8 @@ export type QueueItem = {
   depth: number;
   pageId?: number; // Database page ID for efficient deletion during refresh
   etag?: string | null; // Last known ETag for conditional requests during refresh
+  /** Internal-only allowlist roots for application-managed temporary files. */
+  internalAllowedFileRoots?: string[];
 };
 
 /**
@@ -121,6 +123,10 @@ export interface ScraperOptions {
    * @default true
    */
   clean?: boolean;
+  /**
+   * Internal-only allowlist roots for application-managed temporary files.
+   */
+  internalAllowedFileRoots?: string[];
 }
 
 /**

--- a/src/scraper/utils/patternMatcher.ts
+++ b/src/scraper/utils/patternMatcher.ts
@@ -58,6 +58,23 @@ export function matchesAnyPattern(path: string, patterns?: string[]): boolean {
 }
 
 /**
+ * Matches a flat string (hostname, label, etc.) against patterns without any
+ * path normalization. Patterns use the same syntax as URL patterns: a glob
+ * processed by minimatch, or a regex wrapped in `/.../`. Matching is
+ * case-insensitive, which matches DNS semantics for the hostname use case.
+ */
+export function matchesAnyHostPattern(value: string, patterns?: string[]): boolean {
+  if (!patterns || patterns.length === 0) return false;
+  const normalized = value.toLowerCase();
+  return patterns.some((pattern) => {
+    if (isRegexPattern(pattern)) {
+      return patternToRegExp(pattern).test(value);
+    }
+    return minimatch(normalized, pattern.toLowerCase(), { dot: true });
+  });
+}
+
+/**
  * Extracts the path and query from a URL string (no domain).
  */
 export function extractPathAndQuery(url: string): string {

--- a/src/utils/accessPolicy.test.ts
+++ b/src/utils/accessPolicy.test.ts
@@ -1,0 +1,568 @@
+import { vol } from "memfs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppConfig } from "./config";
+import { defaults as configDefaults } from "./config";
+import { AccessPolicyError } from "./errors";
+
+vi.mock("node:fs/promises", () => ({ default: vol.promises }));
+
+const lookupMock = vi.fn();
+vi.mock("node:dns/promises", () => ({
+  lookup: (...args: Parameters<typeof lookupMock>) => lookupMock(...args),
+}));
+
+import os from "node:os";
+import { expandConfiguredRoot, ScraperAccessPolicy } from "./accessPolicy";
+
+type SecurityOverrides = {
+  network?: Partial<AppConfig["scraper"]["security"]["network"]>;
+  fileAccess?: Partial<AppConfig["scraper"]["security"]["fileAccess"]>;
+};
+
+function createSecurityConfig(
+  overrides: SecurityOverrides = {},
+): AppConfig["scraper"]["security"] {
+  const baseline = configDefaults.scraper.security;
+  return {
+    ...baseline,
+    ...overrides,
+    network: {
+      ...baseline.network,
+      ...overrides.network,
+    },
+    fileAccess: {
+      ...baseline.fileAccess,
+      ...overrides.fileAccess,
+    },
+  };
+}
+
+describe("ScraperAccessPolicy", () => {
+  beforeEach(() => {
+    vol.reset();
+    lookupMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("blocks loopback targets by default", async () => {
+    const policy = new ScraperAccessPolicy(createSecurityConfig());
+
+    await expect(
+      policy.assertNetworkUrlAllowed("http://127.0.0.1/test"),
+    ).rejects.toBeInstanceOf(AccessPolicyError);
+  });
+
+  it("blocks bracketed IPv6 loopback targets by default", async () => {
+    const policy = new ScraperAccessPolicy(createSecurityConfig());
+
+    await expect(
+      policy.assertNetworkUrlAllowed("http://[::1]/test"),
+    ).rejects.toBeInstanceOf(AccessPolicyError);
+  });
+
+  it("allows explicitly allowlisted private hostname targets", async () => {
+    lookupMock.mockResolvedValue([{ address: "10.42.0.10", family: 4 }]);
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        network: {
+          allowedHosts: ["docs.internal.example"],
+        },
+      }),
+    );
+
+    await expect(
+      policy.assertNetworkUrlAllowed("https://docs.internal.example/guide"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("keeps host allowlists hostname-bound", async () => {
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        network: {
+          allowedHosts: ["docs.internal.example"],
+        },
+      }),
+    );
+
+    await expect(
+      policy.assertNetworkUrlAllowed("https://10.42.0.10/guide"),
+    ).rejects.toBeInstanceOf(AccessPolicyError);
+  });
+
+  it("allows explicitly allowlisted CIDR targets", async () => {
+    lookupMock.mockResolvedValue([{ address: "10.42.0.10", family: 4 }]);
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        network: {
+          allowedCidrs: ["10.42.0.0/16"],
+        },
+      }),
+    );
+
+    await expect(
+      policy.assertNetworkUrlAllowed("https://wiki.internal.example/guide"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("enables invalid TLS only for already-allowed https targets", () => {
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        network: {
+          allowInvalidTls: true,
+        },
+      }),
+    );
+
+    expect(policy.shouldAllowInvalidTls("https://docs.internal.example")).toBe(true);
+    expect(policy.shouldAllowInvalidTls("http://docs.internal.example")).toBe(false);
+  });
+
+  it("blocks hidden local paths by default", async () => {
+    vol.fromJSON({
+      "/docs/.hidden/file.md": "secret",
+    });
+
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        fileAccess: {
+          mode: "unrestricted",
+        },
+      }),
+    );
+
+    await expect(
+      policy.resolveFileAccess("file:///docs/.hidden/file.md"),
+    ).rejects.toBeInstanceOf(AccessPolicyError);
+  });
+
+  it("permits access under an allowed root whose path contains a hidden ancestor", async () => {
+    // Configuring `/srv/.config/docs` as an allowed root is an explicit opt-in,
+    // so files inside that root must not be self-rejected by the hidden-segment
+    // check just because `.config` appears in the root's absolute path.
+    vol.fromJSON({
+      "/srv/.config/docs/guide.md": "content",
+    });
+
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        fileAccess: {
+          mode: "allowedRoots",
+          allowedRoots: ["/srv/.config/docs"],
+        },
+      }),
+    );
+
+    const resolved = await policy.resolveFileAccess("file:///srv/.config/docs/guide.md");
+    expect(resolved.accessPath).toBe("/srv/.config/docs/guide.md");
+  });
+
+  it("still blocks hidden segments below the allowed root", async () => {
+    vol.fromJSON({
+      "/srv/.config/docs/.git/HEAD": "ref",
+    });
+
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        fileAccess: {
+          mode: "allowedRoots",
+          allowedRoots: ["/srv/.config/docs"],
+        },
+      }),
+    );
+
+    await expect(
+      policy.resolveFileAccess("file:///srv/.config/docs/.git/HEAD"),
+    ).rejects.toBeInstanceOf(AccessPolicyError);
+  });
+
+  it("blocks symlink access by default", async () => {
+    vol.fromJSON({
+      "/docs/real.md": "content",
+    });
+    await vol.promises.symlink("/docs/real.md", "/docs/link.md");
+
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        fileAccess: {
+          mode: "unrestricted",
+        },
+      }),
+    );
+
+    await expect(policy.resolveFileAccess("file:///docs/link.md")).rejects.toBeInstanceOf(
+      AccessPolicyError,
+    );
+  });
+
+  it("blocks symlinked parent directories by default", async () => {
+    vol.fromJSON({
+      "/outside/secret.md": "secret",
+    });
+    await vol.promises.mkdir("/docs", { recursive: true });
+    await vol.promises.symlink("/outside", "/docs/link");
+
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        fileAccess: {
+          mode: "allowedRoots",
+          allowedRoots: ["/docs"],
+        },
+      }),
+    );
+
+    await expect(
+      policy.resolveFileAccess("file:///docs/link/secret.md"),
+    ).rejects.toBeInstanceOf(AccessPolicyError);
+  });
+
+  it("validates archive members against the backing archive path", async () => {
+    vol.fromJSON({
+      "/allowed/docs.zip": "archive-bytes",
+    });
+
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        fileAccess: {
+          mode: "allowedRoots",
+          allowedRoots: ["/allowed"],
+        },
+      }),
+    );
+
+    const resolved = await policy.resolveFileAccess(
+      "file:///allowed/docs.zip/guide/intro.md",
+    );
+
+    expect(resolved.accessPath).toBe("/allowed/docs.zip");
+    expect(resolved.virtualArchivePath).toBe("guide/intro.md");
+  });
+
+  it("matches host allowlist entries by glob across subdomains", async () => {
+    lookupMock.mockResolvedValue([{ address: "10.42.0.10", family: 4 }]);
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        network: {
+          allowedHosts: ["*.internal.example"],
+        },
+      }),
+    );
+
+    await expect(
+      policy.assertNetworkUrlAllowed("https://docs.internal.example/guide"),
+    ).resolves.toBeUndefined();
+    await expect(
+      policy.assertNetworkUrlAllowed("https://wiki.team.internal.example/page"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not match the bare apex against a leading-wildcard host pattern", async () => {
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        network: {
+          allowedHosts: ["*.internal.example"],
+        },
+      }),
+    );
+
+    lookupMock.mockResolvedValue([{ address: "10.42.0.10", family: 4 }]);
+    await expect(
+      policy.assertNetworkUrlAllowed("https://internal.example/"),
+    ).rejects.toBeInstanceOf(AccessPolicyError);
+  });
+
+  it("supports regex host allowlist entries", async () => {
+    lookupMock.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        network: {
+          allowedHosts: ["/^docs\\d+\\.example\\.com$/"],
+        },
+      }),
+    );
+
+    await expect(
+      policy.assertNetworkUrlAllowed("https://docs42.example.com/path"),
+    ).resolves.toBeUndefined();
+  });
+
+  describe("allowlist mode", () => {
+    it("permits only hostnames that match the allowlist", async () => {
+      // Use a real public IP rather than a special-use sentinel so the
+      // post-resolution rebinding check (which now runs even for allowlisted
+      // hostnames) doesn't reject the request on its own.
+      lookupMock.mockResolvedValue([{ address: "8.8.8.8", family: 4 }]);
+      const policy = new ScraperAccessPolicy(
+        createSecurityConfig({
+          network: {
+            mode: "allowlist",
+            allowedHosts: ["docs.python.org", "*.rust-lang.org"],
+          },
+        }),
+      );
+
+      await expect(
+        policy.assertNetworkUrlAllowed("https://docs.python.org/3/"),
+      ).resolves.toBeUndefined();
+      await expect(
+        policy.assertNetworkUrlAllowed("https://docs.rust-lang.org/std/"),
+      ).resolves.toBeUndefined();
+      await expect(
+        policy.assertNetworkUrlAllowed("https://news.ycombinator.com/"),
+      ).rejects.toBeInstanceOf(AccessPolicyError);
+    });
+
+    it("permits direct IP targets only when inside an allowed CIDR", async () => {
+      const policy = new ScraperAccessPolicy(
+        createSecurityConfig({
+          network: {
+            mode: "allowlist",
+            allowedCidrs: ["10.42.0.0/16"],
+          },
+        }),
+      );
+
+      await expect(
+        policy.assertNetworkUrlAllowed("https://10.42.7.1/"),
+      ).resolves.toBeUndefined();
+      await expect(
+        policy.assertNetworkUrlAllowed("https://10.99.0.1/"),
+      ).rejects.toBeInstanceOf(AccessPolicyError);
+    });
+
+    it("denies everything when both lists are empty", async () => {
+      const policy = new ScraperAccessPolicy(
+        createSecurityConfig({
+          network: { mode: "allowlist" },
+        }),
+      );
+
+      await expect(
+        policy.assertNetworkUrlAllowed("https://example.com/"),
+      ).rejects.toBeInstanceOf(AccessPolicyError);
+    });
+
+    it("ignores allowPrivateNetworks in allowlist mode", async () => {
+      const policy = new ScraperAccessPolicy(
+        createSecurityConfig({
+          network: {
+            mode: "allowlist",
+            allowPrivateNetworks: true,
+          },
+        }),
+      );
+
+      await expect(
+        policy.assertNetworkUrlAllowed("https://10.0.0.1/"),
+      ).rejects.toBeInstanceOf(AccessPolicyError);
+    });
+
+    it("trusts an allowlisted hostname even when DNS resolves it to a private IP", async () => {
+      // `allowedHosts` is authoritative for the named host: adding a hostname
+      // is an explicit trust decision in that name and its DNS answers, so we
+      // do not also require the resolved IP to be in `allowedCidrs`. This
+      // matches `open` mode behavior and lets operators add a single internal
+      // hostname without also pinning its subnet.
+      lookupMock.mockResolvedValue([{ address: "10.42.0.5", family: 4 }]);
+      const policy = new ScraperAccessPolicy(
+        createSecurityConfig({
+          network: {
+            mode: "allowlist",
+            allowedHosts: ["docs.internal.example"],
+          },
+        }),
+      );
+
+      await expect(
+        policy.assertNetworkUrlAllowed("https://docs.internal.example/"),
+      ).resolves.toBeUndefined();
+    });
+
+    it("permits an allowlisted hostname when its resolved IP is covered by allowedCidrs", async () => {
+      lookupMock.mockResolvedValue([{ address: "10.42.0.5", family: 4 }]);
+      const policy = new ScraperAccessPolicy(
+        createSecurityConfig({
+          network: {
+            mode: "allowlist",
+            allowedHosts: ["docs.internal.example"],
+            allowedCidrs: ["10.42.0.0/16"],
+          },
+        }),
+      );
+
+      await expect(
+        policy.assertNetworkUrlAllowed("https://docs.internal.example/"),
+      ).resolves.toBeUndefined();
+    });
+
+    it("rejects CIDR-authorized hostnames when any resolved address falls outside allowedCidrs", async () => {
+      lookupMock.mockResolvedValue([
+        { address: "10.42.0.5", family: 4 },
+        { address: "10.99.0.5", family: 4 },
+      ]);
+      const policy = new ScraperAccessPolicy(
+        createSecurityConfig({
+          network: {
+            mode: "allowlist",
+            allowedCidrs: ["10.42.0.0/16"],
+          },
+        }),
+      );
+
+      await expect(
+        policy.assertNetworkUrlAllowed("https://wiki.internal.example/"),
+      ).rejects.toBeInstanceOf(AccessPolicyError);
+    });
+  });
+
+  describe("invalid-TLS does not bypass network allowlists", () => {
+    it("rejects a private hostname even when allowInvalidTls is true", async () => {
+      lookupMock.mockResolvedValue([{ address: "10.42.0.10", family: 4 }]);
+      const policy = new ScraperAccessPolicy(
+        createSecurityConfig({
+          network: { allowInvalidTls: true },
+        }),
+      );
+
+      await expect(
+        policy.assertNetworkUrlAllowed("https://docs.internal.example/"),
+      ).rejects.toBeInstanceOf(AccessPolicyError);
+    });
+
+    it("rejects a non-allowlisted host in allowlist mode even when allowInvalidTls is true", async () => {
+      const policy = new ScraperAccessPolicy(
+        createSecurityConfig({
+          network: {
+            mode: "allowlist",
+            allowedHosts: ["docs.python.org"],
+            allowInvalidTls: true,
+          },
+        }),
+      );
+
+      await expect(
+        policy.assertNetworkUrlAllowed("https://example.com/"),
+      ).rejects.toBeInstanceOf(AccessPolicyError);
+    });
+  });
+});
+
+describe("temp-archive bypass scoping", () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("permits a downloaded archive temp file when its dir is supplied as a bypass root", async () => {
+    vol.fromJSON({ "/tmp/dl/docs.zip": "archive-bytes" });
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        fileAccess: { mode: "allowedRoots", allowedRoots: ["/docs"] },
+      }),
+    );
+
+    const resolved = await policy.resolveFileAccess(
+      "file:///tmp/dl/docs.zip/guide/intro.md",
+      ["/tmp/dl"],
+    );
+
+    expect(resolved.accessPath).toBe("/tmp/dl/docs.zip");
+    expect(resolved.virtualArchivePath).toBe("guide/intro.md");
+  });
+
+  it("rejects unrelated temp files even when a temp bypass root is configured for an archive", async () => {
+    vol.fromJSON({
+      "/tmp/dl/docs.zip": "archive-bytes",
+      "/tmp/other/secret.md": "secret",
+    });
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        fileAccess: { mode: "allowedRoots", allowedRoots: ["/docs"] },
+      }),
+    );
+
+    await expect(
+      policy.resolveFileAccess("file:///tmp/other/secret.md", ["/tmp/dl"]),
+    ).rejects.toBeInstanceOf(AccessPolicyError);
+  });
+
+  it("rejects archive virtual members whose entry path crosses into a hidden segment", async () => {
+    vol.fromJSON({ "/tmp/dl/docs.zip": "archive-bytes" });
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        fileAccess: { mode: "allowedRoots", allowedRoots: ["/docs"] },
+      }),
+    );
+
+    await expect(
+      policy.resolveFileAccess("file:///tmp/dl/docs.zip/.hidden/notes.md", ["/tmp/dl"]),
+    ).rejects.toBeInstanceOf(AccessPolicyError);
+  });
+});
+
+describe("expandConfiguredRoot", () => {
+  const realCwd = process.cwd();
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vol.reset();
+  });
+
+  it("returns null when $DOCUMENTS cannot be resolved", async () => {
+    vi.spyOn(os, "homedir").mockReturnValue("/missing-home");
+    const result = await expandConfiguredRoot("$DOCUMENTS");
+    expect(result).toBeNull();
+  });
+
+  it("resolves $DOCUMENTS when the directory exists", async () => {
+    vi.spyOn(os, "homedir").mockReturnValue("/home/tester");
+    vol.fromJSON({
+      "/home/tester/Documents/readme.md": "hello",
+    });
+
+    const result = await expandConfiguredRoot("$DOCUMENTS");
+    expect(result).toBe("/home/tester/Documents");
+  });
+
+  it("resolves $HOME without requiring the directory to exist on the mock fs", async () => {
+    vi.spyOn(os, "homedir").mockReturnValue("/home/tester");
+    const result = await expandConfiguredRoot("$HOME");
+    expect(result).toBe("/home/tester");
+  });
+
+  it("returns null for $HOME when homedir is empty", async () => {
+    vi.spyOn(os, "homedir").mockReturnValue("");
+    const result = await expandConfiguredRoot("$HOME");
+    expect(result).toBeNull();
+  });
+
+  it("resolves $DOWNLOADS to <home>/Downloads when present", async () => {
+    vi.spyOn(os, "homedir").mockReturnValue("/home/tester");
+    vol.fromJSON({ "/home/tester/Downloads/x.txt": "" });
+    const result = await expandConfiguredRoot("$DOWNLOADS");
+    expect(result).toBe("/home/tester/Downloads");
+  });
+
+  it("resolves $DESKTOP to <home>/Desktop when present", async () => {
+    vi.spyOn(os, "homedir").mockReturnValue("/home/tester");
+    vol.fromJSON({ "/home/tester/Desktop/x.txt": "" });
+    const result = await expandConfiguredRoot("$DESKTOP");
+    expect(result).toBe("/home/tester/Desktop");
+  });
+
+  it("returns null for $DOWNLOADS when the directory is missing", async () => {
+    vi.spyOn(os, "homedir").mockReturnValue("/home/tester");
+    const result = await expandConfiguredRoot("$DOWNLOADS");
+    expect(result).toBeNull();
+  });
+
+  it("resolves $CWD to the process working directory", async () => {
+    const result = await expandConfiguredRoot("$CWD");
+    expect(result).toBe(realCwd);
+  });
+});

--- a/src/utils/accessPolicy.ts
+++ b/src/utils/accessPolicy.ts
@@ -1,0 +1,480 @@
+import { lookup } from "node:dns/promises";
+import fs from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { matchesAnyHostPattern } from "../scraper/utils/patternMatcher";
+import type { AppConfig } from "./config";
+import { AccessPolicyError } from "./errors";
+
+const SPECIAL_USE_IPV4_CIDRS = [
+  "0.0.0.0/8",
+  "10.0.0.0/8",
+  "100.64.0.0/10",
+  "127.0.0.0/8",
+  "169.254.0.0/16",
+  "172.16.0.0/12",
+  "192.0.0.0/24",
+  "192.0.2.0/24",
+  "192.168.0.0/16",
+  "198.18.0.0/15",
+  "198.51.100.0/24",
+  "203.0.113.0/24",
+  "224.0.0.0/4",
+  "240.0.0.0/4",
+];
+
+const SPECIAL_USE_IPV6_CIDRS = ["::/128", "::1/128", "fc00::/7", "fe80::/10", "ff00::/8"];
+
+const ARCHIVE_EXTENSIONS = new Set([".zip", ".tar", ".gz", ".tgz"]);
+
+type ScraperSecurityConfig = AppConfig["scraper"]["security"];
+
+export interface ResolvedFileAccess {
+  filePath: string;
+  accessPath: string;
+  virtualArchivePath: string | null;
+}
+
+/**
+ * Shared access policy for outbound network and local file access.
+ */
+export class ScraperAccessPolicy {
+  private readonly allowedCidrs = new net.BlockList();
+  private readonly specialUseCidrs = new net.BlockList();
+  private readonly allowedHosts: string[];
+
+  constructor(private readonly security: ScraperSecurityConfig) {
+    this.allowedHosts = security.network.allowedHosts;
+
+    for (const cidr of security.network.allowedCidrs) {
+      this.addCidr(this.allowedCidrs, cidr);
+    }
+
+    for (const cidr of SPECIAL_USE_IPV4_CIDRS) {
+      this.addCidr(this.specialUseCidrs, cidr);
+    }
+    for (const cidr of SPECIAL_USE_IPV6_CIDRS) {
+      this.addCidr(this.specialUseCidrs, cidr);
+    }
+  }
+
+  /**
+   * Checks whether a network URL is allowed before connecting.
+   */
+  async assertNetworkUrlAllowed(url: string): Promise<void> {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return;
+    }
+
+    const hostname = normalizeHostname(parsed.hostname);
+    const ipFamily = net.isIP(hostname);
+
+    if (this.security.network.mode === "allowlist") {
+      // Allowlist mode: a request is permitted iff its hostname matches a
+      // configured host pattern OR every resolved IP for the hostname is
+      // inside `allowedCidrs`. `allowPrivateNetworks` is intentionally ignored
+      // here because the explicit allowlist is the complete authorization
+      // surface.
+      //
+      // A hostname listed in `allowedHosts` is authoritative for that name:
+      // we trust its DNS answers, even when they resolve to private or
+      // special-use addresses. This mirrors `open` mode and matches the
+      // documented mental model — adding a host to `allowedHosts` is the
+      // explicit trust decision. Operators who want a strictly address-bound
+      // policy can leave `allowedHosts` empty and use `allowedCidrs` only.
+      if (ipFamily !== 0) {
+        const family = ipFamily === 6 ? "ipv6" : "ipv4";
+        if (this.allowedCidrs.check(hostname, family)) return;
+        throw new AccessPolicyError(`Security policy blocked network access to ${url}`);
+      }
+
+      if (matchesAnyHostPattern(hostname, this.allowedHosts)) {
+        return;
+      }
+
+      const addresses = await resolveAddresses(hostname);
+      const allAllowedByCidr =
+        addresses.length > 0 &&
+        addresses.every((address) => {
+          const family = net.isIP(address.address);
+          if (family === 0) return false;
+          return this.allowedCidrs.check(address.address, family === 6 ? "ipv6" : "ipv4");
+        });
+      if (allAllowedByCidr) return;
+
+      throw new AccessPolicyError(`Security policy blocked network access to ${url}`);
+    }
+
+    // Open mode: public targets are allowed; private/special-use targets are
+    // blocked unless explicitly opened up.
+    if (this.security.network.allowPrivateNetworks) {
+      return;
+    }
+
+    if (ipFamily !== 0) {
+      this.assertSpecialUseAddressAllowed(hostname, url);
+      return;
+    }
+
+    if (looksLikeIpLiteral(hostname)) {
+      throw new AccessPolicyError(`Security policy blocked network access to ${url}`);
+    }
+
+    if (matchesAnyHostPattern(hostname, this.allowedHosts)) {
+      return;
+    }
+
+    const addresses = await resolveAddresses(hostname);
+    for (const address of addresses) {
+      this.assertSpecialUseAddressAllowed(address.address, url);
+    }
+  }
+
+  /**
+   * Checks whether TLS certificate validation may be bypassed for a URL.
+   */
+  shouldAllowInvalidTls(url: string): boolean {
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === "https:" && this.security.network.allowInvalidTls;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Resolves and validates a file URL against the configured file access policy.
+   */
+  async resolveFileAccess(
+    url: string,
+    additionalAllowedRoots: string[] = [],
+  ): Promise<ResolvedFileAccess> {
+    const filePath = fileUrlToPathLoose(url);
+    const resolved = await resolveArchiveAwarePath(filePath);
+    const accessPath = resolved.archivePath ?? filePath;
+    const bypassRoots = await this.expandRoots(additionalAllowedRoots);
+    const matchedBypassRoot = await this.findContainingRoot(
+      accessPath,
+      bypassRoots,
+      false,
+    );
+
+    let matchedRoot: string | null = matchedBypassRoot;
+
+    if (this.security.fileAccess.mode === "disabled" && !matchedBypassRoot) {
+      throw new AccessPolicyError(`Security policy blocked local file access for ${url}`);
+    }
+
+    if (this.security.fileAccess.mode === "allowedRoots" && !matchedBypassRoot) {
+      const configuredRoots = await this.expandRoots(
+        this.security.fileAccess.allowedRoots,
+      );
+      if (configuredRoots.length === 0) {
+        throw new AccessPolicyError(
+          `Security policy blocked local file access for ${url}`,
+        );
+      }
+
+      matchedRoot = await this.findContainingRoot(
+        accessPath,
+        configuredRoots,
+        this.security.fileAccess.followSymlinks,
+      );
+      if (!matchedRoot) {
+        throw new AccessPolicyError(
+          `Security policy blocked local file access for ${url}`,
+        );
+      }
+    }
+
+    if (!this.security.fileAccess.followSymlinks && !matchedBypassRoot) {
+      const symlinkPath = await findSymlinkInPath(accessPath);
+      if (symlinkPath) {
+        throw new AccessPolicyError(`Security policy blocked symlink access for ${url}`);
+      }
+    }
+
+    if (!this.security.fileAccess.includeHidden) {
+      // Hidden-segment checks apply to segments strictly below the matched
+      // allowed root. Segments at-or-above the root are part of the user's
+      // explicit opt-in: a configured root like `/Users/x/.config/docs` is
+      // expected to live under a hidden ancestor and must not be self-rejected.
+      // In `unrestricted` mode with no specific match, fall back to checking
+      // the full absolute path.
+      if (hasHiddenSegmentBelowRoot(filePath, matchedRoot)) {
+        throw new AccessPolicyError(
+          `Security policy blocked hidden file access for ${url}`,
+        );
+      }
+      if (
+        resolved.virtualArchivePath &&
+        hasHiddenArchiveSegment(resolved.virtualArchivePath)
+      ) {
+        throw new AccessPolicyError(
+          `Security policy blocked hidden archive entry access for ${url}`,
+        );
+      }
+    }
+
+    return {
+      filePath,
+      accessPath,
+      virtualArchivePath: resolved.virtualArchivePath,
+    };
+  }
+
+  /**
+   * Throws if `address` falls inside a blocked special-use range and is not
+   * explicitly permitted by `allowedCidrs`. Used both for direct-IP targets
+   * and for revalidating DNS-resolved addresses (open mode) and allowlisted
+   * hostnames (allowlist mode, to close DNS-rebinding gaps).
+   */
+  private assertSpecialUseAddressAllowed(address: string, url: string): void {
+    const family = net.isIP(address);
+    if (family === 0) {
+      return;
+    }
+
+    const type = family === 6 ? "ipv6" : "ipv4";
+    if (!this.specialUseCidrs.check(address, type)) {
+      return;
+    }
+
+    if (this.allowedCidrs.check(address, type)) {
+      return;
+    }
+
+    throw new AccessPolicyError(`Security policy blocked network access to ${url}`);
+  }
+
+  private addCidr(blockList: net.BlockList, cidr: string): void {
+    const [network, prefix] = cidr.split("/");
+    const family = net.isIP(network);
+    if (family === 0 || prefix === undefined) {
+      return;
+    }
+    blockList.addSubnet(
+      network,
+      Number.parseInt(prefix, 10),
+      family === 6 ? "ipv6" : "ipv4",
+    );
+  }
+
+  private async expandRoots(roots: string[]): Promise<string[]> {
+    const expanded: string[] = [];
+    for (const root of roots) {
+      const value = await expandConfiguredRoot(root);
+      if (value) {
+        expanded.push(value);
+      }
+    }
+    return expanded;
+  }
+
+  private async findContainingRoot(
+    accessPath: string,
+    roots: string[],
+    followSymlinks: boolean,
+  ): Promise<string | null> {
+    const resolvedAccessPath = await resolveContainmentPath(accessPath, followSymlinks);
+    for (const root of roots) {
+      const resolvedRoot = await resolveContainmentPath(root, followSymlinks);
+      if (pathContains(resolvedRoot, resolvedAccessPath)) {
+        return resolvedRoot;
+      }
+    }
+    return null;
+  }
+}
+
+async function resolveAddresses(
+  hostname: string,
+): Promise<Array<{ address: string; family: number }>> {
+  try {
+    const result = await lookup(hostname, { all: true, verbatim: true });
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.toLowerCase().replace(/^\[(.*)]$/, "$1");
+}
+
+function looksLikeIpLiteral(hostname: string): boolean {
+  return hostname.includes(":") || /^\d+(?:\.\d+){0,3}$/.test(hostname);
+}
+
+async function findSymlinkInPath(targetPath: string): Promise<string | null> {
+  const resolved = path.resolve(targetPath);
+  const root = path.parse(resolved).root;
+  const relative = path.relative(root, resolved);
+  const segments = relative.split(path.sep).filter(Boolean);
+  let current = root;
+
+  for (const segment of segments) {
+    current = path.join(current, segment);
+    const stats = await fs.lstat(current).catch(() => null);
+    if (stats?.isSymbolicLink()) {
+      return current;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Converts a file URL into a local filesystem path while preserving legacy leniency.
+ */
+export function fileUrlToPathLoose(url: string): string {
+  let filePath = url.replace(/^file:\/\/\/?/, "");
+  filePath = decodeURIComponent(filePath);
+
+  if (!filePath.startsWith("/") && process.platform !== "win32") {
+    filePath = `/${filePath}`;
+  }
+
+  return filePath;
+}
+
+const USER_DIR_TOKENS: Record<string, string> = {
+  $DOCUMENTS: "Documents",
+  $DOWNLOADS: "Downloads",
+  $DESKTOP: "Desktop",
+};
+
+/**
+ * Expands user-facing configured root tokens into concrete filesystem paths.
+ *
+ * Supported tokens:
+ * - `$HOME`     — the user's home directory (broad; grants access to dotfiles).
+ * - `$DOCUMENTS`, `$DOWNLOADS`, `$DESKTOP` — standard user folders. Resolve to
+ *   `<home>/<Folder>` if that directory exists, otherwise null so the token
+ *   denies rather than silently granting an unexpected path.
+ * - `$CWD`      — the process's current working directory. Useful for CLI use.
+ *
+ * Any other value is treated as a literal filesystem path and absolute-resolved.
+ * Returning `null` means the token could not be resolved on this platform or
+ * account and therefore grants no access by itself.
+ */
+export async function expandConfiguredRoot(root: string): Promise<string | null> {
+  if (root === "$HOME") {
+    const homeDir = os.homedir();
+    return homeDir ? path.resolve(homeDir) : null;
+  }
+
+  if (root === "$CWD") {
+    return path.resolve(process.cwd());
+  }
+
+  const subdir = USER_DIR_TOKENS[root];
+  if (subdir !== undefined) {
+    const homeDir = os.homedir();
+    if (!homeDir) {
+      return null;
+    }
+    const candidate = path.join(homeDir, subdir);
+    const stats = await fs.stat(candidate).catch(() => null);
+    if (!stats?.isDirectory()) {
+      return null;
+    }
+    return path.resolve(candidate);
+  }
+
+  return path.resolve(root);
+}
+
+async function resolveArchiveAwarePath(filePath: string): Promise<{
+  archivePath: string | null;
+  virtualArchivePath: string | null;
+}> {
+  let currentPath = filePath;
+  while (
+    currentPath !== "/" &&
+    currentPath !== "." &&
+    path.dirname(currentPath) !== currentPath
+  ) {
+    const stats = await fs.lstat(currentPath).catch(() => null);
+    if (stats?.isFile() && looksLikeArchivePath(currentPath)) {
+      const virtualArchivePath = filePath
+        .substring(currentPath.length)
+        .replace(/^\/+/, "")
+        .replace(/^\\+/, "");
+      return {
+        archivePath: currentPath,
+        virtualArchivePath: virtualArchivePath || null,
+      };
+    }
+    if (stats) {
+      return { archivePath: null, virtualArchivePath: null };
+    }
+    currentPath = path.dirname(currentPath);
+  }
+
+  return { archivePath: null, virtualArchivePath: null };
+}
+
+async function resolveContainmentPath(
+  targetPath: string,
+  followSymlinks: boolean,
+): Promise<string> {
+  if (!followSymlinks) {
+    return path.resolve(targetPath);
+  }
+
+  return fs.realpath(targetPath).catch(() => path.resolve(targetPath));
+}
+
+function looksLikeArchivePath(filePath: string): boolean {
+  return ARCHIVE_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+function pathContains(root: string, candidate: string): boolean {
+  if (root === candidate) {
+    return true;
+  }
+
+  const relative = path.relative(root, candidate);
+  return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+/**
+ * Returns true if any path segment strictly below `matchedRoot` starts with a
+ * dot. When `matchedRoot` is null (e.g. `unrestricted` mode with no explicit
+ * containing root), the entire absolute path is checked. The matched root
+ * itself is treated as opt-in and never contributes to the hidden check, so
+ * configuring an allowed root like `/Users/x/.config/docs` does not
+ * self-reject because its absolute path contains `.config`.
+ */
+function hasHiddenSegmentBelowRoot(
+  targetPath: string,
+  matchedRoot: string | null,
+): boolean {
+  const resolved = path.resolve(targetPath);
+  let segments: string[];
+  if (matchedRoot) {
+    const resolvedRoot = path.resolve(matchedRoot);
+    if (resolved === resolvedRoot) return false;
+    const relative = path.relative(resolvedRoot, resolved);
+    if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+      // Target is outside the matched root — fall back to the strict check
+      // to remain defensive.
+      segments = resolved.split(path.sep).filter(Boolean);
+    } else {
+      segments = relative.split(path.sep).filter(Boolean);
+    }
+  } else {
+    segments = resolved.split(path.sep).filter(Boolean);
+  }
+  return segments.some((segment) => segment.startsWith("."));
+}
+
+function hasHiddenArchiveSegment(archivePath: string): boolean {
+  return archivePath
+    .split(/[\\/]+/)
+    .filter(Boolean)
+    .some((segment) => segment.startsWith("."));
+}

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { expandConfiguredRoot } from "./accessPolicy";
 import {
   camelToUpperSnake,
   collectLeafPaths,
@@ -244,6 +245,12 @@ describe("Environment Variable Helpers", () => {
     it("converts path with camelCase segments", () => {
       expect(pathToEnvVar(["splitter", "json", "maxNestingDepth"])).toBe(
         "DOCS_MCP_SPLITTER_JSON_MAX_NESTING_DEPTH",
+      );
+    });
+
+    it("converts nested security path", () => {
+      expect(pathToEnvVar(["scraper", "security", "fileAccess", "followSymlinks"])).toBe(
+        "DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_FOLLOW_SYMLINKS",
       );
     });
   });
@@ -514,5 +521,110 @@ describe("Auto-generated Environment Variable Overrides", () => {
     expect(() =>
       loadConfig({}, { configPath: path.join(tmpDir, "dim-neg.yaml") }),
     ).toThrow();
+  });
+
+  it("loads scraper security defaults", () => {
+    const config = loadConfig(
+      {},
+      { configPath: path.join(tmpDir, "security-defaults.yaml") },
+    );
+
+    expect(config.scraper.security.network.allowPrivateNetworks).toBe(false);
+    expect(config.scraper.security.network.allowedHosts).toEqual([]);
+    expect(config.scraper.security.network.allowedCidrs).toEqual([]);
+    expect(config.scraper.security.network.allowInvalidTls).toBe(false);
+    expect(config.scraper.security.fileAccess.mode).toBe("allowedRoots");
+    expect(config.scraper.security.fileAccess.allowedRoots).toEqual(["$DOCUMENTS"]);
+    expect(config.scraper.security.fileAccess.followSymlinks).toBe(false);
+    expect(config.scraper.security.fileAccess.includeHidden).toBe(false);
+  });
+
+  it("applies nested security env overrides", () => {
+    process.env.DOCS_MCP_SCRAPER_SECURITY_NETWORK_ALLOW_INVALID_TLS = "true";
+    process.env.DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_FOLLOW_SYMLINKS = "true";
+    process.env.DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_INCLUDE_HIDDEN = "true";
+
+    const config = loadConfig({}, { configPath: path.join(tmpDir, "security-env.yaml") });
+
+    expect(config.scraper.security.network.allowInvalidTls).toBe(true);
+    expect(config.scraper.security.fileAccess.followSymlinks).toBe(true);
+    expect(config.scraper.security.fileAccess.includeHidden).toBe(true);
+  });
+
+  it("parses security arrays from env", () => {
+    process.env.DOCS_MCP_SCRAPER_SECURITY_NETWORK_ALLOWED_HOSTS =
+      '["docs.internal.example","wiki.corp.local"]';
+    process.env.DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_ALLOWED_ROOTS =
+      '["$DOCUMENTS", "/srv/docs"]';
+
+    const config = loadConfig(
+      {},
+      { configPath: path.join(tmpDir, "security-arrays.yaml") },
+    );
+
+    expect(config.scraper.security.network.allowedHosts).toEqual([
+      "docs.internal.example",
+      "wiki.corp.local",
+    ]);
+    expect(config.scraper.security.fileAccess.allowedRoots).toEqual([
+      "$DOCUMENTS",
+      "/srv/docs",
+    ]);
+  });
+
+  it("recovers in-memory from a structurally invalid explicit config without touching the file", () => {
+    // Read-only mode (explicit `configPath`): we still return a valid config
+    // built from defaults rather than throwing, but we must not rewrite or
+    // move the user's file because they passed it deliberately.
+    const configPath = path.join(tmpDir, "invalid-shape.yaml");
+    const original = [
+      "scraper:",
+      "  security:",
+      "    network:",
+      "      allowedHosts: {}",
+      "      allowedCidrs: {}",
+      "    fileAccess:",
+      '      allowedRoots: { "0": "$DOCUMENTS" }',
+      "",
+    ].join("\n");
+    fs.writeFileSync(configPath, original);
+
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const config = loadConfig({}, { configPath });
+
+    expect(Array.isArray(config.scraper.security.network.allowedHosts)).toBe(true);
+    expect(Array.isArray(config.scraper.security.fileAccess.allowedRoots)).toBe(true);
+    // File contents preserved exactly in read-only mode.
+    expect(fs.readFileSync(configPath, "utf8")).toBe(original);
+    // No quarantine file in read-only mode either.
+    const quarantined = fs
+      .readdirSync(tmpDir)
+      .filter((name) => name.startsWith("invalid-shape.yaml.invalid-"));
+    expect(quarantined.length).toBe(0);
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("invalid shape"));
+    warnSpy.mockRestore();
+  });
+
+  it("preserves array-valued defaults across a saved-then-reloaded config", () => {
+    // Regression: deepMerge used to recurse into arrays as if they were
+    // objects, producing `{}` when an array default merged with the same
+    // array shape read back from the saved YAML file.
+    const configPath = path.join(tmpDir, "roundtrip.yaml");
+    loadConfig({}, { configPath });
+    const second = loadConfig({}, { configPath });
+
+    expect(Array.isArray(second.scraper.security.network.allowedHosts)).toBe(true);
+    expect(Array.isArray(second.scraper.security.network.allowedCidrs)).toBe(true);
+    expect(Array.isArray(second.scraper.security.fileAccess.allowedRoots)).toBe(true);
+    expect(second.scraper.security.fileAccess.allowedRoots).toEqual(["$DOCUMENTS"]);
+  });
+
+  it("treats unresolved $DOCUMENTS as no access", async () => {
+    const homedirSpy = vi.spyOn(os, "homedir").mockReturnValue("/missing-home");
+
+    await expect(expandConfiguredRoot("$DOCUMENTS")).resolves.toBeNull();
+
+    homedirSpy.mockRestore();
   });
 });

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -6,6 +6,22 @@ import { z } from "zod";
 import { normalizeEnvValue } from "./env";
 import { logger } from "./logger";
 
+const envStringArray = z
+  .union([z.array(z.string()), z.string()])
+  .transform((value) => {
+    if (Array.isArray(value)) {
+      return value;
+    }
+
+    const parsed = yaml.parse(value);
+    if (Array.isArray(parsed)) {
+      return parsed.map((item) => String(item));
+    }
+
+    return [value];
+  })
+  .pipe(z.array(z.string()));
+
 /**
  * Custom zod schema for boolean values that properly handles string representations.
  * Unlike z.coerce.boolean() which treats any non-empty string as true,
@@ -67,6 +83,21 @@ export const DEFAULT_CONFIG = {
     },
     document: {
       maxSize: 10 * 1024 * 1024, // 10MB max size for PDF/Office documents
+    },
+    security: {
+      network: {
+        mode: "open",
+        allowPrivateNetworks: false,
+        allowedHosts: [] as string[],
+        allowedCidrs: [] as string[],
+        allowInvalidTls: false,
+      },
+      fileAccess: {
+        mode: "allowedRoots",
+        allowedRoots: ["$DOCUMENTS"] as string[],
+        followSymlinks: false,
+        includeHidden: false,
+      },
     },
   },
   splitter: {
@@ -191,6 +222,45 @@ export const AppConfigSchema = z.object({
             .default(DEFAULT_CONFIG.scraper.document.maxSize),
         })
         .default(DEFAULT_CONFIG.scraper.document),
+      security: z
+        .object({
+          network: z
+            .object({
+              mode: z
+                .enum(["open", "allowlist"])
+                .default(DEFAULT_CONFIG.scraper.security.network.mode),
+              allowPrivateNetworks: envBoolean.default(
+                DEFAULT_CONFIG.scraper.security.network.allowPrivateNetworks,
+              ),
+              allowedHosts: envStringArray.default(
+                DEFAULT_CONFIG.scraper.security.network.allowedHosts,
+              ),
+              allowedCidrs: envStringArray.default(
+                DEFAULT_CONFIG.scraper.security.network.allowedCidrs,
+              ),
+              allowInvalidTls: envBoolean.default(
+                DEFAULT_CONFIG.scraper.security.network.allowInvalidTls,
+              ),
+            })
+            .default(DEFAULT_CONFIG.scraper.security.network),
+          fileAccess: z
+            .object({
+              mode: z
+                .enum(["disabled", "allowedRoots", "unrestricted"])
+                .default(DEFAULT_CONFIG.scraper.security.fileAccess.mode),
+              allowedRoots: envStringArray.default(
+                DEFAULT_CONFIG.scraper.security.fileAccess.allowedRoots,
+              ),
+              followSymlinks: envBoolean.default(
+                DEFAULT_CONFIG.scraper.security.fileAccess.followSymlinks,
+              ),
+              includeHidden: envBoolean.default(
+                DEFAULT_CONFIG.scraper.security.fileAccess.includeHidden,
+              ),
+            })
+            .default(DEFAULT_CONFIG.scraper.security.fileAccess),
+        })
+        .default(DEFAULT_CONFIG.scraper.security),
     })
     .default(DEFAULT_CONFIG.scraper),
   splitter: z
@@ -416,7 +486,52 @@ export function loadConfig(
     setAtPath(mergedInput, ["app", "embeddingModel"], "text-embedding-3-small");
   }
 
-  return AppConfigSchema.parse(mergedInput);
+  const parseResult = AppConfigSchema.safeParse(mergedInput);
+  if (parseResult.success) {
+    return parseResult.data;
+  }
+
+  // The file on disk is structurally wrong (e.g., array fields saved as
+  // objects by a prior buggy version, or a hand-edit with a typo). Rather
+  // than refusing to start, fall back to env-and-CLI-on-defaults and replace
+  // the corrupted file so the next load is clean. The original file is moved
+  // aside to `<configPath>.invalid-<timestamp>` so hand-edits aren't lost.
+  if (!isReadOnlyConfig && fs.existsSync(configPath)) {
+    const quarantinePath = `${configPath}.invalid-${Date.now()}`;
+    try {
+      fs.renameSync(configPath, quarantinePath);
+      logger.warn(
+        `Configuration file has invalid shape and was moved to ${quarantinePath}; resetting to defaults. Reason: ${parseResult.error.message}`,
+      );
+    } catch (renameError) {
+      logger.warn(
+        `Configuration file has invalid shape; resetting to defaults (could not quarantine original: ${renameError}). Reason: ${parseResult.error.message}`,
+      );
+    }
+  } else {
+    logger.warn(
+      `Configuration file has invalid shape; resetting to defaults. Reason: ${parseResult.error.message}`,
+    );
+  }
+  const fallbackInput = deepMerge(
+    defaults,
+    deepMerge(envConfig, cliConfig),
+  ) as ConfigObject;
+  if (
+    !getAtPath(fallbackInput, ["app", "embeddingModel"]) &&
+    process.env.OPENAI_API_KEY
+  ) {
+    setAtPath(fallbackInput, ["app", "embeddingModel"], "text-embedding-3-small");
+  }
+  const fallback = AppConfigSchema.parse(fallbackInput);
+  if (!isReadOnlyConfig) {
+    try {
+      saveConfigFile(configPath, fallback as unknown as ConfigObject);
+    } catch (error) {
+      logger.warn(`Failed to write fresh config file ${configPath}: ${error}`);
+    }
+  }
+  return fallback;
 }
 
 function loadConfigFile(filePath: string): Record<string, unknown> | null {
@@ -560,6 +675,11 @@ function getAtPath(obj: ConfigObject, pathArr: string[]): unknown {
 function deepMerge(target: unknown, source: unknown): unknown {
   if (typeof target !== "object" || target === null) return source;
   if (typeof source !== "object" || source === null) return target;
+  // Arrays are scalars from a merge standpoint: source replaces target entirely.
+  // Recursing into arrays would either splice into a wrong shape (spreading an
+  // array into a plain object) or silently union by index, neither of which
+  // matches user expectations for list-shaped config values.
+  if (Array.isArray(target) || Array.isArray(source)) return source;
 
   const t = target as ConfigObject;
   const s = source as ConfigObject;
@@ -572,8 +692,10 @@ function deepMerge(target: unknown, source: unknown): unknown {
     if (
       typeof sValue === "object" &&
       sValue !== null &&
+      !Array.isArray(sValue) &&
       typeof tValue === "object" &&
       tValue !== null &&
+      !Array.isArray(tValue) &&
       key in t
     ) {
       output[key] = deepMerge(tValue, sValue);

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -60,7 +60,14 @@ class TlsCertificateError extends ScraperError {
   }
 }
 
+class AccessPolicyError extends ScraperError {
+  constructor(message: string) {
+    super(message, false);
+  }
+}
+
 export {
+  AccessPolicyError,
   ChallengeError,
   InvalidUrlError,
   RedirectError,

--- a/test/archive-integration.test.ts
+++ b/test/archive-integration.test.ts
@@ -39,6 +39,21 @@ describe("LocalFileStrategy - Archive Integration", () => {
         document: {
             maxSize: 1024 * 1024,
         },
+        security: {
+          network: {
+            mode: "open",
+            allowPrivateNetworks: false,
+            allowedHosts: [],
+            allowedCidrs: [],
+            allowInvalidTls: false,
+          },
+          fileAccess: {
+            mode: "unrestricted",
+            allowedRoots: [],
+            followSymlinks: true,
+            includeHidden: true,
+          },
+        },
       },
       splitter: {
           maxChunkSize: 1000,

--- a/test/local-file-pdf-e2e.test.ts
+++ b/test/local-file-pdf-e2e.test.ts
@@ -65,6 +65,14 @@ describe("LocalFileStrategy - PDF in mounted directory (issue #394)", () => {
 
   it("indexes a PDF sitting next to .txt/.md in a directory served via file://", async () => {
     const appConfig = loadConfig();
+    // This test points at an OS temp directory that lives outside the default
+    // `$DOCUMENTS` allowed root. The new scraper security policy would block
+    // it unless we widen the allowed roots to include this run's tmpDir.
+    // On macOS, `/var/folders/...` is itself reached via a symlinked ancestor
+    // (`/var` → `/private/var`), so we also need to permit symlink traversal
+    // for the policy to read fixture files.
+    appConfig.scraper.security.fileAccess.allowedRoots = [tmpDir];
+    appConfig.scraper.security.fileAccess.followSymlinks = true;
     const strategy = new LocalFileStrategy(appConfig);
 
     const dirUrl = `file://${tmpDir}`;

--- a/test/refresh-pipeline-e2e.test.ts
+++ b/test/refresh-pipeline-e2e.test.ts
@@ -39,6 +39,13 @@ describe("Refresh Pipeline E2E Tests", () => {
     appConfig = loadConfig();
     appConfig.app.storePath = ":memory:";
     appConfig.app.embeddingModel = ""; // disable embeddings for refresh e2e
+    // Tests mock the network with nock and the filesystem with memfs at
+    // virtual paths like /test-docs. Loosen scraper security so the test
+    // doesn't have to thread those paths through the policy machinery.
+    appConfig.scraper.security.fileAccess.mode = "unrestricted";
+    appConfig.scraper.security.fileAccess.includeHidden = true;
+    appConfig.scraper.security.fileAccess.followSymlinks = true;
+    appConfig.scraper.security.network.allowPrivateNetworks = true;
     // Initialize in-memory store and services
     // DocumentManagementService creates its own DocumentStore internally
     const eventBus = new EventBusService();
@@ -771,6 +778,78 @@ describe("Refresh Pipeline E2E Tests", () => {
         10,
       );
       expect(search.length).toBeGreaterThan(0);
+    }, 30000);
+  });
+
+  describe("Network access policy (allowlist mode)", () => {
+    const ALLOWED_HOST = "docs.allowed.example";
+    const BLOCKED_HOST = "evil.blocked.example";
+    const ALLOWED_BASE = `http://${ALLOWED_HOST}`;
+    const BLOCKED_BASE = `http://${BLOCKED_HOST}`;
+
+    beforeEach(() => {
+      // Stop the open-mode pipeline that the outer beforeEach started so we
+      // can swap in an allowlist-mode config for this group of tests.
+      // (PipelineManager is recreated by the inner setup below.)
+      appConfig.scraper.security.network.mode = "allowlist";
+      appConfig.scraper.security.network.allowedHosts = [ALLOWED_HOST];
+      appConfig.scraper.security.network.allowedCidrs = [];
+      appConfig.scraper.security.network.allowPrivateNetworks = false;
+    });
+
+    it("scrapes allowlisted hosts and rejects non-allowlisted hosts end-to-end", async () => {
+      nock(ALLOWED_BASE)
+        .get("/")
+        .reply(200, "<html><body><h1>Allowed</h1></body></html>", {
+          "Content-Type": "text/html",
+        });
+
+      const allowedJobId = await pipelineManager.enqueueScrapeJob(
+        "allow-lib",
+        "1.0.0",
+        {
+          url: `${ALLOWED_BASE}/`,
+          library: "allow-lib",
+          version: "1.0.0",
+          maxPages: 1,
+          maxDepth: 0,
+        } satisfies ScraperOptions,
+      );
+      await pipelineManager.waitForJobCompletion(allowedJobId);
+
+      const allowedPages = await docService.getPagesByVersionId(
+        await docService.ensureVersion({ library: "allow-lib", version: "1.0.0" }),
+      );
+      expect(allowedPages.length).toBe(1);
+
+      // The blocked host must never receive a request — set up an
+      // interceptor that would be consumed if the request leaked through.
+      const blockedInterceptor = nock(BLOCKED_BASE).get("/").reply(200, "should-not-fire");
+
+      const blockedJobId = await pipelineManager.enqueueScrapeJob(
+        "block-lib",
+        "1.0.0",
+        {
+          url: `${BLOCKED_BASE}/`,
+          library: "block-lib",
+          version: "1.0.0",
+          maxPages: 1,
+          maxDepth: 0,
+        } satisfies ScraperOptions,
+      );
+      // The job is expected to fail with an AccessPolicyError; surface it as
+      // a job failure rather than letting it bubble out of the test.
+      await pipelineManager.waitForJobCompletion(blockedJobId).catch(() => {});
+
+      // No pages indexed for the blocked host.
+      const blockedPages = await docService.getPagesByVersionId(
+        await docService.ensureVersion({ library: "block-lib", version: "1.0.0" }),
+      );
+      expect(blockedPages.length).toBe(0);
+
+      // The blocked interceptor must not have been consumed.
+      expect(blockedInterceptor.isDone()).toBe(false);
+      nock.cleanAll();
     }, 30000);
   });
 });

--- a/test/vector-persistence-e2e.test.ts
+++ b/test/vector-persistence-e2e.test.ts
@@ -50,6 +50,14 @@ describe("Vector persistence", () => {
     appConfig.app.storePath = tempDir;
     appConfig.app.embeddingModel = embeddingConfig.modelSpec;
 
+    // The test scrapes a real file under process.cwd(), which in CI/worktree
+    // setups can live under a hidden segment (e.g. `.claude/worktrees/...`).
+    // Loosen the local file policy for this e2e test so the path itself does
+    // not become the thing under test.
+    appConfig.scraper.security.fileAccess.mode = "unrestricted";
+    appConfig.scraper.security.fileAccess.includeHidden = true;
+    appConfig.scraper.security.fileAccess.followSymlinks = true;
+
     const eventBus = new EventBusService();
     docService = await createLocalDocumentManagement(eventBus, appConfig);
 


### PR DESCRIPTION
## Summary
- add shared network and file access policy enforcement across HTTP fetches, browser rendering, and local file scraping
- introduce secure scraper security defaults with explicit host, CIDR, and allowed-root overrides plus archive temp-file handling
- document the trust model and add focused config, policy, and browser tests for the new access controls

## Verification
- created focused tests for config parsing, shared access policy behavior, and browser fetch enforcement
- local command execution in this environment still cannot fully run `vitest` or `tsc` because `vitest/config` and `vite/client` resolution is broken here