### PR TITLE
fix(scraper): support hash-routed spa crawling (#379)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ For agents and scripts, the CLI is usually the simplest way to use Grounded Docs
 npx @arabold/docs-mcp-server@latest scrape react https://react.dev/reference/react
 ```
 
+For hash-routed SPA docs sites, enable hash preservation explicitly:
+
+```bash
+npx @arabold/docs-mcp-server@latest scrape my-spa https://docs.example.com/#/guide --preserve-hashes
+```
+
 **2. Query the index:**
 
 ```bash
@@ -97,6 +103,9 @@ npx @arabold/docs-mcp-server@latest
 
 See **[Connecting Clients](docs/guides/mcp-clients.md)** for VS Code (Cline, Roo) and other setup options.
 
+`scrape_docs` also accepts `preserveHashes: true` for documentation sites that use hash-based client-side routing.
+Use it only for hash-routed SPAs; normal sites typically use hash fragments for in-page anchors.
+
 <details>
 <summary>Alternative: Run with Docker</summary>
 
@@ -134,6 +143,11 @@ See **[Embedding Models](docs/guides/embedding-models.md)** for configuring **Ol
 -   **[Configuration](docs/setup/configuration.md)**: Full reference for config files and environment variables.
 -   **[Supported Formats](docs/concepts/supported-formats.md)**: Complete file format and MIME type reference.
 -   **[Embedding Models](docs/guides/embedding-models.md)**: Configure OpenAI, Ollama, Gemini, and other providers.
+
+### Hash-Routed SPAs
+-   Use `--preserve-hashes`, MCP `preserveHashes`, or the Web UI "Preserve Hash Routes" checkbox only for docs sites that route with URLs like `#/guide`.
+-   When enabled with `scrapeMode=fetch`, the scraper automatically upgrades the job to Playwright because plain fetch cannot evaluate client-side hash routes.
+-   Refresh reuses the stored `preserveHashes` setting by default, and CLI/Web refresh entrypoints can override it explicitly.
 
 ### Key Concepts & Architecture
 -   **[Deployment Modes](docs/infrastructure/deployment-modes.md)**: Standalone vs. Distributed (Docker Compose).

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -21,6 +21,7 @@ app:
 scraper:
   maxPages: 1000
   maxDepth: 3
+  preserveHashes: false
   document:
     maxSize: 10485760  # 10MB
 
@@ -166,6 +167,7 @@ Settings controlling the web scraping behavior.
 | `maxPages` | `1000` | Maximum number of pages to crawl per job. |
 | `maxDepth` | `3` | Maximum link depth to traverse. |
 | `maxConcurrency` | `3` | Number of concurrent page fetches. |
+| `preserveHashes` | `false` | Preserve hash fragments as page identity for hash-routed SPA docs sites. |
 | `pageTimeoutMs` | `5000` | Timeout for a single page load (ms). |
 | `browserTimeoutMs` | `30000` | Timeout for the browser instance (ms). |
 | `fetcher.maxRetries` | `6` | Number of retries for failed requests. |
@@ -173,6 +175,18 @@ Settings controlling the web scraping behavior.
 | `document.maxSize` | `10485760` | Maximum size (bytes) for PDF/Office documents. |
 
 _Note: Scraper settings are often overridden per-job via CLI arguments like `--max-pages`._
+
+Use `scraper.preserveHashes` only for documentation sites that use hash-based SPA routes such as `https://docs.example.com/#/guide`.
+Leave it disabled for normal sites, where hashes usually point to anchors within the same page.
+
+### Hash Route Behavior
+
+- CLI scrape: use `--preserve-hashes` to enable hash-aware crawling for a job.
+- CLI refresh: use `--preserve-hashes` to override the stored setting for that refresh job.
+- MCP: `scrape_docs` accepts `preserveHashes: true`.
+- Web UI: the scrape form includes a "Preserve Hash Routes" checkbox, and refresh reuses the stored setting.
+- Refresh: stored scraper options retain `preserveHashes` and reuse it by default.
+- Rendering: if `preserveHashes` is enabled and `scrapeMode` is `fetch`, the job is upgraded to `playwright` automatically.
 
 > **Migration Note:** In versions prior to 1.37, `document.maxSize` was a top-level setting. It has been moved to `scraper.document.maxSize`. Update your config files accordingly.
 

--- a/openspec/changes/support-hash-routed-spas/.openspec.yaml
+++ b/openspec/changes/support-hash-routed-spas/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-29

--- a/openspec/changes/support-hash-routed-spas/design.md
+++ b/openspec/changes/support-hash-routed-spas/design.md
@@ -10,6 +10,7 @@ Attempting to "guess" whether a site is a hash-routed SPA is unpredictable and r
 - Provide a CLI flag (`--preserve-hashes`) and config option (`preserveHashes`) to disable hash stripping.
 - Ensure URLs with hashes are treated as distinct documents in the database and crawler queue when the flag is enabled.
 - Ensure `HtmlPlaywrightMiddleware` correctly intercepts and serves the initial page shell, even when the requested URL contains a hash fragment.
+- Expose the `preserveHashes` setting in the Web UI for both adding and refreshing libraries.
 - Validate that `preserveHashes` is only used with a compatible scrape mode (`playwright` or `auto`), since pure `fetch` cannot execute client-side routing.
 
 **Non-Goals:**
@@ -31,6 +32,10 @@ Attempting to "guess" whether a site is a hash-routed SPA is unpredictable and r
 3. **Scrape Mode Enforcement**:
    - *Decision*: If `preserveHashes` is enabled and `scrapeMode` is explicitly set to `fetch`, the scraper should either throw a validation error or automatically upgrade the mode to `playwright`.
    - *Rationale*: A pure HTTP fetch cannot resolve a hash route (the server just returns the empty SPA shell). Playwright is required to boot the SPA and allow the client-side router to render the content for the specific hash.
+
+4. **Web UI Integration**:
+   - *Decision*: Expose a checkbox for "Preserve Hash Routes" in the Web UI.
+   - *Rationale*: Users must be able to specify this option without resorting to the CLI. The checkbox state will be passed via the form submission to the API endpoints and onto the pipeline.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/support-hash-routed-spas/design.md
+++ b/openspec/changes/support-hash-routed-spas/design.md
@@ -1,0 +1,40 @@
+## Context
+
+Currently, the crawler's `normalizeUrl` utility removes URL hash fragments by default. This is correct for 99% of web crawling scenarios, as hashes usually indicate jump links (anchors) within the same page. However, for Single Page Applications (SPAs) that use hash-based routing (e.g., `docs.xyops.io/#Docs/api`), this behavior causes all internal links to collapse into the root URL, resulting in only the main shell being indexed.
+
+Attempting to "guess" whether a site is a hash-routed SPA is unpredictable and risky. Therefore, an explicit opt-in mechanism is required to preserve hashes during crawling.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a CLI flag (`--preserve-hashes`) and config option (`preserveHashes`) to disable hash stripping.
+- Ensure URLs with hashes are treated as distinct documents in the database and crawler queue when the flag is enabled.
+- Ensure `HtmlPlaywrightMiddleware` correctly intercepts and serves the initial page shell, even when the requested URL contains a hash fragment.
+- Validate that `preserveHashes` is only used with a compatible scrape mode (`playwright` or `auto`), since pure `fetch` cannot execute client-side routing.
+
+**Non-Goals:**
+- Automatically detecting hash-routed SPAs.
+- Changing the default behavior of `normalizeUrl`.
+- Supporting hash routing in `fetch` scrape mode.
+
+## Decisions
+
+1. **Explicit Opt-in Flag (`preserveHashes`)**:
+   - *Decision*: Add a `preserveHashes` boolean to `ScraperOptions` and the CLI.
+   - *Rationale*: Safe, predictable, and doesn't break the vast majority of sites that use traditional anchor links.
+   - *Alternative Considered*: "Auto" detection based on DOM analysis or URL patterns (e.g., `#/`). Rejected because heuristics are brittle and often lead to false positives (indexing duplicate pages for normal anchor links).
+
+2. **Middleware Interception Fix**:
+   - *Decision*: In `HtmlPlaywrightMiddleware`, when checking if `reqUrl === context.source` for the initial page fulfill, strip the hash from `context.source` before comparison.
+   - *Rationale*: Browsers (and thus Playwright's network stack) do not send hash fragments to the server. If `context.source` is `http://site/#/route`, the `reqUrl` intercepted by Playwright will be `http://site/`. We must compare the origin + pathname + search components to successfully fulfill the initial document request.
+
+3. **Scrape Mode Enforcement**:
+   - *Decision*: If `preserveHashes` is enabled and `scrapeMode` is explicitly set to `fetch`, the scraper should either throw a validation error or automatically upgrade the mode to `playwright`.
+   - *Rationale*: A pure HTTP fetch cannot resolve a hash route (the server just returns the empty SPA shell). Playwright is required to boot the SPA and allow the client-side router to render the content for the specific hash.
+
+## Risks / Trade-offs
+
+- **[Risk] User Confusion**: Users might enable `--preserve-hashes` on a traditional site, causing every anchor link to be indexed as a separate duplicate page.
+  - *Mitigation*: Clearly document that this flag is exclusively for hash-routed SPAs.
+- **[Risk] Playwright Interception Mismatch**: The updated URL comparison in `HtmlPlaywrightMiddleware` might inadvertently fulfill sub-resource requests if not scoped correctly.
+  - *Mitigation*: Use strict URL parsing (e.g., `new URL(context.source)`) to ensure only the exact base path of the initial document is fulfilled from the pre-fetched content.

--- a/openspec/changes/support-hash-routed-spas/design.md
+++ b/openspec/changes/support-hash-routed-spas/design.md
@@ -8,6 +8,7 @@ Attempting to "guess" whether a site is a hash-routed SPA is unpredictable and r
 
 **Goals:**
 - Provide a CLI flag (`--preserve-hashes`) and config option (`preserveHashes`) to disable hash stripping.
+- Expose the same option consistently through MCP `scrape_docs` so external clients can request hash-routed scraping.
 - Ensure URLs with hashes are treated as distinct documents in the database and crawler queue when the flag is enabled.
 - Ensure `HtmlPlaywrightMiddleware` correctly intercepts and serves the initial page shell, even when the requested URL contains a hash fragment.
 - Expose the `preserveHashes` setting in the Web UI for both adding and refreshing libraries.
@@ -21,7 +22,7 @@ Attempting to "guess" whether a site is a hash-routed SPA is unpredictable and r
 ## Decisions
 
 1. **Explicit Opt-in Flag (`preserveHashes`)**:
-   - *Decision*: Add a `preserveHashes` boolean to `ScraperOptions` and the CLI.
+   - *Decision*: Add a `preserveHashes` boolean to `ScraperOptions` and expose it through every user-facing scrape entrypoint: CLI, Web UI, and MCP `scrape_docs`.
    - *Rationale*: Safe, predictable, and doesn't break the vast majority of sites that use traditional anchor links.
    - *Alternative Considered*: "Auto" detection based on DOM analysis or URL patterns (e.g., `#/`). Rejected because heuristics are brittle and often lead to false positives (indexing duplicate pages for normal anchor links).
 
@@ -37,9 +38,15 @@ Attempting to "guess" whether a site is a hash-routed SPA is unpredictable and r
    - *Decision*: Expose a checkbox for "Preserve Hash Routes" in the Web UI.
    - *Rationale*: Users must be able to specify this option without resorting to the CLI. The checkbox state will be passed via the form submission to the API endpoints and onto the pipeline.
 
+5. **MCP Tool Integration**:
+   - *Decision*: Add `preserveHashes` to the MCP `scrape_docs` input schema and pass it through `ScrapeTool` into the pipeline job options.
+   - *Rationale*: MCP is a first-class public scraping interface. Omitting the option there would make the feature inconsistent and unavailable to automated clients that do not use the CLI or Web UI.
+
 ## Risks / Trade-offs
 
 - **[Risk] User Confusion**: Users might enable `--preserve-hashes` on a traditional site, causing every anchor link to be indexed as a separate duplicate page.
   - *Mitigation*: Clearly document that this flag is exclusively for hash-routed SPAs.
 - **[Risk] Playwright Interception Mismatch**: The updated URL comparison in `HtmlPlaywrightMiddleware` might inadvertently fulfill sub-resource requests if not scoped correctly.
   - *Mitigation*: Use strict URL parsing (e.g., `new URL(context.source)`) to ensure only the exact base path of the initial document is fulfilled from the pre-fetched content.
+- **[Risk] Entry-point Drift**: One user-facing surface could expose different behavior or defaults than another.
+  - *Mitigation*: Treat `preserveHashes` as a shared `ScraperOptions` field, add propagation tests for CLI, Web UI, and MCP, and document the same behavior in all interfaces.

--- a/openspec/changes/support-hash-routed-spas/design.md
+++ b/openspec/changes/support-hash-routed-spas/design.md
@@ -12,7 +12,8 @@ Attempting to "guess" whether a site is a hash-routed SPA is unpredictable and r
 - Ensure URLs with hashes are treated as distinct documents in the database and crawler queue when the flag is enabled.
 - Ensure `HtmlPlaywrightMiddleware` correctly intercepts and serves the initial page shell, even when the requested URL contains a hash fragment.
 - Expose the `preserveHashes` setting in the Web UI for both adding and refreshing libraries.
-- Validate that `preserveHashes` is only used with a compatible scrape mode (`playwright` or `auto`), since pure `fetch` cannot execute client-side routing.
+- Ensure refresh jobs persist and reuse `preserveHashes`, while still allowing users to override stored scraper options through supported entrypoints.
+- Enforce one consistent runtime behavior when `preserveHashes` is combined with `scrapeMode=fetch`, since pure `fetch` cannot execute client-side routing.
 
 **Non-Goals:**
 - Automatically detecting hash-routed SPAs.
@@ -30,15 +31,23 @@ Attempting to "guess" whether a site is a hash-routed SPA is unpredictable and r
    - *Decision*: In `HtmlPlaywrightMiddleware`, when checking if `reqUrl === context.source` for the initial page fulfill, strip the hash from `context.source` before comparison.
    - *Rationale*: Browsers (and thus Playwright's network stack) do not send hash fragments to the server. If `context.source` is `http://site/#/route`, the `reqUrl` intercepted by Playwright will be `http://site/`. We must compare the origin + pathname + search components to successfully fulfill the initial document request.
 
-3. **Scrape Mode Enforcement**:
-   - *Decision*: If `preserveHashes` is enabled and `scrapeMode` is explicitly set to `fetch`, the scraper should either throw a validation error or automatically upgrade the mode to `playwright`.
-   - *Rationale*: A pure HTTP fetch cannot resolve a hash route (the server just returns the empty SPA shell). Playwright is required to boot the SPA and allow the client-side router to render the content for the specific hash.
+3. **Crawl Identity in Base Strategy**:
+   - *Decision*: Apply `preserveHashes` to the shared crawl identity layer in `BaseScraperStrategy`, where root URL normalization, `visited` deduplication, and refresh `initialQueue` handling occur.
+   - *Rationale*: `WebScraperStrategy.processItem()` is too late for queue identity. Preserving hashes only there would still allow `#/a` and `#/b` to collapse before processing.
 
-4. **Web UI Integration**:
+4. **Scrape Mode Enforcement**:
+   - *Decision*: If `preserveHashes` is enabled and `scrapeMode` is explicitly set to `fetch`, the system SHALL upgrade the job to `playwright` and log a warning consistently across CLI, Web UI, and MCP entrypoints.
+   - *Rationale*: A pure HTTP fetch cannot resolve a hash route (the server just returns the empty SPA shell). Silent no-op behavior or entrypoint-specific validation errors would make the feature inconsistent.
+
+5. **Refresh Propagation**:
+   - *Decision*: Treat `preserveHashes` as stored scraper state for a version and ensure refresh jobs reuse it by default, while allowing explicit refresh entrypoints to override and persist the setting when changed.
+   - *Rationale*: Refresh currently rebuilds jobs from stored scraper options. Without explicitly carrying `preserveHashes` through that path, a refresh toggle would be documented but ineffective.
+
+6. **Web UI Integration**:
    - *Decision*: Expose a checkbox for "Preserve Hash Routes" in the Web UI.
-   - *Rationale*: Users must be able to specify this option without resorting to the CLI. The checkbox state will be passed via the form submission to the API endpoints and onto the pipeline.
+   - *Rationale*: Users must be able to specify this option without resorting to the CLI. The checkbox state will be passed via the form submission to the API endpoints and onto the pipeline for both scrape and refresh flows.
 
-5. **MCP Tool Integration**:
+7. **MCP Tool Integration**:
    - *Decision*: Add `preserveHashes` to the MCP `scrape_docs` input schema and pass it through `ScrapeTool` into the pipeline job options.
    - *Rationale*: MCP is a first-class public scraping interface. Omitting the option there would make the feature inconsistent and unavailable to automated clients that do not use the CLI or Web UI.
 
@@ -50,3 +59,5 @@ Attempting to "guess" whether a site is a hash-routed SPA is unpredictable and r
   - *Mitigation*: Use strict URL parsing (e.g., `new URL(context.source)`) to ensure only the exact base path of the initial document is fulfilled from the pre-fetched content.
 - **[Risk] Entry-point Drift**: One user-facing surface could expose different behavior or defaults than another.
   - *Mitigation*: Treat `preserveHashes` as a shared `ScraperOptions` field, add propagation tests for CLI, Web UI, and MCP, and document the same behavior in all interfaces.
+- **[Risk] Refresh Drift**: A version could be scraped with preserved hashes but later refreshed without them, collapsing previously distinct pages.
+  - *Mitigation*: Persist `preserveHashes` in stored scraper options, reuse it for refresh jobs, and add explicit override tests for refresh entrypoints.

--- a/openspec/changes/support-hash-routed-spas/proposal.md
+++ b/openspec/changes/support-hash-routed-spas/proposal.md
@@ -6,10 +6,11 @@ Currently, when scraping hash-routed Single Page Applications (SPAs) like `docs.
 
 - Add a new explicit configuration option (e.g., `--preserve-hashes` via CLI, `preserveHashes` in scraper config, and a `preserveHashes` field in MCP `scrape_docs`) to disable hash stripping during URL normalization for web crawling.
 - When enabled, `normalizeUrl` within the web scraping strategy will retain URL hash fragments, treating them as distinct crawler identities.
-- Enforce or strongly warn that the `playwright` (or `auto`) scrape mode must be used when preserving hashes, as the `fetch` mode cannot evaluate client-side hash routes.
+- Require `preserveHashes` to run with `playwright`-compatible scraping by upgrading `scrapeMode=fetch` to `playwright` in a consistent way across CLI, Web UI, and MCP.
 - Update `HtmlPlaywrightMiddleware` to correctly handle page interception when hash fragments are present in the source URL, ensuring the SPA can boot up and navigate to the requested hash route.
 - Expose the `preserveHashes` option in the Web UI so users can enable it when adding or refreshing a library via the browser.
 - Expose the `preserveHashes` option through the MCP `scrape_docs` tool so non-CLI clients can request hash-routed SPA crawling as well.
+- Ensure refresh operations persist and reuse the `preserveHashes` setting so re-indexing an existing version behaves the same as the original scrape unless the user explicitly changes it.
 
 ## Capabilities
 
@@ -23,6 +24,7 @@ Currently, when scraping hash-routed Single Page Applications (SPAs) like `docs.
 
 - **CLI/Config/MCP**: Introduces a new `--preserve-hashes` argument to scraper commands, a `preserveHashes` boolean property to the internal scraper configuration, and a matching field on the MCP `scrape_docs` tool.
 - **WebScraperStrategy**: Updates how URL normalization is invoked, explicitly passing `removeHash: false` when the feature is enabled.
+- **BaseScraperStrategy**: Updates crawl queue identity and visited-set deduplication so preserved hashes affect discovery, queuing, and refresh initial queues.
 - **HtmlPlaywrightMiddleware**: Updates request interception logic (`reqUrl === context.source`) to account for browsers stripping hash fragments from network requests.
 - **Web UI**: Updates the add and refresh library components and their respective route handlers to expose and process the new toggle.
 - **Documentation**: Requires updates to `README.md` and configuration docs explaining how to index hash-routed SPAs.

--- a/openspec/changes/support-hash-routed-spas/proposal.md
+++ b/openspec/changes/support-hash-routed-spas/proposal.md
@@ -4,11 +4,12 @@ Currently, when scraping hash-routed Single Page Applications (SPAs) like `docs.
 
 ## What Changes
 
-- Add a new explicit configuration option (e.g., `--preserve-hashes` via CLI or `preserveHashes` in scraper config) to disable hash stripping during URL normalization for web crawling.
+- Add a new explicit configuration option (e.g., `--preserve-hashes` via CLI, `preserveHashes` in scraper config, and a `preserveHashes` field in MCP `scrape_docs`) to disable hash stripping during URL normalization for web crawling.
 - When enabled, `normalizeUrl` within the web scraping strategy will retain URL hash fragments, treating them as distinct crawler identities.
 - Enforce or strongly warn that the `playwright` (or `auto`) scrape mode must be used when preserving hashes, as the `fetch` mode cannot evaluate client-side hash routes.
 - Update `HtmlPlaywrightMiddleware` to correctly handle page interception when hash fragments are present in the source URL, ensuring the SPA can boot up and navigate to the requested hash route.
 - Expose the `preserveHashes` option in the Web UI so users can enable it when adding or refreshing a library via the browser.
+- Expose the `preserveHashes` option through the MCP `scrape_docs` tool so non-CLI clients can request hash-routed SPA crawling as well.
 
 ## Capabilities
 
@@ -20,7 +21,7 @@ Currently, when scraping hash-routed Single Page Applications (SPAs) like `docs.
 
 ## Impact
 
-- **CLI/Config**: Introduces a new `--preserve-hashes` argument to scraper commands and a `preserveHashes` boolean property to the internal scraper configuration.
+- **CLI/Config/MCP**: Introduces a new `--preserve-hashes` argument to scraper commands, a `preserveHashes` boolean property to the internal scraper configuration, and a matching field on the MCP `scrape_docs` tool.
 - **WebScraperStrategy**: Updates how URL normalization is invoked, explicitly passing `removeHash: false` when the feature is enabled.
 - **HtmlPlaywrightMiddleware**: Updates request interception logic (`reqUrl === context.source`) to account for browsers stripping hash fragments from network requests.
 - **Web UI**: Updates the add and refresh library components and their respective route handlers to expose and process the new toggle.

--- a/openspec/changes/support-hash-routed-spas/proposal.md
+++ b/openspec/changes/support-hash-routed-spas/proposal.md
@@ -8,6 +8,7 @@ Currently, when scraping hash-routed Single Page Applications (SPAs) like `docs.
 - When enabled, `normalizeUrl` within the web scraping strategy will retain URL hash fragments, treating them as distinct crawler identities.
 - Enforce or strongly warn that the `playwright` (or `auto`) scrape mode must be used when preserving hashes, as the `fetch` mode cannot evaluate client-side hash routes.
 - Update `HtmlPlaywrightMiddleware` to correctly handle page interception when hash fragments are present in the source URL, ensuring the SPA can boot up and navigate to the requested hash route.
+- Expose the `preserveHashes` option in the Web UI so users can enable it when adding or refreshing a library via the browser.
 
 ## Capabilities
 
@@ -22,5 +23,6 @@ Currently, when scraping hash-routed Single Page Applications (SPAs) like `docs.
 - **CLI/Config**: Introduces a new `--preserve-hashes` argument to scraper commands and a `preserveHashes` boolean property to the internal scraper configuration.
 - **WebScraperStrategy**: Updates how URL normalization is invoked, explicitly passing `removeHash: false` when the feature is enabled.
 - **HtmlPlaywrightMiddleware**: Updates request interception logic (`reqUrl === context.source`) to account for browsers stripping hash fragments from network requests.
+- **Web UI**: Updates the add and refresh library components and their respective route handlers to expose and process the new toggle.
 - **Documentation**: Requires updates to `README.md` and configuration docs explaining how to index hash-routed SPAs.
 - **Backwards Compatibility**: No impact on default behavior. Traditional sites and existing crawls remain unaffected.

--- a/openspec/changes/support-hash-routed-spas/proposal.md
+++ b/openspec/changes/support-hash-routed-spas/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Currently, when scraping hash-routed Single Page Applications (SPAs) like `docs.xyops.io`, the scraper collapses all internal documentation pages into a single root page. This occurs because the `normalizeUrl` utility aggressively strips hash fragments by default, which is correct for traditional websites with anchor links but breaks navigation discovery for hash-routed SPAs. To support indexing these SPAs without relying on unpredictable heuristics or breaking existing behavior for traditional sites, we need an explicit, predictable opt-in mechanism to preserve hash routes during crawling.
+
+## What Changes
+
+- Add a new explicit configuration option (e.g., `--preserve-hashes` via CLI or `preserveHashes` in scraper config) to disable hash stripping during URL normalization for web crawling.
+- When enabled, `normalizeUrl` within the web scraping strategy will retain URL hash fragments, treating them as distinct crawler identities.
+- Enforce or strongly warn that the `playwright` (or `auto`) scrape mode must be used when preserving hashes, as the `fetch` mode cannot evaluate client-side hash routes.
+- Update `HtmlPlaywrightMiddleware` to correctly handle page interception when hash fragments are present in the source URL, ensuring the SPA can boot up and navigate to the requested hash route.
+
+## Capabilities
+
+### New Capabilities
+- `hash-routed-spa-support`: Explicit configuration and middleware handling to accurately crawl, deduplicate, and render hash-routed Single Page Applications.
+
+### Modified Capabilities
+- (None)
+
+## Impact
+
+- **CLI/Config**: Introduces a new `--preserve-hashes` argument to scraper commands and a `preserveHashes` boolean property to the internal scraper configuration.
+- **WebScraperStrategy**: Updates how URL normalization is invoked, explicitly passing `removeHash: false` when the feature is enabled.
+- **HtmlPlaywrightMiddleware**: Updates request interception logic (`reqUrl === context.source`) to account for browsers stripping hash fragments from network requests.
+- **Documentation**: Requires updates to `README.md` and configuration docs explaining how to index hash-routed SPAs.
+- **Backwards Compatibility**: No impact on default behavior. Traditional sites and existing crawls remain unaffected.

--- a/openspec/changes/support-hash-routed-spas/specs/hash-routed-spa-support/spec.md
+++ b/openspec/changes/support-hash-routed-spas/specs/hash-routed-spa-support/spec.md
@@ -12,11 +12,11 @@ The system SHALL provide a configuration option and CLI flag (`--preserve-hashes
 - **THEN** the MCP tool SHALL pass `preserveHashes: true` through to the scraping pipeline as part of the `ScraperOptions`
 
 ### Requirement: Playwright Rendering for Hash Routes
-The system SHALL enforce the use of `playwright` (or `auto`, which falls back to Playwright) as the `scrapeMode` when `preserveHashes` is enabled, because the `fetch` mode cannot evaluate client-side hash routing.
+The system SHALL enforce the use of `playwright` rendering when `preserveHashes` is enabled, because the `fetch` mode cannot evaluate client-side hash routing.
 
 #### Scenario: User attempts to use fetch mode with preserve hashes
 - **WHEN** `preserveHashes` is true AND `scrapeMode` is explicitly set to `fetch`
-- **THEN** the system SHALL throw a configuration validation error or automatically upgrade the mode to `playwright`, logging a warning to the user
+- **THEN** the system SHALL upgrade the effective scrape mode to `playwright` and SHALL log a warning that `fetch` mode is incompatible with preserved hash routes
 
 ### Requirement: Accurate Page Interception in Playwright
 When `preserveHashes` is enabled and Playwright intercepts the initial page load, it SHALL fulfill the request using the pre-fetched content, successfully matching the `reqUrl` (which lacks the hash fragment due to browser networking rules) against the base path of the original `context.source`.
@@ -24,6 +24,17 @@ When `preserveHashes` is enabled and Playwright intercepts the initial page load
 #### Scenario: Playwright intercepts a hash-routed URL
 - **WHEN** `HtmlPlaywrightMiddleware` intercepts a request for a URL that originally contained a hash (e.g., `http://example.com/#/docs`)
 - **THEN** it SHALL successfully fulfill the `http://example.com/` request with the pre-fetched content, allowing the SPA to boot and the client-side router to evaluate the `#/docs` fragment
+
+### Requirement: Hash-Aware Crawl Identity
+When `preserveHashes` is enabled, the system SHALL preserve hash fragments in crawl identity at the queue and deduplication layer so that hash-routed pages are discovered, queued, refreshed, and stored as distinct pages.
+
+#### Scenario: Distinct hash routes are queued separately
+- **WHEN** the crawler discovers `https://example.com/#/guide` and `https://example.com/#/api` during the same job with `preserveHashes` enabled
+- **THEN** the queue and `visited` deduplication logic SHALL treat them as distinct URLs and SHALL process both pages
+
+#### Scenario: Refresh preserves existing hash-routed pages
+- **WHEN** a version was originally scraped with `preserveHashes: true` and a refresh job is enqueued without changing that option
+- **THEN** the refresh job SHALL reuse the stored `preserveHashes: true` setting and SHALL rebuild its `initialQueue` without collapsing stored hash-routed page URLs
 
 ### Requirement: Web UI Configuration
 The system SHALL expose the `preserveHashes` option in the Web UI, allowing users to explicitly enable it when adding a new library or refreshing an existing one.

--- a/openspec/changes/support-hash-routed-spas/specs/hash-routed-spa-support/spec.md
+++ b/openspec/changes/support-hash-routed-spas/specs/hash-routed-spa-support/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Explicit Hash Route Preservation
+The system SHALL provide a configuration option and CLI flag (`--preserve-hashes` / `preserveHashes`) to disable the stripping of hash fragments from URLs during web crawling. This allows Single Page Applications (SPAs) that utilize hash-based client-side routing to be correctly identified, queued, and indexed as distinct pages.
+
+#### Scenario: User enables hash preservation for an SPA
+- **WHEN** the user provides the `--preserve-hashes` CLI flag or enables `preserveHashes` in the configuration
+- **THEN** the scraper's URL normalization step SHALL NOT strip the `#` fragment from discovered URLs, queuing each hash route as a separate entity
+
+### Requirement: Playwright Rendering for Hash Routes
+The system SHALL enforce the use of `playwright` (or `auto`, which falls back to Playwright) as the `scrapeMode` when `preserveHashes` is enabled, because the `fetch` mode cannot evaluate client-side hash routing.
+
+#### Scenario: User attempts to use fetch mode with preserve hashes
+- **WHEN** `preserveHashes` is true AND `scrapeMode` is explicitly set to `fetch`
+- **THEN** the system SHALL throw a configuration validation error or automatically upgrade the mode to `playwright`, logging a warning to the user
+
+### Requirement: Accurate Page Interception in Playwright
+When `preserveHashes` is enabled and Playwright intercepts the initial page load, it SHALL fulfill the request using the pre-fetched content, successfully matching the `reqUrl` (which lacks the hash fragment due to browser networking rules) against the base path of the original `context.source`.
+
+#### Scenario: Playwright intercepts a hash-routed URL
+- **WHEN** `HtmlPlaywrightMiddleware` intercepts a request for a URL that originally contained a hash (e.g., `http://example.com/#/docs`)
+- **THEN** it SHALL successfully fulfill the `http://example.com/` request with the pre-fetched content, allowing the SPA to boot and the client-side router to evaluate the `#/docs` fragment

--- a/openspec/changes/support-hash-routed-spas/specs/hash-routed-spa-support/spec.md
+++ b/openspec/changes/support-hash-routed-spas/specs/hash-routed-spa-support/spec.md
@@ -20,3 +20,10 @@ When `preserveHashes` is enabled and Playwright intercepts the initial page load
 #### Scenario: Playwright intercepts a hash-routed URL
 - **WHEN** `HtmlPlaywrightMiddleware` intercepts a request for a URL that originally contained a hash (e.g., `http://example.com/#/docs`)
 - **THEN** it SHALL successfully fulfill the `http://example.com/` request with the pre-fetched content, allowing the SPA to boot and the client-side router to evaluate the `#/docs` fragment
+
+### Requirement: Web UI Configuration
+The system SHALL expose the `preserveHashes` option in the Web UI, allowing users to explicitly enable it when adding a new library or refreshing an existing one.
+
+#### Scenario: User configures hash preservation via Web UI
+- **WHEN** the user checks the "Preserve Hash Routes" option in the Web UI and submits the form
+- **THEN** the `preserveHashes` setting SHALL be passed to the scraping pipeline as part of the `ScraperOptions`

--- a/openspec/changes/support-hash-routed-spas/specs/hash-routed-spa-support/spec.md
+++ b/openspec/changes/support-hash-routed-spas/specs/hash-routed-spa-support/spec.md
@@ -1,11 +1,15 @@
 ## ADDED Requirements
 
 ### Requirement: Explicit Hash Route Preservation
-The system SHALL provide a configuration option and CLI flag (`--preserve-hashes` / `preserveHashes`) to disable the stripping of hash fragments from URLs during web crawling. This allows Single Page Applications (SPAs) that utilize hash-based client-side routing to be correctly identified, queued, and indexed as distinct pages.
+The system SHALL provide a configuration option and CLI flag (`--preserve-hashes` / `preserveHashes`) and SHALL expose the same capability through the MCP `scrape_docs` tool to disable the stripping of hash fragments from URLs during web crawling. This allows Single Page Applications (SPAs) that utilize hash-based client-side routing to be correctly identified, queued, and indexed as distinct pages.
 
 #### Scenario: User enables hash preservation for an SPA
 - **WHEN** the user provides the `--preserve-hashes` CLI flag or enables `preserveHashes` in the configuration
 - **THEN** the scraper's URL normalization step SHALL NOT strip the `#` fragment from discovered URLs, queuing each hash route as a separate entity
+
+#### Scenario: MCP client enables hash preservation for an SPA
+- **WHEN** an MCP client calls `scrape_docs` with `preserveHashes: true`
+- **THEN** the MCP tool SHALL pass `preserveHashes: true` through to the scraping pipeline as part of the `ScraperOptions`
 
 ### Requirement: Playwright Rendering for Hash Routes
 The system SHALL enforce the use of `playwright` (or `auto`, which falls back to Playwright) as the `scrapeMode` when `preserveHashes` is enabled, because the `fetch` mode cannot evaluate client-side hash routing.

--- a/openspec/changes/support-hash-routed-spas/tasks.md
+++ b/openspec/changes/support-hash-routed-spas/tasks.md
@@ -16,8 +16,13 @@
 - [ ] 3.1 Modify `HtmlPlaywrightMiddleware.ts` to correctly match intercepted requests. Change `if (reqUrl === context.source)` to compare `reqUrl` against the hash-stripped version of `context.source` (e.g., `reqUrl === new URL(context.source).origin + new URL(context.source).pathname + new URL(context.source).search`).
 - [ ] 3.2 Add or update tests in `HtmlPlaywrightMiddleware.test.ts` to verify the interceptor works properly with URLs containing hash routes.
 
-## 4. Documentation & Final Testing
+## 4. Web UI Updates
 
-- [ ] 4.1 Write tests in `WebScraperStrategy.test.ts` to verify that setting `preserveHashes` queues URLs with varying hashes as distinct documents.
-- [ ] 4.2 Document the `--preserve-hashes` flag and its specific use case (Hash-routed SPAs) in `README.md`.
-- [ ] 4.3 Update `docs/setup/configuration.md` and related docs to explain the `preserveHashes` config option.
+- [ ] 4.1 Update the Web UI forms (e.g., the add library modal/view and refresh forms) to include a "Preserve Hash Routes" checkbox.
+- [ ] 4.2 Update the corresponding route handlers (e.g., in `src/web/routes/...`) to parse the checkbox value from the form submission and correctly pass `preserveHashes: true` to the pipeline options.
+
+## 5. Documentation & Final Testing
+
+- [ ] 5.1 Write tests in `WebScraperStrategy.test.ts` to verify that setting `preserveHashes` queues URLs with varying hashes as distinct documents.
+- [ ] 5.2 Document the `--preserve-hashes` flag and its specific use case (Hash-routed SPAs) in `README.md`.
+- [ ] 5.3 Update `docs/setup/configuration.md` and related docs to explain the `preserveHashes` config option.

--- a/openspec/changes/support-hash-routed-spas/tasks.md
+++ b/openspec/changes/support-hash-routed-spas/tasks.md
@@ -1,0 +1,23 @@
+## 1. Configuration & CLI Updates
+
+- [ ] 1.1 Add `preserveHashes` boolean property to scraper configuration schema in `src/utils/config.ts` (default: false).
+- [ ] 1.2 Add `--preserve-hashes` option to `scrape` command in `src/cli/commands/scrape.ts`.
+- [ ] 1.3 Add `--preserve-hashes` option to `refresh` command in `src/cli/commands/refresh.ts`.
+- [ ] 1.4 Ensure CLI commands map `--preserve-hashes` to `options.preserveHashes` correctly when building the `ScraperOptions`.
+
+## 2. Core Scraper Strategy & Validation Updates
+
+- [ ] 2.1 Update `ScraperOptions` interface in `src/scraper/types.ts` to include `preserveHashes?: boolean`.
+- [ ] 2.2 Update `WebScraperStrategy` to respect `options.preserveHashes`. Pass `removeHash: !options.preserveHashes` via `urlNormalizerOptions` when normalizing URLs during queue processing.
+- [ ] 2.3 Add validation to `ScraperService` or `PipelineManager` (or `WebScraperStrategy` initialization) to ensure that if `preserveHashes` is true, the `scrapeMode` is not explicitly set to `fetch` (throw a validation error or warn and upgrade to `playwright`).
+
+## 3. Playwright Middleware Fixes
+
+- [ ] 3.1 Modify `HtmlPlaywrightMiddleware.ts` to correctly match intercepted requests. Change `if (reqUrl === context.source)` to compare `reqUrl` against the hash-stripped version of `context.source` (e.g., `reqUrl === new URL(context.source).origin + new URL(context.source).pathname + new URL(context.source).search`).
+- [ ] 3.2 Add or update tests in `HtmlPlaywrightMiddleware.test.ts` to verify the interceptor works properly with URLs containing hash routes.
+
+## 4. Documentation & Final Testing
+
+- [ ] 4.1 Write tests in `WebScraperStrategy.test.ts` to verify that setting `preserveHashes` queues URLs with varying hashes as distinct documents.
+- [ ] 4.2 Document the `--preserve-hashes` flag and its specific use case (Hash-routed SPAs) in `README.md`.
+- [ ] 4.3 Update `docs/setup/configuration.md` and related docs to explain the `preserveHashes` config option.

--- a/openspec/changes/support-hash-routed-spas/tasks.md
+++ b/openspec/changes/support-hash-routed-spas/tasks.md
@@ -1,37 +1,37 @@
 ## 1. Configuration & CLI Updates
 
-- [ ] 1.1 Add `preserveHashes` boolean property to scraper configuration schema in `src/utils/config.ts` (default: false).
-- [ ] 1.2 Add `--preserve-hashes` option to `scrape` command in `src/cli/commands/scrape.ts`.
-- [ ] 1.3 Add `--preserve-hashes` option to `refresh` command in `src/cli/commands/refresh.ts` and define whether it overrides stored scraper options for that version.
-- [ ] 1.4 Ensure CLI scrape and refresh commands map `--preserve-hashes` to `options.preserveHashes` correctly when building or overriding `ScraperOptions`.
+- [x] 1.1 Add `preserveHashes` boolean property to scraper configuration schema in `src/utils/config.ts` (default: false).
+- [x] 1.2 Add `--preserve-hashes` option to `scrape` command in `src/cli/commands/scrape.ts`.
+- [x] 1.3 Add `--preserve-hashes` option to `refresh` command in `src/cli/commands/refresh.ts` and define whether it overrides stored scraper options for that version.
+- [x] 1.4 Ensure CLI scrape and refresh commands map `--preserve-hashes` to `options.preserveHashes` correctly when building or overriding `ScraperOptions`.
 
 ## 2. MCP Tool Updates
 
-- [ ] 2.1 Extend the MCP `scrape_docs` tool input schema in `src/mcp/mcpServer.ts` to accept `preserveHashes?: boolean` with clear help text for hash-routed SPAs.
-- [ ] 2.2 Update `ScrapeToolOptions` in `src/tools/ScrapeTool.ts` to include `preserveHashes?: boolean` and pass it through when enqueueing scrape jobs.
-- [ ] 2.3 Add or update MCP and `ScrapeTool` tests to verify `preserveHashes` is accepted and propagated into `ScraperOptions`.
+- [x] 2.1 Extend the MCP `scrape_docs` tool input schema in `src/mcp/mcpServer.ts` to accept `preserveHashes?: boolean` with clear help text for hash-routed SPAs.
+- [x] 2.2 Update `ScrapeToolOptions` in `src/tools/ScrapeTool.ts` to include `preserveHashes?: boolean` and pass it through when enqueueing scrape jobs.
+- [x] 2.3 Add or update MCP and `ScrapeTool` tests to verify `preserveHashes` is accepted and propagated into `ScraperOptions`.
 
 ## 3. Core Scraper Strategy & Validation Updates
 
-- [ ] 3.1 Update `ScraperOptions` interface in `src/scraper/types.ts` to include `preserveHashes?: boolean`.
-- [ ] 3.2 Update `BaseScraperStrategy` crawl identity handling to respect `options.preserveHashes` for root URL normalization, `visited` deduplication, and refresh `initialQueue` processing.
-- [ ] 3.3 Ensure `WebScraperStrategy` and related web-specific code use the same hash-preservation behavior for fetched/result URLs and stored page identities.
-- [ ] 3.4 Add runtime enforcement so that if `preserveHashes` is true and `scrapeMode` is `fetch`, the effective mode is upgraded to `playwright` with a warning.
-- [ ] 3.5 Extend refresh job construction in `PipelineManager`, `RefreshVersionTool`, and related pipeline interfaces so `preserveHashes` is stored, reused by default, and overridable when a refresh entrypoint explicitly changes it.
+- [x] 3.1 Update `ScraperOptions` interface in `src/scraper/types.ts` to include `preserveHashes?: boolean`.
+- [x] 3.2 Update `BaseScraperStrategy` crawl identity handling to respect `options.preserveHashes` for root URL normalization, `visited` deduplication, and refresh `initialQueue` processing.
+- [x] 3.3 Ensure `WebScraperStrategy` and related web-specific code use the same hash-preservation behavior for fetched/result URLs and stored page identities.
+- [x] 3.4 Add runtime enforcement so that if `preserveHashes` is true and `scrapeMode` is `fetch`, the effective mode is upgraded to `playwright` with a warning.
+- [x] 3.5 Extend refresh job construction in `PipelineManager`, `RefreshVersionTool`, and related pipeline interfaces so `preserveHashes` is stored, reused by default, and overridable when a refresh entrypoint explicitly changes it.
 
 ## 4. Playwright Middleware Fixes
 
-- [ ] 4.1 Modify `HtmlPlaywrightMiddleware.ts` to correctly match intercepted requests. Change `if (reqUrl === context.source)` to compare `reqUrl` against the hash-stripped version of `context.source` (e.g., `reqUrl === new URL(context.source).origin + new URL(context.source).pathname + new URL(context.source).search`).
-- [ ] 4.2 Add or update tests in `HtmlPlaywrightMiddleware.test.ts` to verify the interceptor works properly with URLs containing hash routes.
+- [x] 4.1 Modify `HtmlPlaywrightMiddleware.ts` to correctly match intercepted requests. Change `if (reqUrl === context.source)` to compare `reqUrl` against the hash-stripped version of `context.source` (e.g., `reqUrl === new URL(context.source).origin + new URL(context.source).pathname + new URL(context.source).search`).
+- [x] 4.2 Add or update tests in `HtmlPlaywrightMiddleware.test.ts` to verify the interceptor works properly with URLs containing hash routes.
 
 ## 5. Web UI Updates
 
-- [ ] 5.1 Update the Web UI forms (e.g., the add library modal/view and refresh forms) to include a "Preserve Hash Routes" checkbox.
-- [ ] 5.2 Update the corresponding route handlers (e.g., in `src/web/routes/...`) to parse the checkbox value from the form submission and correctly pass `preserveHashes` into scrape and refresh pipeline options.
+- [x] 5.1 Update the Web UI forms (e.g., the add library modal/view and refresh forms) to include a "Preserve Hash Routes" checkbox.
+- [x] 5.2 Update the corresponding route handlers (e.g., in `src/web/routes/...`) to parse the checkbox value from the form submission and correctly pass `preserveHashes` into scrape and refresh pipeline options.
 
 ## 6. Documentation & Final Testing
 
-- [ ] 6.1 Write tests in `BaseScraperStrategy.test.ts` and `WebScraperStrategy.test.ts` to verify that setting `preserveHashes` keeps distinct hash routes separate in discovery, deduplication, and storage.
-- [ ] 6.2 Document the `--preserve-hashes` flag, MCP `preserveHashes` field, and Web UI toggle and their specific use case (hash-routed SPAs) in `README.md`.
-- [ ] 6.3 Add refresh-focused tests covering stored-option reuse and explicit override behavior for `preserveHashes`.
-- [ ] 6.4 Update `docs/setup/configuration.md` and related docs to explain the `preserveHashes` config option across CLI, MCP, Web UI, and refresh behavior.
+- [x] 6.1 Write tests in `BaseScraperStrategy.test.ts` and `WebScraperStrategy.test.ts` to verify that setting `preserveHashes` keeps distinct hash routes separate in discovery, deduplication, and storage.
+- [x] 6.2 Document the `--preserve-hashes` flag, MCP `preserveHashes` field, and Web UI toggle and their specific use case (hash-routed SPAs) in `README.md`.
+- [x] 6.3 Add refresh-focused tests covering stored-option reuse and explicit override behavior for `preserveHashes`.
+- [x] 6.4 Update `docs/setup/configuration.md` and related docs to explain the `preserveHashes` config option across CLI, MCP, Web UI, and refresh behavior.

--- a/openspec/changes/support-hash-routed-spas/tasks.md
+++ b/openspec/changes/support-hash-routed-spas/tasks.md
@@ -5,24 +5,30 @@
 - [ ] 1.3 Add `--preserve-hashes` option to `refresh` command in `src/cli/commands/refresh.ts`.
 - [ ] 1.4 Ensure CLI commands map `--preserve-hashes` to `options.preserveHashes` correctly when building the `ScraperOptions`.
 
-## 2. Core Scraper Strategy & Validation Updates
+## 2. MCP Tool Updates
 
-- [ ] 2.1 Update `ScraperOptions` interface in `src/scraper/types.ts` to include `preserveHashes?: boolean`.
-- [ ] 2.2 Update `WebScraperStrategy` to respect `options.preserveHashes`. Pass `removeHash: !options.preserveHashes` via `urlNormalizerOptions` when normalizing URLs during queue processing.
-- [ ] 2.3 Add validation to `ScraperService` or `PipelineManager` (or `WebScraperStrategy` initialization) to ensure that if `preserveHashes` is true, the `scrapeMode` is not explicitly set to `fetch` (throw a validation error or warn and upgrade to `playwright`).
+- [ ] 2.1 Extend the MCP `scrape_docs` tool input schema in `src/mcp/mcpServer.ts` to accept `preserveHashes?: boolean` with clear help text for hash-routed SPAs.
+- [ ] 2.2 Update `ScrapeToolOptions` in `src/tools/ScrapeTool.ts` to include `preserveHashes?: boolean` and pass it through when enqueueing scrape jobs.
+- [ ] 2.3 Add or update MCP and `ScrapeTool` tests to verify `preserveHashes` is accepted and propagated into `ScraperOptions`.
 
-## 3. Playwright Middleware Fixes
+## 3. Core Scraper Strategy & Validation Updates
 
-- [ ] 3.1 Modify `HtmlPlaywrightMiddleware.ts` to correctly match intercepted requests. Change `if (reqUrl === context.source)` to compare `reqUrl` against the hash-stripped version of `context.source` (e.g., `reqUrl === new URL(context.source).origin + new URL(context.source).pathname + new URL(context.source).search`).
-- [ ] 3.2 Add or update tests in `HtmlPlaywrightMiddleware.test.ts` to verify the interceptor works properly with URLs containing hash routes.
+- [ ] 3.1 Update `ScraperOptions` interface in `src/scraper/types.ts` to include `preserveHashes?: boolean`.
+- [ ] 3.2 Update `WebScraperStrategy` to respect `options.preserveHashes`. Pass `removeHash: !options.preserveHashes` via `urlNormalizerOptions` when normalizing URLs during queue processing.
+- [ ] 3.3 Add validation to `ScraperService` or `PipelineManager` (or `WebScraperStrategy` initialization) to ensure that if `preserveHashes` is true, the `scrapeMode` is not explicitly set to `fetch` (throw a validation error or warn and upgrade to `playwright`).
 
-## 4. Web UI Updates
+## 4. Playwright Middleware Fixes
 
-- [ ] 4.1 Update the Web UI forms (e.g., the add library modal/view and refresh forms) to include a "Preserve Hash Routes" checkbox.
-- [ ] 4.2 Update the corresponding route handlers (e.g., in `src/web/routes/...`) to parse the checkbox value from the form submission and correctly pass `preserveHashes: true` to the pipeline options.
+- [ ] 4.1 Modify `HtmlPlaywrightMiddleware.ts` to correctly match intercepted requests. Change `if (reqUrl === context.source)` to compare `reqUrl` against the hash-stripped version of `context.source` (e.g., `reqUrl === new URL(context.source).origin + new URL(context.source).pathname + new URL(context.source).search`).
+- [ ] 4.2 Add or update tests in `HtmlPlaywrightMiddleware.test.ts` to verify the interceptor works properly with URLs containing hash routes.
 
-## 5. Documentation & Final Testing
+## 5. Web UI Updates
 
-- [ ] 5.1 Write tests in `WebScraperStrategy.test.ts` to verify that setting `preserveHashes` queues URLs with varying hashes as distinct documents.
-- [ ] 5.2 Document the `--preserve-hashes` flag and its specific use case (Hash-routed SPAs) in `README.md`.
-- [ ] 5.3 Update `docs/setup/configuration.md` and related docs to explain the `preserveHashes` config option.
+- [ ] 5.1 Update the Web UI forms (e.g., the add library modal/view and refresh forms) to include a "Preserve Hash Routes" checkbox.
+- [ ] 5.2 Update the corresponding route handlers (e.g., in `src/web/routes/...`) to parse the checkbox value from the form submission and correctly pass `preserveHashes: true` to the pipeline options.
+
+## 6. Documentation & Final Testing
+
+- [ ] 6.1 Write tests in `WebScraperStrategy.test.ts` to verify that setting `preserveHashes` queues URLs with varying hashes as distinct documents.
+- [ ] 6.2 Document the `--preserve-hashes` flag, MCP `preserveHashes` field, and Web UI toggle and their specific use case (hash-routed SPAs) in `README.md`.
+- [ ] 6.3 Update `docs/setup/configuration.md` and related docs to explain the `preserveHashes` config option across CLI, MCP, and Web UI.

--- a/openspec/changes/support-hash-routed-spas/tasks.md
+++ b/openspec/changes/support-hash-routed-spas/tasks.md
@@ -2,8 +2,8 @@
 
 - [ ] 1.1 Add `preserveHashes` boolean property to scraper configuration schema in `src/utils/config.ts` (default: false).
 - [ ] 1.2 Add `--preserve-hashes` option to `scrape` command in `src/cli/commands/scrape.ts`.
-- [ ] 1.3 Add `--preserve-hashes` option to `refresh` command in `src/cli/commands/refresh.ts`.
-- [ ] 1.4 Ensure CLI commands map `--preserve-hashes` to `options.preserveHashes` correctly when building the `ScraperOptions`.
+- [ ] 1.3 Add `--preserve-hashes` option to `refresh` command in `src/cli/commands/refresh.ts` and define whether it overrides stored scraper options for that version.
+- [ ] 1.4 Ensure CLI scrape and refresh commands map `--preserve-hashes` to `options.preserveHashes` correctly when building or overriding `ScraperOptions`.
 
 ## 2. MCP Tool Updates
 
@@ -14,8 +14,10 @@
 ## 3. Core Scraper Strategy & Validation Updates
 
 - [ ] 3.1 Update `ScraperOptions` interface in `src/scraper/types.ts` to include `preserveHashes?: boolean`.
-- [ ] 3.2 Update `WebScraperStrategy` to respect `options.preserveHashes`. Pass `removeHash: !options.preserveHashes` via `urlNormalizerOptions` when normalizing URLs during queue processing.
-- [ ] 3.3 Add validation to `ScraperService` or `PipelineManager` (or `WebScraperStrategy` initialization) to ensure that if `preserveHashes` is true, the `scrapeMode` is not explicitly set to `fetch` (throw a validation error or warn and upgrade to `playwright`).
+- [ ] 3.2 Update `BaseScraperStrategy` crawl identity handling to respect `options.preserveHashes` for root URL normalization, `visited` deduplication, and refresh `initialQueue` processing.
+- [ ] 3.3 Ensure `WebScraperStrategy` and related web-specific code use the same hash-preservation behavior for fetched/result URLs and stored page identities.
+- [ ] 3.4 Add runtime enforcement so that if `preserveHashes` is true and `scrapeMode` is `fetch`, the effective mode is upgraded to `playwright` with a warning.
+- [ ] 3.5 Extend refresh job construction in `PipelineManager`, `RefreshVersionTool`, and related pipeline interfaces so `preserveHashes` is stored, reused by default, and overridable when a refresh entrypoint explicitly changes it.
 
 ## 4. Playwright Middleware Fixes
 
@@ -25,10 +27,11 @@
 ## 5. Web UI Updates
 
 - [ ] 5.1 Update the Web UI forms (e.g., the add library modal/view and refresh forms) to include a "Preserve Hash Routes" checkbox.
-- [ ] 5.2 Update the corresponding route handlers (e.g., in `src/web/routes/...`) to parse the checkbox value from the form submission and correctly pass `preserveHashes: true` to the pipeline options.
+- [ ] 5.2 Update the corresponding route handlers (e.g., in `src/web/routes/...`) to parse the checkbox value from the form submission and correctly pass `preserveHashes` into scrape and refresh pipeline options.
 
 ## 6. Documentation & Final Testing
 
-- [ ] 6.1 Write tests in `WebScraperStrategy.test.ts` to verify that setting `preserveHashes` queues URLs with varying hashes as distinct documents.
+- [ ] 6.1 Write tests in `BaseScraperStrategy.test.ts` and `WebScraperStrategy.test.ts` to verify that setting `preserveHashes` keeps distinct hash routes separate in discovery, deduplication, and storage.
 - [ ] 6.2 Document the `--preserve-hashes` flag, MCP `preserveHashes` field, and Web UI toggle and their specific use case (hash-routed SPAs) in `README.md`.
-- [ ] 6.3 Update `docs/setup/configuration.md` and related docs to explain the `preserveHashes` config option across CLI, MCP, and Web UI.
+- [ ] 6.3 Add refresh-focused tests covering stored-option reuse and explicit override behavior for `preserveHashes`.
+- [ ] 6.4 Update `docs/setup/configuration.md` and related docs to explain the `preserveHashes` config option across CLI, MCP, Web UI, and refresh behavior.

--- a/src/cli/commands/refresh.test.ts
+++ b/src/cli/commands/refresh.test.ts
@@ -78,4 +78,18 @@ describe("refresh command", () => {
     expect(pipelineMock.start).toHaveBeenCalledTimes(1);
     expect(pipelineMock.stop).toHaveBeenCalledTimes(1);
   });
+
+  it("passes preserveHashes override to RefreshVersionTool", async () => {
+    const parser = yargs().scriptName("test");
+    createRefreshCommand(parser);
+
+    await parser.parse(`refresh react --preserve-hashes`);
+
+    const execute = vi.mocked(RefreshVersionTool).mock.results[0]?.value.execute;
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preserveHashes: true,
+      }),
+    );
+  });
 });

