### PR TITLE
fix(store): use vec0 partition columns directly in search queries

### DIFF
--- a/src/store/DocumentStore.ts
+++ b/src/store/DocumentStore.ts
@@ -1723,6 +1723,19 @@ export class DocumentStore {
       const ftsQuery = this.escapeFtsQuery(query);
       const normalizedVersion = version.toLowerCase();
 
+      // Resolve library/version to IDs upfront so we can pass them directly
+      // to the vec0 partition columns and avoid full-table scans.
+      const versionRow = this.statements.getVersionId.get(
+        library.toLowerCase(),
+        normalizedVersion,
+      ) as { id: number; library_id: number } | undefined;
+
+      if (!versionRow) {
+        return [];
+      }
+
+      const { id: versionId, library_id: libraryId } = versionRow;
+
       if (this.isVectorSearchEnabled) {
         // Hybrid search: vector + full-text search with RRF ranking
         const rawEmbedding = await this.embeddings.embedQuery(query);
@@ -1740,12 +1753,8 @@ export class DocumentStore {
               dv.rowid as id,
               dv.distance as vec_distance
             FROM documents_vec dv
-            JOIN documents d ON dv.rowid = d.id
-            JOIN pages p ON d.page_id = p.id
-            JOIN versions v ON p.version_id = v.id
-            JOIN libraries l ON v.library_id = l.id
-            WHERE l.name = ?
-              AND COALESCE(v.name, '') = COALESCE(?, '')
+            WHERE dv.library_id = ?
+              AND dv.version_id = ?
               AND dv.embedding MATCH ?
               AND dv.k = ?
             ORDER BY dv.distance
@@ -1757,10 +1766,7 @@ export class DocumentStore {
             FROM documents_fts f
             JOIN documents d ON f.rowid = d.id
             JOIN pages p ON d.page_id = p.id
-            JOIN versions v ON p.version_id = v.id
-            JOIN libraries l ON v.library_id = l.id
-            WHERE l.name = ?
-              AND COALESCE(v.name, '') = COALESCE(?, '')
+            WHERE p.version_id = ?
               AND documents_fts MATCH ?
             ORDER BY fts_score
             LIMIT ?
@@ -1787,12 +1793,11 @@ export class DocumentStore {
         `);
 
         const rawResults = stmt.all(
-          library.toLowerCase(),
-          normalizedVersion,
+          libraryId,
+          versionId,
           JSON.stringify(embedding),
           vectorSearchK,
-          library.toLowerCase(),
-          normalizedVersion,
+          versionId,
           ftsQuery,
           overfetchLimit,
         ) as RawSearchResult[];
@@ -1835,10 +1840,7 @@ export class DocumentStore {
           FROM documents_fts f
           JOIN documents d ON f.rowid = d.id
           JOIN pages p ON d.page_id = p.id
-          JOIN versions v ON p.version_id = v.id
-          JOIN libraries l ON v.library_id = l.id
-          WHERE l.name = ?
-            AND COALESCE(v.name, '') = COALESCE(?, '')
+          WHERE p.version_id = ?
             AND documents_fts MATCH ?
             AND NOT EXISTS (
               SELECT 1 FROM json_each(json_extract(d.metadata, '$.types')) je
@@ -1848,12 +1850,9 @@ export class DocumentStore {
           LIMIT ?
         `);
 
-        const rawResults = stmt.all(
-          library.toLowerCase(),
-          normalizedVersion,
-          ftsQuery,
-          limit,
-        ) as (RawSearchResult & { fts_score: number })[];
+        const rawResults = stmt.all(versionId, ftsQuery, limit) as (RawSearchResult & {
+          fts_score: number;
+        })[];
 
         // Assign FTS ranks based on order (best score = rank 1)
         return rawResults.map((row, index) => {


### PR DESCRIPTION
## Problem

We're using this tool to index both documentation and code repositories, so we have a large data set and a large set of libraries. The hybrid search query in `findByContent()` filters `documents_vec` by library/version through 4 JOINs:

```sql
FROM documents_vec dv
  JOIN documents d ON dv.rowid = d.id
  JOIN pages p ON d.page_id = p.id
  JOIN versions v ON p.version_id = v.id
  JOIN libraries l ON v.library_id = l.id
WHERE l.name = ?
  AND COALESCE(v.name, '') = COALESCE(?, '')
  AND dv.embedding MATCH ?
```

`sqlite-vec`'s `vec0` virtual table supports partition pruning via `library_id` and `version_id` columns, but only when they appear as **direct equality constraints** in the WHERE clause on the virtual table itself. The query planner cannot see through JOINs to apply partition pruning, so every search does a brute-force scan of **all** vectors regardless of which library was requested.

At small scale this is unnoticeable. At 451K vectors (45GB database across ~30 indexed repositories), search queries hang indefinitely — the full brute-force scan takes longer than any reasonable timeout.

## Fix

Resolve library/version names to their IDs upfront using the existing `getVersionId` prepared statement (read-only, not `resolveVersionId` which inserts), then pass `library_id` and `version_id` directly to the vec0 WHERE clause:

```sql
FROM documents_vec dv
WHERE dv.library_id = ?
  AND dv.version_id = ?
  AND dv.embedding MATCH ?
```

This enables sqlite-vec partition pruning — only vectors in the requested library's partition are scanned (typically 5-15K vectors instead of 451K).

The same optimization is applied to the FTS CTEs for consistency, replacing JOINs through `versions`/`libraries` with a direct `p.version_id = ?` filter.

## Impact

- Search goes from hanging (60s+ timeout) to sub-second on large databases
- No change in search results — same vectors, same ranking, just scanned efficiently
- FTS-only fallback also benefits from fewer JOINs
- All 57 existing tests pass

## Test plan

- [x] `npx vitest run src/store/DocumentStore.test.ts` — 57 tests pass