--- a/src/cli/commands/refresh.ts
+++ b/src/cli/commands/refresh.ts
@@ -32,6 +32,11 @@ export function createRefreshCommand(cli: Argv) {
           description: "Version of the library (optional)",
           alias: "v",
         })
+        .option("preserve-hashes", {
+          type: "boolean",
+          description: "Override the stored hash-route setting for this refresh job",
+          alias: "preserveHashes",
+        })
         .option("embedding-model", {
           type: "string",
           description:
@@ -59,6 +64,7 @@ export function createRefreshCommand(cli: Argv) {
         command: "refresh",
         library: argv.library,
         version: argv.version,
+        preserveHashes: argv.preserveHashes,
         useServerUrl: !!argv.serverUrl,
       });
 
@@ -129,6 +135,7 @@ export function createRefreshCommand(cli: Argv) {
         const result = await refreshTool.execute({
           library,
           version,
+          preserveHashes: argv.preserveHashes as boolean | undefined,
           waitForCompletion: true, // Always wait for completion in CLI
         });
 

--- a/src/cli/commands/scrape.test.ts
+++ b/src/cli/commands/scrape.test.ts
@@ -89,4 +89,20 @@ describe("scrape command", () => {
     expect(pipelineMock.start).toHaveBeenCalledTimes(1);
     expect(pipelineMock.stop).toHaveBeenCalledTimes(1);
   });
+
+  it("passes preserveHashes through to ScrapeTool", async () => {
+    const parser = yargs().scriptName("test");
+    createScrapeCommand(parser);
+
+    await parser.parse(["scrape", "react", "https://react.dev", "--preserve-hashes"]);
+
+    const execute = vi.mocked(ScrapeTool).mock.results[0]?.value.execute;
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          preserveHashes: true,
+        }),
+      }),
+    );
+  });
 });

--- a/src/cli/commands/scrape.ts
+++ b/src/cli/commands/scrape.ts
@@ -81,6 +81,12 @@ export function createScrapeCommand(cli: Argv) {
           default: ScrapeMode.Auto,
           alias: "scrapeMode",
         })
+        .option("preserve-hashes", {
+          type: "boolean",
+          description:
+            "Preserve URL hash fragments for hash-routed SPA documentation sites",
+          alias: "preserveHashes",
+        })
         .option("include-pattern", {
           type: "string",
           array: true,
@@ -146,6 +152,10 @@ export function createScrapeCommand(cli: Argv) {
       const maxDepth = (argv.maxDepth as number) ?? appConfig.scraper.maxDepth;
       const maxConcurrency =
         (argv.maxConcurrency as number) ?? appConfig.scraper.maxConcurrency;
+      const preserveHashes =
+        typeof argv.preserveHashes === "boolean"
+          ? (argv.preserveHashes as boolean)
+          : appConfig.scraper.preserveHashes;
 
       // Update appConfig with effective values
       appConfig.scraper.maxPages = maxPages;
@@ -162,6 +172,7 @@ export function createScrapeCommand(cli: Argv) {
         maxConcurrency,
         scope: argv.scope,
         scrapeMode: argv.scrapeMode,
+        preserveHashes,
         followRedirects: argv.followRedirects,
         hasHeaders: (argv.header as string[]).length > 0,
         hasIncludePatterns: (argv.includePattern as string[]).length > 0,
@@ -237,6 +248,7 @@ export function createScrapeCommand(cli: Argv) {
             scope: argv.scope as "subpages" | "hostname" | "domain",
             followRedirects: argv.followRedirects as boolean,
             scrapeMode: argv.scrapeMode as ScrapeMode,
+            preserveHashes,
             includePatterns:
               (argv.includePattern as string[])?.length > 0
                 ? (argv.includePattern as string[])

--- a/src/mcp/mcpServer.test.ts
+++ b/src/mcp/mcpServer.test.ts
@@ -75,4 +75,33 @@ describe("MCP Server Read-Only Mode", () => {
     // This ensures our capability changes don't break server creation
     expect(server).toBeDefined();
   });
+
+  it("should register scrape_docs with preserveHashes support and propagate it", async () => {
+    const server = createMcpServerInstance(mockTools, mockConfig);
+    const scrapeTool = (server as any)._registeredTools.scrape_docs;
+
+    expect(scrapeTool).toBeDefined();
+    expect(scrapeTool.inputSchema).toBeDefined();
+
+    const parsed = scrapeTool.inputSchema.parse({
+      url: "https://example.com/#/guide",
+      library: "example-lib",
+      preserveHashes: true,
+    });
+    expect(parsed.preserveHashes).toBe(true);
+
+    await scrapeTool.handler({
+      url: "https://example.com/#/guide",
+      library: "example-lib",
+      preserveHashes: true,
+    });
+
+    expect(mockTools.scrape.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          preserveHashes: true,
+        }),
+      }),
+    );
+  });
 });

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -67,13 +67,26 @@ export function createMcpServerInstance(
           .optional()
           .default(true)
           .describe("Follow HTTP redirects (3xx responses)."),
+        preserveHashes: z
+          .boolean()
+          .optional()
+          .describe("Preserve hash fragments for hash-routed SPA documentation sites."),
       },
       {
         title: "Scrape New Library Documentation",
         destructiveHint: true, // replaces existing docs
         openWorldHint: true, // requires internet access
       },
-      async ({ url, library, version, maxPages, maxDepth, scope, followRedirects }) => {
+      async ({
+        url,
+        library,
+        version,
+        maxPages,
+        maxDepth,
+        scope,
+        followRedirects,
+        preserveHashes,
+      }) => {
         // Track MCP tool usage
         telemetry.track(TelemetryEvent.TOOL_USED, {
           tool: "scrape_docs",
@@ -99,6 +112,7 @@ export function createMcpServerInstance(
               maxDepth,
               scope,
               followRedirects,
+              preserveHashes,
             },
           });
 

--- a/src/pipeline/PipelineClient.ts
+++ b/src/pipeline/PipelineClient.ts
@@ -109,6 +109,7 @@ export class PipelineClient implements IPipeline {
   async enqueueRefreshJob(
     library: string,
     version: string | undefined | null,
+    options?: { preserveHashes?: boolean },
   ): Promise<string> {
     try {
       const normalizedVersion =
@@ -118,6 +119,7 @@ export class PipelineClient implements IPipeline {
       const result = await this.client.enqueueRefreshJob.mutate({
         library,
         version: normalizedVersion,
+        options,
       });
       logger.debug(`Refresh job ${result.jobId} enqueued successfully`);
       return result.jobId;

--- a/src/pipeline/PipelineManager.test.ts
+++ b/src/pipeline/PipelineManager.test.ts
@@ -771,7 +771,7 @@ describe("PipelineManager", () => {
       const jobId = await manager.enqueueRefreshJob("incomplete-lib", "1.0.0");
 
       // Assertions: Should have called enqueueJobWithStoredOptions instead of normal refresh
-      expect(enqueueStoredSpy).toHaveBeenCalledWith("incomplete-lib", "1.0.0");
+      expect(enqueueStoredSpy).toHaveBeenCalledWith("incomplete-lib", "1.0.0", undefined);
       expect(jobId).toBe("mock-job-id");
 
       // Should NOT have called getPagesByVersionId since we're doing a full re-scrape
@@ -806,7 +806,7 @@ describe("PipelineManager", () => {
       await manager.enqueueRefreshJob("queued-lib", "2.0.0");
 
       // Assertions: Should perform full re-scrape for queued versions
-      expect(enqueueStoredSpy).toHaveBeenCalledWith("queued-lib", "2.0.0");
+      expect(enqueueStoredSpy).toHaveBeenCalledWith("queued-lib", "2.0.0", undefined);
     });
 
     it("should perform normal refresh for completed versions", async () => {
@@ -848,6 +848,79 @@ describe("PipelineManager", () => {
       expect(job).toBeDefined();
       expect(job?.library).toBe("completed-lib");
       expect(job?.version).toBe("3.0.0");
+    });
+
+    it("should upgrade fetch mode to playwright when preserveHashes is enabled", async () => {
+      const jobId = await manager.enqueueScrapeJob("test-lib", "1.0.0", {
+        url: "https://example.com/#/guide",
+        library: "test-lib",
+        version: "1.0.0",
+        scrapeMode: "fetch" as any,
+        preserveHashes: true,
+      });
+
+      const job = await manager.getJob(jobId);
+      expect(job?.scraperOptions?.scrapeMode).toBe("playwright");
+      expect(job?.scraperOptions?.preserveHashes).toBe(true);
+    });
+
+    it("should reuse stored preserveHashes during refresh when no override is provided", async () => {
+      const mockPages = [
+        { id: 1, url: "https://example.com/#/guide", depth: 0, etag: "etag1" },
+      ];
+
+      (mockStore.ensureVersion as Mock).mockResolvedValue(888);
+      (mockStore.getPagesByVersionId as Mock).mockResolvedValue(mockPages);
+      (mockStore.getScraperOptions as Mock).mockResolvedValue({
+        sourceUrl: "https://example.com/#/guide",
+        options: { preserveHashes: true },
+      });
+
+      const jobId = await manager.enqueueRefreshJob("test-lib", "1.0.0");
+      const job = await manager.getJob(jobId);
+
+      expect(job?.scraperOptions?.preserveHashes).toBe(true);
+    });
+
+    it("should override stored preserveHashes during refresh when explicitly provided", async () => {
+      const mockPages = [
+        { id: 1, url: "https://example.com/#/guide", depth: 0, etag: "etag1" },
+      ];
+
+      (mockStore.ensureVersion as Mock).mockResolvedValue(889);
+      (mockStore.getPagesByVersionId as Mock).mockResolvedValue(mockPages);
+      (mockStore.getScraperOptions as Mock).mockResolvedValue({
+        sourceUrl: "https://example.com/#/guide",
+        options: { preserveHashes: true },
+      });
+
+      const jobId = await manager.enqueueRefreshJob("test-lib", "1.0.0", {
+        preserveHashes: false,
+      });
+      const job = await manager.getJob(jobId);
+
+      expect(job?.scraperOptions?.preserveHashes).toBe(false);
+    });
+
+    it("should default refresh jobs to auto scrapeMode when older stored options omit it", async () => {
+      const mockPages = [
+        { id: 1, url: "https://example.com/#/guide", depth: 0, etag: "etag1" },
+      ];
+
+      (mockStore.ensureVersion as Mock).mockResolvedValue(890);
+      (mockStore.getPagesByVersionId as Mock).mockResolvedValue(mockPages);
+      (mockStore.getScraperOptions as Mock).mockResolvedValue({
+        sourceUrl: "https://example.com/#/guide",
+        options: { preserveHashes: true },
+      });
+
+      const jobId = await manager.enqueueRefreshJob("test-lib", "1.0.0", {
+        preserveHashes: true,
+      });
+      const job = await manager.getJob(jobId);
+
+      expect(job?.scraperOptions?.scrapeMode).toBe("auto");
+      expect(job?.scraperOptions?.preserveHashes).toBe(true);
     });
   });
 

--- a/src/pipeline/PipelineManager.ts
+++ b/src/pipeline/PipelineManager.ts
@@ -12,6 +12,7 @@ import type { EventBusService } from "../events/EventBusService";
 import { EventType } from "../events/types";
 import { ScraperRegistry, ScraperService } from "../scraper";
 import type { ScraperOptions, ScraperProgressEvent } from "../scraper/types";
+import { ScrapeMode } from "../scraper/types";
 import type { DocumentManagementService } from "../store";
 import { VersionStatus } from "../store/types";
 import type { AppConfig } from "../utils/config";
@@ -83,6 +84,26 @@ export class PipelineManager implements IPipeline {
       sourceUrl: job.sourceUrl,
       scraperOptions: job.scraperOptions,
     };
+  }
+
+  private normalizeScraperOptions(options: ScraperOptions): ScraperOptions {
+    const normalizedOptions: ScraperOptions = {
+      ...options,
+      scrapeMode: options.scrapeMode ?? ScrapeMode.Auto,
+      preserveHashes: options.preserveHashes ?? this.appConfig.scraper.preserveHashes,
+    };
+
+    if (
+      normalizedOptions.preserveHashes &&
+      normalizedOptions.scrapeMode === ScrapeMode.Fetch
+    ) {
+      logger.warn(
+        `⚠️  Upgrading scrape mode to '${ScrapeMode.Playwright}' for ${options.url} because preserved hash routes are incompatible with '${ScrapeMode.Fetch}'.`,
+      );
+      normalizedOptions.scrapeMode = ScrapeMode.Playwright;
+    }
+
+    return normalizedOptions;
   }
 
   /**
@@ -233,6 +254,8 @@ export class PipelineManager implements IPipeline {
       await this.cancelJob(job.id);
     }
 
+    const normalizedOptions = this.normalizeScraperOptions(options);
+
     const jobId = uuidv4();
     const abortController = new AbortController();
     let resolveCompletion!: () => void;
@@ -265,8 +288,8 @@ export class PipelineManager implements IPipeline {
       progressMaxPages: 0,
       errorMessage: null,
       updatedAt: new Date(),
-      sourceUrl: options.url,
-      scraperOptions: options,
+      sourceUrl: normalizedOptions.url,
+      scraperOptions: normalizedOptions,
     };
 
     this.jobMap.set(jobId, job);
@@ -298,6 +321,7 @@ export class PipelineManager implements IPipeline {
   async enqueueRefreshJob(
     library: string,
     version: string | undefined | null,
+    options?: Pick<ScraperOptions, "preserveHashes">,
   ): Promise<string> {
     // Normalize version: treat undefined/null as "" (unversioned)
     const normalizedVersion = version ?? "";
@@ -327,7 +351,7 @@ export class PipelineManager implements IPipeline {
         logger.info(
           `⚠️  Version ${library}@${normalizedVersion || "latest"} has status "${versionInfo.status}". Performing full re-scrape instead of refresh.`,
         );
-        return this.enqueueJobWithStoredOptions(library, normalizedVersion);
+        return this.enqueueJobWithStoredOptions(library, normalizedVersion, options);
       }
 
       // Get all pages for this version with their ETags and depths
@@ -367,6 +391,9 @@ export class PipelineManager implements IPipeline {
         library,
         version: normalizedVersion,
         ...(storedOptions?.options || {}), // Include stored options if available (spread first)
+        ...(options?.preserveHashes !== undefined
+          ? { preserveHashes: options.preserveHashes }
+          : {}),
         // Override with refresh-specific options (these must come after the spread)
         initialQueue, // Pre-populated queue with existing pages
         isRefresh: true, // Mark this as a refresh operation
@@ -390,6 +417,7 @@ export class PipelineManager implements IPipeline {
   async enqueueJobWithStoredOptions(
     library: string,
     version: string | undefined | null,
+    options?: Pick<ScraperOptions, "preserveHashes">,
   ): Promise<string> {
     const normalizedVersion = version ?? "";
 
@@ -415,6 +443,9 @@ export class PipelineManager implements IPipeline {
         library,
         version: normalizedVersion,
         ...storedOptions,
+        ...(options?.preserveHashes !== undefined
+          ? { preserveHashes: options.preserveHashes }
+          : {}),
       };
 
       logger.info(

--- a/src/pipeline/trpc/interfaces.ts
+++ b/src/pipeline/trpc/interfaces.ts
@@ -26,7 +26,11 @@ export interface IPipeline {
     version: string | undefined | null,
     options: ScraperOptions,
   ): Promise<string>;
-  enqueueRefreshJob(library: string, version: string | undefined | null): Promise<string>;
+  enqueueRefreshJob(
+    library: string,
+    version: string | undefined | null,
+    options?: Pick<ScraperOptions, "preserveHashes">,
+  ): Promise<string>;
   getJob(jobId: string): Promise<PipelineJob | undefined>;
   getJobs(status?: PipelineJobStatus): Promise<PipelineJob[]>;
   cancelJob(jobId: string): Promise<void>;

--- a/src/pipeline/trpc/router.ts
+++ b/src/pipeline/trpc/router.ts
@@ -42,6 +42,11 @@ const enqueueScrapeInput = z.object({
 const enqueueRefreshInput = z.object({
   library: nonEmptyTrimmed,
   version: optionalTrimmed,
+  options: z
+    .object({
+      preserveHashes: z.boolean().optional(),
+    })
+    .optional(),
 });
 
 const jobIdInput = z.object({ id: z.string().min(1) });
@@ -89,6 +94,7 @@ export function createPipelineRouter(trpc: unknown) {
           const jobId = await ctx.pipeline.enqueueRefreshJob(
             input.library,
             input.version ?? null,
+            input.options,
           );
 
           return { jobId };

--- a/src/scraper/middleware/HtmlPlaywrightMiddleware.test.ts
+++ b/src/scraper/middleware/HtmlPlaywrightMiddleware.test.ts
@@ -163,6 +163,7 @@ describe("HtmlPlaywrightMiddleware", () => {
       maxPages: 1000,
       maxDepth: 3,
       maxConcurrency: 3,
+      preserveHashes: false,
       pageTimeoutMs: 5000,
       browserTimeoutMs: 30000,
       fetcher: {
@@ -932,6 +933,7 @@ describe("Route handling race condition protection", () => {
       maxPages: 1000,
       maxDepth: 3,
       maxConcurrency: 3,
+      preserveHashes: false,
       pageTimeoutMs: 5000,
       browserTimeoutMs: 30000,
       fetcher: {
@@ -1167,6 +1169,53 @@ describe("Route handling race condition protection", () => {
       expect(mockRoute.abort).toHaveBeenCalledWith("failed");
       expect(context.errors).toHaveLength(0);
       expect(next).toHaveBeenCalled();
+
+      launchSpy.mockRestore();
+    });
+
+    it("should fulfill the initial request for hash-routed URLs using the hash-stripped source", async () => {
+      const initialHtml = "<html><body><p>Hash-routed app</p></body></html>";
+      const context = createPipelineTestContext(
+        initialHtml,
+        "https://example.com/docs#/guide",
+        {
+          scrapeMode: ScrapeMode.Playwright,
+          preserveHashes: true,
+        },
+      );
+      const next = vi.fn();
+
+      let routeHandler: ((route: any) => Promise<void>) | null = null;
+      const mockRoute = {
+        request: () => ({
+          url: () => "https://example.com/docs",
+          resourceType: () => "document",
+          method: () => "GET",
+          headers: () => ({}),
+        }),
+        fulfill: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const pageSpy = createMockPlaywrightPage(initialHtml, {
+        url: "https://example.com/docs#/guide",
+      });
+      pageSpy.route = vi.fn().mockImplementation((_pattern: string, handler: any) => {
+        routeHandler = handler;
+        return Promise.resolve();
+      });
+
+      const browserSpy = createMockBrowser(pageSpy);
+      const launchSpy = vi.spyOn(chromium, "launch").mockResolvedValue(browserSpy);
+
+      await playwrightMiddleware.process(context, next);
+
+      expect(routeHandler).toBeDefined();
+      await expect((routeHandler as any)(mockRoute)).resolves.not.toThrow();
+      expect(mockRoute.fulfill).toHaveBeenCalledWith({
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        body: initialHtml,
+      });
 
       launchSpy.mockRestore();
     });

--- a/src/scraper/middleware/HtmlPlaywrightMiddleware.ts
+++ b/src/scraper/middleware/HtmlPlaywrightMiddleware.ts
@@ -873,18 +873,19 @@ export class HtmlPlaywrightMiddleware implements ContentProcessorMiddleware {
       // Inject shadow DOM extractor script early
       await this.injectShadowDOMExtractor(page);
 
+      const initialRequestUrl = (() => {
+        try {
+          const initialUrl = new URL(context.source);
+          initialUrl.hash = "";
+          return initialUrl.toString();
+        } catch {
+          return context.source;
+        }
+      })();
+
       // Set up route interception with special handling for the initial page load
       await page.route("**/*", async (route) => {
         const reqUrl = route.request().url();
-        const initialRequestUrl = (() => {
-          try {
-            const initialUrl = new URL(context.source);
-            initialUrl.hash = "";
-            return initialUrl.toString();
-          } catch {
-            return context.source;
-          }
-        })();
 
         // Serve the initial HTML for the main page (bypass cache and fetch)
         if (reqUrl === initialRequestUrl) {

--- a/src/scraper/middleware/HtmlPlaywrightMiddleware.ts
+++ b/src/scraper/middleware/HtmlPlaywrightMiddleware.ts
@@ -876,9 +876,18 @@ export class HtmlPlaywrightMiddleware implements ContentProcessorMiddleware {
       // Set up route interception with special handling for the initial page load
       await page.route("**/*", async (route) => {
         const reqUrl = route.request().url();
+        const initialRequestUrl = (() => {
+          try {
+            const initialUrl = new URL(context.source);
+            initialUrl.hash = "";
+            return initialUrl.toString();
+          } catch {
+            return context.source;
+          }
+        })();
 
         // Serve the initial HTML for the main page (bypass cache and fetch)
-        if (reqUrl === context.source) {
+        if (reqUrl === initialRequestUrl) {
           try {
             return await route.fulfill({
               status: 200,

--- a/src/scraper/strategies/BaseScraperStrategy.test.ts
+++ b/src/scraper/strategies/BaseScraperStrategy.test.ts
@@ -303,6 +303,58 @@ describe("BaseScraperStrategy", () => {
     expect(progressCallback).toHaveBeenCalledTimes(3);
   });
 
+  it("should keep distinct hash routes separate when preserveHashes is enabled", async () => {
+    const options: ScraperOptions = {
+      url: "https://example.com/",
+      library: "test",
+      version: "1.0.0",
+      maxPages: 10,
+      maxDepth: 1,
+      preserveHashes: true,
+    };
+    const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
+
+    strategy.processItem.mockImplementation(async (item: QueueItem) => {
+      if (item.url === "https://example.com/") {
+        return {
+          content: {
+            textContent: "main page",
+            metadata: {},
+            links: [],
+            errors: [],
+            chunks: [],
+          },
+          links: [
+            "https://example.com/#/guide",
+            "https://example.com/#/api",
+            "https://example.com/#/guide",
+          ],
+          status: FetchStatus.SUCCESS,
+        };
+      }
+
+      return {
+        content: {
+          textContent: item.url,
+          metadata: {},
+          links: [],
+          errors: [],
+          chunks: [],
+        },
+        links: [],
+        status: FetchStatus.SUCCESS,
+      };
+    });
+
+    await strategy.scrape(options, progressCallback);
+
+    expect(strategy.processItem).toHaveBeenCalledTimes(3);
+    const visitedUrls = Array.from(strategy.getVisitedUrls());
+    expect(visitedUrls).toContain("https://example.com/");
+    expect(visitedUrls).toContain("https://example.com/#/guide");
+    expect(visitedUrls).toContain("https://example.com/#/api");
+  });
+
   it("should process page via shortest path (breadth-first search)", async () => {
     const options: ScraperOptions = {
       url: "https://example.com/",

--- a/src/scraper/strategies/BaseScraperStrategy.ts
+++ b/src/scraper/strategies/BaseScraperStrategy.ts
@@ -80,6 +80,15 @@ export abstract class BaseScraperStrategy implements ScraperStrategy {
     this.options = options;
   }
 
+  protected getUrlNormalizerOptions(scrapeOptions: ScraperOptions): UrlNormalizerOptions {
+    return {
+      ...this.options.urlNormalizerOptions,
+      removeHash: scrapeOptions.preserveHashes
+        ? false
+        : (this.options.urlNormalizerOptions?.removeHash ?? true),
+    };
+  }
+
   /**
    * Determines if a URL should be processed based on scope and include/exclude patterns in ScraperOptions.
    * Scope is checked first, then patterns.
@@ -257,12 +266,12 @@ export abstract class BaseScraperStrategy implements ScraperStrategy {
     );
 
     // After all concurrent processing is done, deduplicate the results
-    const allLinks = results.flat();
+    const allLinks = results.flat().filter((item): item is QueueItem => item !== null);
     const uniqueLinks: QueueItem[] = [];
 
     // Now perform deduplication once, after all parallel processing is complete
     for (const item of allLinks) {
-      const normalizedUrl = normalizeUrl(item.url, this.options.urlNormalizerOptions);
+      const normalizedUrl = normalizeUrl(item.url, this.getUrlNormalizerOptions(options));
       if (!this.visited.has(normalizedUrl)) {
         this.visited.add(normalizedUrl);
         uniqueLinks.push(item);
@@ -302,7 +311,7 @@ export abstract class BaseScraperStrategy implements ScraperStrategy {
     const queue: QueueItem[] = [];
     const normalizedRootUrl = normalizeUrl(
       options.url,
-      this.options.urlNormalizerOptions,
+      this.getUrlNormalizerOptions(options),
     );
 
     if (isRefreshMode) {
@@ -312,7 +321,10 @@ export abstract class BaseScraperStrategy implements ScraperStrategy {
 
       // Add all items from initialQueue, using visited set to deduplicate
       for (const item of initialQueue) {
-        const normalizedUrl = normalizeUrl(item.url, this.options.urlNormalizerOptions);
+        const normalizedUrl = normalizeUrl(
+          item.url,
+          this.getUrlNormalizerOptions(options),
+        );
         if (!this.visited.has(normalizedUrl)) {
           this.visited.add(normalizedUrl);
           queue.push(item);

--- a/src/scraper/strategies/WebScraperStrategy.test.ts
+++ b/src/scraper/strategies/WebScraperStrategy.test.ts
@@ -523,6 +523,48 @@ describe("WebScraperStrategy", () => {
     );
   });
 
+  it("should preserve the requested hash in stored page identity when enabled", async () => {
+    const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
+    options.url = "https://example.com/docs#/guide";
+    options.preserveHashes = true;
+
+    mockFetchFn.mockResolvedValue({
+      content:
+        "<html><head><title>Guide</title></head><body><h1>Guide</h1></body></html>",
+      mimeType: "text/html",
+      source: "https://example.com/docs",
+      status: FetchStatus.SUCCESS,
+    });
+
+    await strategy.scrape(options, progressCallback);
+
+    const docCall = progressCallback.mock.calls.find((call) => call[0].result);
+    expect(docCall).toBeDefined();
+    expect(docCall![0].currentUrl).toBe("https://example.com/docs#/guide");
+    expect(docCall![0].result?.url).toBe("https://example.com/docs#/guide");
+  });
+
+  it("should preserve the requested hash across canonical trailing-slash redirects", async () => {
+    const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
+    options.url = "https://example.com/docs#/guide";
+    options.preserveHashes = true;
+
+    mockFetchFn.mockResolvedValue({
+      content:
+        "<html><head><title>Guide</title></head><body><h1>Guide</h1></body></html>",
+      mimeType: "text/html",
+      source: "https://example.com/docs/",
+      status: FetchStatus.SUCCESS,
+    });
+
+    await strategy.scrape(options, progressCallback);
+
+    const docCall = progressCallback.mock.calls.find((call) => call[0].result);
+    expect(docCall).toBeDefined();
+    expect(docCall![0].currentUrl).toBe("https://example.com/docs/#/guide");
+    expect(docCall![0].result?.url).toBe("https://example.com/docs/#/guide");
+  });
+
   describe("pipeline selection", () => {
     it("should process HTML content through HtmlPipeline", async () => {
       const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();

--- a/src/scraper/strategies/WebScraperStrategy.ts
+++ b/src/scraper/strategies/WebScraperStrategy.ts
@@ -46,6 +46,31 @@ export class WebScraperStrategy extends BaseScraperStrategy {
     }
   }
 
+  private restorePreservedHash(requestedUrl: string, actualUrl: string): string {
+    if (!requestedUrl.includes("#")) {
+      return actualUrl;
+    }
+
+    try {
+      const requested = new URL(requestedUrl);
+      const actual = new URL(actualUrl);
+      const normalizePathname = (pathname: string): string =>
+        pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+      if (
+        requested.origin === actual.origin &&
+        normalizePathname(requested.pathname) === normalizePathname(actual.pathname) &&
+        requested.search === actual.search
+      ) {
+        actual.hash = requested.hash;
+        return actual.toString();
+      }
+    } catch {
+      return actualUrl;
+    }
+
+    return actualUrl;
+  }
+
   // Removed custom isInScope logic; using shared scope utility for consistent behavior
 
   /**
@@ -87,6 +112,9 @@ export class WebScraperStrategy extends BaseScraperStrategy {
 
       // Use AutoDetectFetcher which handles fallbacks automatically
       const rawContent: RawContent = await this.fetcher.fetch(url, fetchOptions);
+      const effectiveSource = options.preserveHashes
+        ? this.restorePreservedHash(url, rawContent.source)
+        : rawContent.source;
 
       logger.debug(
         `Fetch result for ${url}: status=${rawContent.status}, etag=${rawContent.etag || "none"}`,
@@ -96,7 +124,7 @@ export class WebScraperStrategy extends BaseScraperStrategy {
       // Use the final URL from rawContent.source (which may differ due to redirects)
       if (rawContent.status !== FetchStatus.SUCCESS) {
         logger.debug(`Skipping pipeline for ${url} due to status: ${rawContent.status}`);
-        return { url: rawContent.source, links: [], status: rawContent.status };
+        return { url: effectiveSource, links: [], status: rawContent.status };
       }
 
       // --- Start Pipeline Processing ---
@@ -109,7 +137,11 @@ export class WebScraperStrategy extends BaseScraperStrategy {
           logger.debug(
             `Selected ${pipeline.constructor.name} for content type "${rawContent.mimeType}" (${url})`,
           );
-          processed = await pipeline.process(rawContent, options, this.fetcher);
+          processed = await pipeline.process(
+            { ...rawContent, source: effectiveSource },
+            options,
+            this.fetcher,
+          );
           break;
         }
       }
@@ -119,7 +151,7 @@ export class WebScraperStrategy extends BaseScraperStrategy {
         logger.warn(
           `⚠️  Unsupported content type "${rawContent.mimeType}" for URL ${url}. Skipping processing.`,
         );
-        return { url: rawContent.source, links: [], status: FetchStatus.SUCCESS };
+        return { url: effectiveSource, links: [], status: FetchStatus.SUCCESS };
       }
 
       // Log errors from pipeline
@@ -133,7 +165,7 @@ export class WebScraperStrategy extends BaseScraperStrategy {
           `⚠️  No processable content found for ${url} after pipeline execution.`,
         );
         return {
-          url: rawContent.source,
+          url: effectiveSource,
           links: processed.links,
           status: FetchStatus.SUCCESS,
         };
@@ -141,7 +173,7 @@ export class WebScraperStrategy extends BaseScraperStrategy {
 
       // Update canonical base URL from the first page's final URL (after redirects)
       if (item.depth === 0) {
-        this.canonicalBaseUrl = new URL(rawContent.source);
+        this.canonicalBaseUrl = new URL(effectiveSource);
       }
 
       const filteredLinks =
@@ -170,7 +202,7 @@ export class WebScraperStrategy extends BaseScraperStrategy {
         }) ?? [];
 
       return {
-        url: rawContent.source,
+        url: effectiveSource,
         etag: rawContent.etag,
         lastModified: rawContent.lastModified,
         sourceContentType: rawContent.mimeType,

--- a/src/scraper/types.ts
+++ b/src/scraper/types.ts
@@ -71,6 +71,8 @@ export interface ScraperOptions {
   followRedirects?: boolean;
   maxConcurrency?: number;
   ignoreErrors?: boolean;
+  /** Preserve URL hash fragments for hash-routed SPAs instead of treating them as anchors. */
+  preserveHashes?: boolean;
   /** CSS selectors for elements to exclude during HTML processing */
   excludeSelectors?: string[];
   /**

--- a/src/store/DocumentManagementService.test.ts
+++ b/src/store/DocumentManagementService.test.ts
@@ -972,6 +972,10 @@ describe("DocumentManagementService", () => {
           ],
         ]);
         mockStore.queryLibraryVersions.mockResolvedValue(enrichedMap);
+        mockStore.getScraperOptions.mockResolvedValue({
+          sourceUrl: "https://ex/libStatus/1.0.0",
+          options: { preserveHashes: true },
+        });
 
         const result = await docService.listLibraries();
         const lib = result.find((r) => r.library === "libStatus");
@@ -981,6 +985,7 @@ describe("DocumentManagementService", () => {
         );
         expect(byVer["1.0.0"]).toMatchObject({
           status: "completed",
+          preserveHashes: true,
           // progress omitted for completed
         });
         expect(byVer["1.1.0"]).toMatchObject({
@@ -1041,6 +1046,7 @@ describe("DocumentManagementService", () => {
           ],
         ]);
         mockStore.queryLibraryVersions.mockResolvedValue(enrichedMap);
+        mockStore.getScraperOptions.mockResolvedValue(null);
         const result = await docService.listLibraries();
         const lib = result.find((r) => r.library === "libActive");
         expect(lib).toBeTruthy();

--- a/src/store/DocumentManagementService.ts
+++ b/src/store/DocumentManagementService.ts
@@ -167,9 +167,10 @@ export class DocumentManagementService {
     const libMap = await this.store.queryLibraryVersions();
     const summaries: LibrarySummary[] = [];
     for (const [library, versions] of libMap) {
-      const vs = versions.map(
-        (v) =>
-          ({
+      const vs = await Promise.all(
+        versions.map(async (v) => {
+          const scraperOptions = await this.store.getScraperOptions(v.versionId);
+          return {
             id: v.versionId,
             ref: { library, version: v.version },
             status: v.status as VersionStatus,
@@ -181,7 +182,9 @@ export class DocumentManagementService {
             counts: { documents: v.documentCount, uniqueUrls: v.uniqueUrlCount },
             indexedAt: v.indexedAt,
             sourceUrl: v.sourceUrl ?? undefined,
-          }) satisfies VersionSummary,
+            preserveHashes: scraperOptions?.options.preserveHashes,
+          } satisfies VersionSummary;
+        }),
       );
       summaries.push({ library, versions: vs });
     }

--- a/src/store/DocumentStore.test.ts
+++ b/src/store/DocumentStore.test.ts
@@ -572,6 +572,7 @@ describe("DocumentStore - With Embeddings", () => {
         maxPages: 100,
         scope: "subpages" as const,
         followRedirects: true,
+        preserveHashes: true,
       };
 
       await store.storeScraperOptions(versionId, scraperOptions);
@@ -581,6 +582,7 @@ describe("DocumentStore - With Embeddings", () => {
       expect(retrieved?.options.maxDepth).toBe(3);
       expect(retrieved?.options.maxPages).toBe(100);
       expect(retrieved?.options.scope).toBe("subpages");
+      expect(retrieved?.options.preserveHashes).toBe(true);
     });
   });
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -115,6 +115,7 @@ export interface VersionScraperOptions {
   excludePatterns?: string[];
 
   // Processing options
+  preserveHashes?: boolean;
   scrapeMode?: ScrapeMode;
   headers?: Record<string, string>;
 }
@@ -167,6 +168,7 @@ export interface VersionSummary {
   counts: { documents: number; uniqueUrls: number };
   indexedAt: string | null; // ISO 8601
   sourceUrl?: string | null;
+  preserveHashes?: boolean;
 }
 
 /**

--- a/src/tools/ListLibrariesTool.test.ts
+++ b/src/tools/ListLibrariesTool.test.ts
@@ -43,6 +43,7 @@ describe("ListLibrariesTool", () => {
       counts: { documents: docs, uniqueUrls: urls },
       indexedAt,
       sourceUrl: null,
+      preserveHashes: version === "18.2.0",
     });
     const mockRawLibraries = [
       {
@@ -81,20 +82,24 @@ describe("ListLibrariesTool", () => {
           name: "react",
           versions: [
             {
+              id: expect.any(Number),
               version: "18.2.0",
               documentCount: 150,
               uniqueUrlCount: 50,
               indexedAt: "2024-01-10T10:00:00.000Z",
               status: "completed",
               sourceUrl: null,
+              preserveHashes: true,
             },
             {
+              id: expect.any(Number),
               version: "17.0.1",
               documentCount: 120,
               uniqueUrlCount: 45,
               indexedAt: "2023-05-15T12:30:00.000Z",
               status: "completed",
               sourceUrl: null,
+              preserveHashes: false,
             },
           ],
         },
@@ -102,12 +107,14 @@ describe("ListLibrariesTool", () => {
           name: "vue",
           versions: [
             {
+              id: expect.any(Number),
               version: "3.2.0",
               documentCount: 200,
               uniqueUrlCount: 70,
               indexedAt: "2024-02-20T08:00:00.000Z",
               status: "completed",
               sourceUrl: null,
+              preserveHashes: false,
             },
           ],
         },
@@ -115,12 +122,14 @@ describe("ListLibrariesTool", () => {
           name: "old-lib",
           versions: [
             {
+              id: expect.any(Number),
               version: "1.0.0",
               documentCount: 10,
               uniqueUrlCount: 5,
               indexedAt: null,
               status: "completed",
               sourceUrl: null,
+              preserveHashes: false,
             },
           ],
         },
@@ -128,12 +137,14 @@ describe("ListLibrariesTool", () => {
           name: "unversioned-only",
           versions: [
             {
+              id: expect.any(Number),
               version: "",
               documentCount: 1,
               uniqueUrlCount: 1,
               indexedAt: "2024-04-01T00:00:00.000Z",
               status: "completed",
               sourceUrl: null,
+              preserveHashes: false,
             },
           ],
         },
@@ -141,20 +152,24 @@ describe("ListLibrariesTool", () => {
           name: "mixed-versions",
           versions: [
             {
+              id: expect.any(Number),
               version: "",
               documentCount: 2,
               uniqueUrlCount: 1,
               indexedAt: "2024-04-03T00:00:00.000Z",
               status: "completed",
               sourceUrl: null,
+              preserveHashes: false,
             },
             {
+              id: expect.any(Number),
               version: "1.0.0",
               documentCount: 5,
               uniqueUrlCount: 2,
               indexedAt: "2024-04-02T00:00:00.000Z",
               status: "completed",
               sourceUrl: null,
+              preserveHashes: false,
             },
           ],
         },

--- a/src/tools/ListLibrariesTool.ts
+++ b/src/tools/ListLibrariesTool.ts
@@ -5,6 +5,7 @@ import type { VersionStatus, VersionSummary } from "../store/types";
 export interface LibraryInfo {
   name: string;
   versions: Array<{
+    id: number;
     version: string;
     documentCount: number;
     uniqueUrlCount: number;
@@ -13,6 +14,7 @@ export interface LibraryInfo {
     // Progress is omitted for COMPLETED versions to reduce noise
     progress?: { pages: number; maxPages: number };
     sourceUrl?: string | null;
+    preserveHashes?: boolean;
   }>;
 }
 
@@ -39,6 +41,7 @@ export class ListLibrariesTool {
     const libraries: LibraryInfo[] = rawLibraries.map(({ library, versions }) => ({
       name: library,
       versions: versions.map((v: VersionSummary) => ({
+        id: v.id,
         version: v.ref.version,
         documentCount: v.counts.documents,
         uniqueUrlCount: v.counts.uniqueUrls,
@@ -46,6 +49,7 @@ export class ListLibrariesTool {
         status: v.status,
         ...(v.progress ? { progress: v.progress } : undefined),
         sourceUrl: v.sourceUrl,
+        preserveHashes: v.preserveHashes,
       })),
     }));
 

--- a/src/tools/RefreshVersionTool.ts
+++ b/src/tools/RefreshVersionTool.ts
@@ -6,6 +6,7 @@ import { ValidationError } from "./errors";
 export interface RefreshVersionToolOptions {
   library: string;
   version?: string | null; // Make version optional
+  preserveHashes?: boolean;
   /** If false, returns jobId immediately without waiting. Defaults to true. */
   waitForCompletion?: boolean;
 }
@@ -30,7 +31,7 @@ export class RefreshVersionTool {
   }
 
   async execute(options: RefreshVersionToolOptions): Promise<RefreshExecuteResult> {
-    const { library, version, waitForCompletion = true } = options;
+    const { library, version, preserveHashes, waitForCompletion = true } = options;
 
     let internalVersion: string;
     const partialVersionRegex = /^\d+(\.\d+)?$/; // Matches '1' or '1.2'
@@ -68,7 +69,9 @@ export class RefreshVersionTool {
     const refreshVersion: string | null = internalVersion === "" ? null : internalVersion;
 
     // Enqueue the refresh job using the injected pipeline
-    const jobId = await pipeline.enqueueRefreshJob(library, refreshVersion);
+    const jobId = await pipeline.enqueueRefreshJob(library, refreshVersion, {
+      preserveHashes,
+    });
 
     // Conditionally wait for completion
     if (waitForCompletion) {

--- a/src/tools/ScrapeTool.test.ts
+++ b/src/tools/ScrapeTool.test.ts
@@ -196,4 +196,23 @@ describe("ScrapeTool", () => {
       }),
     );
   });
+
+  it("should pass preserveHashes to the pipeline manager", async () => {
+    const options: ScrapeToolOptions = {
+      ...getBaseOptions("2.0.0"),
+      options: {
+        preserveHashes: true,
+      },
+    };
+
+    await scrapeTool.execute(options);
+
+    expect(mockManagerInstance.enqueueScrapeJob).toHaveBeenCalledWith(
+      "test-lib",
+      "2.0.0",
+      expect.objectContaining({
+        preserveHashes: true,
+      }),
+    );
+  });
 });

--- a/src/tools/ScrapeTool.ts
+++ b/src/tools/ScrapeTool.ts
@@ -47,6 +47,8 @@ export interface ScrapeToolOptions {
      * Regex patterns must be wrapped in slashes, e.g. /pattern/.
      */
     excludePatterns?: string[];
+    /** Preserve URL hash fragments for hash-routed SPA documentation sites. */
+    preserveHashes?: boolean;
     /**
      * Custom HTTP headers to send with each request (e.g., for authentication).
      * Keys are header names, values are header values.
@@ -149,6 +151,7 @@ export class ScrapeTool {
       scrapeMode: scraperOptions?.scrapeMode ?? ScrapeMode.Auto, // Pass scrapeMode enum
       includePatterns: scraperOptions?.includePatterns,
       excludePatterns: scraperOptions?.excludePatterns,
+      preserveHashes: scraperOptions?.preserveHashes,
       headers: scraperOptions?.headers, // <-- propagate headers
       clean: scraperOptions?.clean, // <-- propagate clean option
     });

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -55,6 +55,7 @@ export const DEFAULT_CONFIG = {
     maxPages: 1000,
     maxDepth: 3,
     maxConcurrency: 3,
+    preserveHashes: false,
     pageTimeoutMs: 5000,
     browserTimeoutMs: 30_000,
     fetcher: {
@@ -147,6 +148,7 @@ export const AppConfigSchema = z.object({
         .number()
         .int()
         .default(DEFAULT_CONFIG.scraper.maxConcurrency),
+      preserveHashes: envBoolean.default(DEFAULT_CONFIG.scraper.preserveHashes),
       pageTimeoutMs: z.coerce
         .number()
         .int()

--- a/src/web/components/LibraryDetailCard.tsx
+++ b/src/web/components/LibraryDetailCard.tsx
@@ -62,6 +62,7 @@ const LibraryDetailCard = ({ library }: LibraryDetailCardProps) => {
               },
               indexedAt: v.indexedAt,
               sourceUrl: v.sourceUrl ?? undefined,
+              preserveHashes: v.preserveHashes,
             };
             return (
               <VersionDetailsRow

--- a/src/web/components/ScrapeFormContent.tsx
+++ b/src/web/components/ScrapeFormContent.tsx
@@ -55,7 +55,8 @@ const ScrapeFormContent = ({
   const scrapeModeValue = initialValues?.scrapeMode || ScrapeMode.Auto;
   const followRedirectsValue = initialValues?.followRedirects ?? true;
   const ignoreErrorsValue = initialValues?.ignoreErrors ?? true;
-  const preserveHashesValue = initialValues?.preserveHashes ?? false;
+  const preserveHashesValue =
+    initialValues?.preserveHashes ?? scraperConfig?.preserveHashes ?? false;
 
   // Format exclude patterns - use initial values if provided, otherwise use defaults
   const excludePatternsText =

--- a/src/web/components/ScrapeFormContent.tsx
+++ b/src/web/components/ScrapeFormContent.tsx
@@ -19,6 +19,7 @@ export interface ScrapeFormInitialValues {
   headers?: Array<{ name: string; value: string }>;
   followRedirects?: boolean;
   ignoreErrors?: boolean;
+  preserveHashes?: boolean;
 }
 
 interface ScrapeFormContentProps {
@@ -54,6 +55,7 @@ const ScrapeFormContent = ({
   const scrapeModeValue = initialValues?.scrapeMode || ScrapeMode.Auto;
   const followRedirectsValue = initialValues?.followRedirects ?? true;
   const ignoreErrorsValue = initialValues?.ignoreErrors ?? true;
+  const preserveHashesValue = initialValues?.preserveHashes ?? false;
 
   // Format exclude patterns - use initial values if provided, otherwise use defaults
   const excludePatternsText =
@@ -247,9 +249,10 @@ const ScrapeFormContent = ({
               scopeValue !== "subpages" ||
               includePatternsValue ||
               excludePatternsText ||
-              scrapeModeValue !== ScrapeMode.Auto)
-              ? "true"
-              : "false"
+              scrapeModeValue !== ScrapeMode.Auto ||
+              preserveHashesValue)
+               ? "true"
+               : "false"
           }
           x-data="{ open: false }"
           x-init="open = $el.dataset.shouldOpen === 'true'"
@@ -460,7 +463,23 @@ const ScrapeFormContent = ({
                 >
                   Playwright
                 </option>
-              </select>
+                </select>
+              </div>
+            <div class="flex items-center">
+              <input
+                id="preserveHashes"
+                name="preserveHashes"
+                type="checkbox"
+                checked={preserveHashesValue}
+                class="h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700"
+              />
+              <label
+                for="preserveHashes"
+                class="ml-1 block text-sm text-gray-900 dark:text-gray-300"
+              >
+                Preserve Hash Routes
+              </label>
+              <Tooltip text="Enable this for documentation sites that use hash fragments as client-side routes rather than same-page anchors." />
             </div>
             <div>
               <div class="flex items-center mb-1">

--- a/src/web/components/VersionDetailsRow.tsx
+++ b/src/web/components/VersionDetailsRow.tsx
@@ -31,6 +31,7 @@ const VersionDetailsRow = ({
   const versionLabel = version.ref.version || "Latest";
   // Use empty string for latest version in param and rowId
   const versionParam = version.ref.version || "";
+  const preserveHashes = version.preserveHashes ?? false;
 
   // Sanitize both libraryName and versionParam for valid CSS selector
   const sanitizedLibraryName = libraryName.replace(/[^a-zA-Z0-9-_]/g, "-");
@@ -137,6 +138,7 @@ const VersionDetailsRow = ({
                 hx-post={`/web/libraries/${encodeURIComponent(libraryName)}/versions/${encodeURIComponent(versionParam)}/refresh`}
                 hx-swap="none"
                 hx-trigger="trigger-refresh"
+                hx-vals={JSON.stringify({ preserveHashes })}
               >
                 <svg
                   class="w-4 h-4"

--- a/src/web/routes/jobs/new.tsx
+++ b/src/web/routes/jobs/new.tsx
@@ -50,6 +50,7 @@ export function registerNewJobRoutes(
           maxDepth?: string;
           scope?: "subpages" | "hostname" | "domain";
           scrapeMode?: ScrapeMode;
+          preserveHashes?: "on" | undefined;
           followRedirects?: "on" | undefined; // Checkbox value is 'on' if checked
           ignoreErrors?: "on" | undefined;
           includePatterns?: string;
@@ -126,6 +127,7 @@ export function registerNewJobRoutes(
               : undefined,
             scope: body.scope,
             scrapeMode: body.scrapeMode,
+            preserveHashes: body.preserveHashes === "on",
             // Checkboxes send 'on' when checked, otherwise undefined
             followRedirects: body.followRedirects === "on",
             ignoreErrors: body.ignoreErrors === "on",

--- a/src/web/routes/libraries/detail.tsx
+++ b/src/web/routes/libraries/detail.tsx
@@ -175,6 +175,7 @@ export function registerLibraryDetailRoutes(
                 },
                 indexedAt: v.indexedAt,
                 sourceUrl: v.sourceUrl ?? undefined,
+                preserveHashes: v.preserveHashes,
               };
               return (
                 <VersionDetailsRow
@@ -237,6 +238,7 @@ export function registerLibraryDetailRoutes(
           headers?: Array<{ name: string; value: string }>;
           followRedirects?: boolean;
           ignoreErrors?: boolean;
+          preserveHashes?: boolean;
         } = {
           library: libraryName,
         };
@@ -276,6 +278,7 @@ export function registerLibraryDetailRoutes(
                     : undefined,
                   followRedirects: opts.followRedirects,
                   ignoreErrors: opts.ignoreErrors,
+                  preserveHashes: opts.preserveHashes,
                 };
               }
             }

--- a/src/web/routes/libraries/list.tsx
+++ b/src/web/routes/libraries/list.tsx
@@ -1,4 +1,4 @@
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyRequest } from "fastify";
 import type { ListLibrariesTool } from "../../../tools/ListLibrariesTool";
 import type { RefreshVersionTool } from "../../../tools/RefreshVersionTool";
 import { RemoveTool } from "../../../tools";
@@ -66,19 +66,36 @@ export function registerLibrariesRoutes(
   );
 
   // POST route for refreshing a version
-  server.post<{ Params: { libraryName: string; versionParam: string } }>(
+  server.post<{
+    Params: { libraryName: string; versionParam: string };
+    Body: { preserveHashes?: boolean | "true" | "false" | undefined };
+  }>(
     "/web/libraries/:libraryName/versions/:versionParam/refresh",
-    async (request, reply) => {
+    async (
+      request: FastifyRequest<{
+        Params: { libraryName: string; versionParam: string };
+        Body: { preserveHashes?: boolean | "true" | "false" | undefined };
+      }>,
+      reply,
+    ) => {
       const { libraryName, versionParam } = request.params;
       const version =
         versionParam === "latest" || versionParam === ""
           ? undefined
           : versionParam;
+      const preserveHashes =
+        request.body?.preserveHashes === true || request.body?.preserveHashes === "true"
+          ? true
+          : request.body?.preserveHashes === false ||
+              request.body?.preserveHashes === "false"
+            ? false
+            : undefined;
       try {
         // Start refresh without waiting for completion
         await refreshVersionTool.execute({
           library: libraryName,
           version,
+          preserveHashes,
           waitForCompletion: false,
         });
         // Show toast notification via HX-Trigger


### PR DESCRIPTION
## Summary
- add explicit `preserveHashes` support across CLI, MCP, web UI, pipeline, refresh, and stored scraper options for hash-routed SPA docs sites
- preserve hash fragments in crawl identity and page storage while keeping normal anchor-link collapsing as the default behavior
- upgrade `fetch` jobs to `playwright` when hash preservation is enabled, and cover refresh reuse/override plus redirect/interception edge cases in tests

## Validation
- npm run typecheck
- npm run lint
- npx vitest run src/tools/ScrapeTool.test.ts src/cli/commands/scrape.test.ts src/cli/commands/refresh.test.ts src/pipeline/PipelineManager.test.ts src/scraper/strategies/BaseScraperStrategy.test.ts src/scraper/strategies/WebScraperStrategy.test.ts src/scraper/middleware/HtmlPlaywrightMiddleware.test.ts src/mcp/mcpServer.test.ts
- npx vitest run src/store/DocumentStore.test.ts src/store/DocumentManagementService.test.ts src/tools/ListLibrariesTool.test.ts