### PR TITLE
Add transformers.js support for offline local embeddings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ public/assets/
 !*.env.example
 *.code-workspace
 .tsbuildinfo
+mise.toml
 .claude/worktrees/
 .opencode/package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,17 +55,19 @@ COPY --from=builder /app/dist ./dist
 # Set data directory for the container
 ENV DOCS_MCP_STORE_PATH=/data
 ENV XDG_CONFIG_HOME=/config
+ENV TRANSFORMERS_CACHE=/models
 
 # Create the writable runtime directories and hand ownership to the
 # unprivileged `node` user that ships with the base image (uid 1000).
 # `/app` is intentionally left root-owned so the runtime user cannot
 # tamper with code or `node_modules` if it is ever compromised.
-RUN mkdir -p /data /config \
-  && chown node:node /data /config
+RUN mkdir -p /data /config /models \
+  && chown node:node /data /config /models
 
 # Define volumes
 VOLUME /data
 VOLUME /config
+VOLUME /models
 
 # Expose the default port of the application
 EXPOSE 6280

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ docker run --rm \
   --protocol http --host 0.0.0.0 --port 6280
 ```
 
+**Note:** When using Transformers.js embeddings, models are cached inside the container in /models. Mount the volume to persist the models cache:
+```bash
+-v docs-mcp-models:/models
+```
+
 </details>
 
 ### 🧠 Configure Embedding Model (Recommended)

--- a/docs/concepts/data-storage.md
+++ b/docs/concepts/data-storage.md
@@ -241,7 +241,7 @@ Handles document lifecycle operations with normalized schema access.
 
 Embeddings stored as BLOB in documents table:
 
-- 1536-dimensional vectors by default (configurable via `embeddings.vectorDimension`)
+- 1536-dimensional vectors by default or model-specific for `transformers:` models, e.g., 384 for `BAAI/bge-small-en-v1.5`, (configurable via `embeddings.vectorDimension`)
 - Provider-agnostic binary serialization
 - NULL handling for documents without embeddings
 - Direct storage eliminates need for separate vector table

--- a/docs/guides/embedding-models.md
+++ b/docs/guides/embedding-models.md
@@ -14,6 +14,7 @@ If you leave the model empty but provide `OPENAI_API_KEY`, the server defaults t
 - `gemini:embedding-001` (Google Gemini)
 - `aws:amazon.titan-embed-text-v1` (AWS Bedrock)
 - `microsoft:text-embedding-ada-002` (Azure OpenAI)
+- `transformers:BAAI/bge-small-en-v1.5` (Local, offline via Transformers.js)
 - Or any OpenAI-compatible model name
 
 ## Provider Configuration
@@ -34,6 +35,7 @@ Provider credentials use the provider-specific environment variables listed belo
 | `AZURE_OPENAI_API_INSTANCE_NAME`   | Azure OpenAI instance name.                           |
 | `AZURE_OPENAI_API_DEPLOYMENT_NAME` | Azure OpenAI deployment name.                         |
 | `AZURE_OPENAI_API_VERSION`         | Azure OpenAI API version.                             |
+| `TRANSFORMERS_DEVICE`              | Device for Transformers.js (cpu or webgpu).           |
 
 ### Examples
 
@@ -114,6 +116,39 @@ DOCS_MCP_EMBEDDING_MODEL="microsoft:text-embedding-ada-002" \
 npx @arabold/docs-mcp-server@latest
 ```
 
+#### Transformers.js (Local, Offline)
+
+Run embeddings locally without any API keys or internet connection after initial model download. Uses ONNX runtime for CPU inference.
+
+```bash
+DOCS_MCP_EMBEDDING_MODEL="transformers:BAAI/bge-small-en-v1.5" \
+npx @arabold/docs-mcp-server@latest
+```
+
+**Optional:** Enable GPU acceleration with WebGPU (requires compatible hardware):
+
+```bash
+TRANSFORMERS_DEVICE="webgpu" \
+DOCS_MCP_EMBEDDING_MODEL="transformers:BAAI/bge-small-en-v1.5" \
+npx @arabold/docs-mcp-server@latest
+```
+
+#### Docker Usage
+
+When running in Docker, the model is downloaded on first use and cached inside the container at `/models`. The cache persists across `docker restart` but is lost when the container is recreated.
+
+To persist the model cache across container recreation, mount the volume:
+
+```bash
+docker run --rm \
+  -v docs-mcp-data:/data \
+  -v docs-mcp-config:/config \
+  -v docs-mcp-models:/models \
+  -e DOCS_MCP_EMBEDDING_MODEL="transformers:BAAI/bge-small-en-v1.5" \
+  -p 6280:6280 \
+  ghcr.io/arabold/docs-mcp-server:latest
+```
+
 ## Changing the Embedding Model
 
 When you change the embedding model or vector dimension after initial setup, existing embedding vectors become semantically incompatible with the new configuration. The server detects this automatically by tracking the active model identity in a metadata table.
@@ -145,4 +180,4 @@ When you change the embedding model or vector dimension after initial setup, exi
 
 ### Vector Dimension Override
 
-The vector dimension defaults to the model's native dimension (e.g., 1536 for `text-embedding-3-small`). You can override it with `embeddings.vectorDimension` in the config file or `DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION` as an environment variable. The value must be a positive integer (minimum 1).
+The vector dimension defaults to the model's native dimension (e.g., 1536 for `text-embedding-3-small`, 384 for `BAAI/bge-small-en-v1.5`). For Transformers.js models not from the list of known models, it is auto-detected via inference. For other providers, it is discovered by embedding a test string. You can override it with `embeddings.vectorDimension` in the config file or `DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION` as an environment variable. The value must be a positive integer (minimum 1).

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -369,7 +369,7 @@ Settings for the vector embedding generation.
 | `batchChars` | `50000` | Maximum total characters per embedding batch. |
 | `requestTimeoutMs` | `30000` | Timeout for each embedding API request (ms). |
 | `initTimeoutMs` | `30000` | Timeout for the initial test embedding during model initialization (ms). |
-| `vectorDimension` | `1536` | Dimension of the vector space. Must be a positive integer (minimum 1). Override with `DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION`. Changing this value triggers a model change confirmation on next startup. |
+| `vectorDimension` | `1536` (or model-specific for `transformers:` models) | Dimension of the vector space. Must be a positive integer (minimum 1). For Transformers.js models, the server auto-detects the model's native dimension (e.g., 384 for `bge-small-en-v1.5`). Override with `DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION`. Changing this value triggers a model change confirmation on next startup. |
 
 ### Search (`search`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@alpinejs/collapse": "^3.15.8",
         "@fastify/formbody": "^8.0.2",
         "@fastify/static": "^9.1.3",
+        "@huggingface/transformers": "^4.2.0",
         "@joplin/turndown-plugin-gfm": "^1.0.64",
         "@kitajs/html": "^4.2.13",
         "@kitajs/ts-html-plugin": "^4.1.4",
@@ -2049,6 +2050,499 @@
         "hono": "^4"
       }
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
+      "integrity": "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/tokenizers": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
+      "integrity": "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.2.0.tgz",
+      "integrity": "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.6",
+        "@huggingface/tokenizers": "^0.1.3",
+        "onnxruntime-node": "1.24.3",
+        "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
+        "sharp": "^0.34.5"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@inquirer/ansi": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
@@ -3516,6 +4010,69 @@
       "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.373.5.tgz",
       "integrity": "sha512-K7STCnRG/WBE1q0BwEkIcrJB5OqECaymsQj6Hp4Ntvaek4dqHkZGfp6hxwIPqQPjlOXwidwPLo+XGsn+CoZUyw==",
       "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "15.3.1",
@@ -5191,7 +5748,6 @@
       "version": "24.12.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
       "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -5212,7 +5768,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
@@ -6369,6 +6924,13 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
     },
     "node_modules/bottleneck": {
       "version": "2.19.5",
@@ -7825,7 +8387,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -7843,7 +8404,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -7892,6 +8452,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -8579,6 +9145,12 @@
         "benchmarks"
       ]
     },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
@@ -9236,6 +9808,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/flowbite": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/flowbite/-/flowbite-4.0.2.tgz",
@@ -9739,6 +10317,23 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
     "node_modules/global-directory": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz",
@@ -9759,7 +10354,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -9863,6 +10457,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
     "node_modules/handlebars": {
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
@@ -9912,7 +10512,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -11173,7 +11772,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/json-with-bigint": {
@@ -11910,6 +12508,12 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -12019,6 +12623,30 @@
       },
       "peerDependencies": {
         "marked": ">=1 <16"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/matcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -16507,7 +17135,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -16590,6 +17217,49 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
+      "integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.24.3"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.26.0-dev.20260416-b7804b056c",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
+      "integrity": "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.24.0-dev.20251116-b39e144322",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.24.0-dev.20251116-b39e144322",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
+      "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
+      "license": "MIT"
     },
     "node_modules/openai": {
       "version": "6.38.0",
@@ -17237,6 +17907,12 @@
         "pathe": "^2.0.3"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
     "node_modules/playwright": {
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
@@ -17434,6 +18110,30 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -17958,6 +18658,29 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/roarr/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/rollup": {
       "version": "4.60.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
@@ -18436,6 +19159,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
+    },
     "node_modules/semver-regex": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
@@ -18473,6 +19202,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/serve-static": {
@@ -18554,6 +19310,50 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@alpinejs/collapse": "^3.15.8",
     "@fastify/formbody": "^8.0.2",
     "@fastify/static": "^9.1.3",
+    "@huggingface/transformers": "^4.2.0",
     "@joplin/turndown-plugin-gfm": "^1.0.64",
     "@kitajs/html": "^4.2.13",
     "@kitajs/ts-html-plugin": "^4.1.4",

--- a/src/store/DocumentStore.transformers.test.ts
+++ b/src/store/DocumentStore.transformers.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for DocumentStore with Transformers.js embeddings.
+ * Tests the dimension-detection path specific to Transformers.js.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadConfig } from "../utils/config";
+import { DocumentStore } from "./DocumentStore";
+import { EmbeddingConfig } from "./embeddings/EmbeddingConfig";
+import { TransformersJSEmbeddings } from "./embeddings/TransformersJSEmbeddings";
+
+const appConfig = loadConfig();
+
+// Model without known dimensions - used for testing the getVectorDimension() path
+const UNKNOWN_DIMENSIONS_MODEL = "transformers:custom/unknown-transformers-model-xyz";
+
+// Model with known dimensions (384) in EmbeddingConfig
+const KNOWN_DIMENSIONS_MODEL = "transformers:sentence-transformers/all-MiniLM-L6-v2";
+
+// Module-level mock for TransformersJSEmbeddings
+const mockGetVectorDimension = vi.fn(async () => 384);
+const mockEmbedQuery = vi.fn(async (_text: string) => new Array(384).fill(0.001));
+const mockEmbedDocuments = vi.fn(async (_documents: string[]) => [
+  new Array(384).fill(0.001),
+]);
+
+vi.mock("./embeddings/TransformersJSEmbeddings", async () => {
+  const actual = await vi.importActual<
+    typeof import("./embeddings/TransformersJSEmbeddings")
+  >("./embeddings/TransformersJSEmbeddings");
+  return {
+    TransformersJSEmbeddings: class extends (actual as any).TransformersJSEmbeddings {
+      async getVectorDimension() {
+        return mockGetVectorDimension();
+      }
+      async embedQuery(text: string) {
+        return mockEmbedQuery(text);
+      }
+      async embedDocuments(documents: string[]) {
+        return mockEmbedDocuments(documents);
+      }
+    },
+  };
+});
+
+describe("DocumentStore - Transformers.js dimension detection (unknown dimensions)", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    EmbeddingConfig.resetInstance();
+
+    // Configure transformers provider with a model that has NO known dimensions
+    const embeddingConfig = EmbeddingConfig.parseEmbeddingConfig(
+      UNKNOWN_DIMENSIONS_MODEL,
+    );
+    appConfig.app.embeddingModel = embeddingConfig.modelSpec;
+  });
+
+  afterEach(async () => {
+    EmbeddingConfig.resetInstance();
+  });
+
+  it("should use Transformers.js getVectorDimension() for dimension detection", async () => {
+    const store = new DocumentStore(":memory:", appConfig);
+    await store.initialize();
+
+    // @ts-expect-error Accessing private property for testing
+    expect(store.modelDimension).toBe(384);
+    // @ts-expect-error Accessing private property for testing
+    expect(store.isVectorSearchEnabled).toBe(true);
+
+    // Verify getVectorDimension was called (indicating the transformers path was taken)
+    expect(mockGetVectorDimension).toHaveBeenCalled();
+
+    await store.shutdown();
+  });
+
+  it("should detect vector dimension before embedding documents", async () => {
+    const store = new DocumentStore(":memory:", appConfig);
+    await store.initialize();
+
+    // Verify getVectorDimension was called during initialization
+    expect(mockGetVectorDimension).toHaveBeenCalled();
+
+    await store.shutdown();
+  });
+
+  it("should return correct instance type", async () => {
+    const store = new DocumentStore(":memory:", appConfig);
+    await store.initialize();
+
+    // @ts-expect-error Accessing private property for testing
+    expect(store.embeddings).toBeInstanceOf(TransformersJSEmbeddings);
+
+    await store.shutdown();
+  });
+});
+
+describe("DocumentStore - Transformers.js with known dimensions", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    EmbeddingConfig.resetInstance();
+
+    // Configure transformers provider with a model that HAS known dimensions
+    const embeddingConfig = EmbeddingConfig.parseEmbeddingConfig(KNOWN_DIMENSIONS_MODEL);
+    appConfig.app.embeddingModel = embeddingConfig.modelSpec;
+  });
+
+  afterEach(async () => {
+    EmbeddingConfig.resetInstance();
+  });
+
+  it("should use known dimensions for dimension detection", async () => {
+    const store = new DocumentStore(":memory:", appConfig);
+    await store.initialize();
+
+    // @ts-expect-error Accessing private property for testing
+    expect(store.modelDimension).toBe(384);
+    // @ts-expect-error Accessing private property for testing
+    expect(store.isVectorSearchEnabled).toBe(true);
+
+    // Verify getVectorDimension was NOT called (known dimensions took priority)
+    expect(mockGetVectorDimension).not.toHaveBeenCalled();
+
+    await store.shutdown();
+  });
+
+  it("should persist transformers model identity in metadata", async () => {
+    const store = new DocumentStore(":memory:", appConfig);
+    await store.initialize();
+
+    // Verify metadata was persisted (dimension is the db dimension, not model dimension)
+    const metadata = store.getEmbeddingMetadata();
+    expect(metadata.model).toBe("transformers:sentence-transformers/all-MiniLM-L6-v2");
+    expect(metadata.dimension).toBe(String(appConfig.embeddings.vectorDimension));
+
+    await store.shutdown();
+  });
+
+  it("should work with different transformers model names", async () => {
+    // Update the model spec to use a different model
+    const embeddingConfig = EmbeddingConfig.parseEmbeddingConfig(KNOWN_DIMENSIONS_MODEL);
+    appConfig.app.embeddingModel = embeddingConfig.modelSpec;
+
+    const store = new DocumentStore(":memory:", appConfig);
+    await store.initialize();
+
+    // @ts-expect-error Accessing private property for testing
+    expect(store.modelDimension).toBe(384);
+
+    // Verify metadata was persisted with the new model
+    const metadata = store.getEmbeddingMetadata();
+    expect(metadata.model).toBe("transformers:sentence-transformers/all-MiniLM-L6-v2");
+
+    await store.shutdown();
+  });
+});

--- a/src/store/DocumentStore.ts
+++ b/src/store/DocumentStore.ts
@@ -14,6 +14,7 @@ import {
   UnsupportedProviderError,
 } from "./embeddings/EmbeddingFactory";
 import { FixedDimensionEmbeddings } from "./embeddings/FixedDimensionEmbeddings";
+import { TransformersJSEmbeddings } from "./embeddings/TransformersJSEmbeddings";
 import {
   ConnectionError,
   DimensionError,
@@ -634,6 +635,27 @@ export class DocumentStore {
       // Use known dimensions if available, otherwise detect via test query
       if (config.dimensions !== null) {
         this.modelDimension = config.dimensions;
+      } else if (this.embeddings instanceof TransformersJSEmbeddings) {
+        // For Transformers.js, use the built-in dimension detection with timeout
+        const dimensionPromise = this.embeddings.getVectorDimension();
+        let timeoutId: NodeJS.Timeout | undefined;
+        const timeoutPromise = new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => {
+            reject(
+              new Error(
+                `Embedding service connection timed out after ${this.embeddingInitTimeoutMs / 1000} seconds`,
+              ),
+            );
+          }, this.embeddingInitTimeoutMs);
+        });
+
+        try {
+          this.modelDimension = await Promise.race([dimensionPromise, timeoutPromise]);
+        } finally {
+          if (timeoutId !== undefined) {
+            clearTimeout(timeoutId);
+          }
+        }
       } else {
         // Fallback: determine the model's actual dimension by embedding a test string
         // Use a timeout to fail fast if the embedding service is unreachable

--- a/src/store/embeddings/EmbeddingConfig.test.ts
+++ b/src/store/embeddings/EmbeddingConfig.test.ts
@@ -215,6 +215,7 @@ describe("EmbeddingConfig", () => {
       "aws",
       "microsoft",
       "sagemaker",
+      "transformers",
     ];
 
     it("should accept all valid providers", () => {

--- a/src/store/embeddings/EmbeddingConfig.ts
+++ b/src/store/embeddings/EmbeddingConfig.ts
@@ -18,7 +18,8 @@ export type EmbeddingProvider =
   | "gemini"
   | "aws"
   | "microsoft"
-  | "sagemaker";
+  | "sagemaker"
+  | "transformers";
 
 /**
  * Embedding model configuration parsed from environment variables.
@@ -186,7 +187,7 @@ export class EmbeddingConfig {
     "intfloat/e5-base": 768,
     "sentence-transformers/static-similarity-mrl-multilingual-v1": 1024,
     "manu/sentence_croissant_alpha_v0.3": 2048,
-    "BAAI/bge-small-en-v1.5": 512,
+    "BAAI/bge-small-en-v1.5": 384,
     "thenlper/gte-small": 384,
     "sdadas/mmlw-e5-small": 384,
     "manu/sentence_croissant_alpha_v0.4": 2048,

--- a/src/store/embeddings/EmbeddingFactory.test.ts
+++ b/src/store/embeddings/EmbeddingFactory.test.ts
@@ -6,8 +6,13 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { loadConfig } from "../../utils/config";
 import { sanitizeEnvironment } from "../../utils/env";
 import { MissingCredentialsError } from "../errors";
-import { createEmbeddingModel, UnsupportedProviderError } from "./EmbeddingFactory";
+import {
+  areCredentialsAvailable,
+  createEmbeddingModel,
+  UnsupportedProviderError,
+} from "./EmbeddingFactory";
 import { FixedDimensionEmbeddings } from "./FixedDimensionEmbeddings";
+import { TransformersJSEmbeddings } from "./TransformersJSEmbeddings";
 
 // Suppress logger output during tests
 
@@ -207,6 +212,86 @@ describe("createEmbeddingModel", () => {
       if (clientConfig?.baseURL) {
         expect(clientConfig.baseURL).toBe("http://localhost:11434/v1");
       }
+    });
+  });
+
+  describe("transformers provider", () => {
+    test("should create TransformersJSEmbeddings with requested model", () => {
+      const model = createEmbeddingModel(
+        "transformers:sentence-transformers/all-MiniLM-L6-v2",
+        runtimeConfig,
+      );
+      expect(model).toBeInstanceOf(TransformersJSEmbeddings);
+      expect(model).toMatchObject({
+        modelName: "sentence-transformers/all-MiniLM-L6-v2",
+      });
+    });
+
+    test("should set device to webgpu when TRANSFORMERS_DEVICE is webgpu", () => {
+      vi.stubGlobal("process", {
+        env: {
+          TRANSFORMERS_DEVICE: "webgpu",
+          OPENAI_API_KEY: "test-openai-key",
+          GOOGLE_APPLICATION_CREDENTIALS: "credentials.json",
+          GOOGLE_API_KEY: "test-gemini-key",
+          BEDROCK_AWS_REGION: "us-east-1",
+          AWS_ACCESS_KEY_ID: "test-aws-key",
+          AWS_SECRET_ACCESS_KEY: "test-aws-secret",
+          AZURE_OPENAI_API_KEY: "test-azure-key",
+          AZURE_OPENAI_API_INSTANCE_NAME: "test-instance",
+          AZURE_OPENAI_API_DEPLOYMENT_NAME: "test-deployment",
+          AZURE_OPENAI_API_VERSION: "2024-02-01",
+        },
+      });
+
+      const model = createEmbeddingModel(
+        "transformers:BAAI/bge-small-en-v1.5",
+        runtimeConfig,
+      );
+      expect(model).toBeInstanceOf(TransformersJSEmbeddings);
+      expect(model).toMatchObject({
+        device: "webgpu",
+      });
+    });
+
+    test("should set device to cpu by default", () => {
+      vi.stubGlobal("process", {
+        env: {
+          OPENAI_API_KEY: "test-openai-key",
+          GOOGLE_APPLICATION_CREDENTIALS: "credentials.json",
+          GOOGLE_API_KEY: "test-gemini-key",
+          BEDROCK_AWS_REGION: "us-east-1",
+          AWS_ACCESS_KEY_ID: "test-aws-key",
+          AWS_SECRET_ACCESS_KEY: "test-aws-secret",
+          AZURE_OPENAI_API_KEY: "test-azure-key",
+          AZURE_OPENAI_API_INSTANCE_NAME: "test-instance",
+          AZURE_OPENAI_API_DEPLOYMENT_NAME: "test-deployment",
+          AZURE_OPENAI_API_VERSION: "2024-02-01",
+        },
+      });
+
+      const model = createEmbeddingModel(
+        "transformers:BAAI/bge-small-en-v1.5",
+        runtimeConfig,
+      );
+      expect(model).toBeInstanceOf(TransformersJSEmbeddings);
+      expect(model).toMatchObject({
+        device: "cpu",
+      });
+    });
+  });
+
+  describe("areCredentialsAvailable", () => {
+    test("should return true for transformers provider", () => {
+      expect(areCredentialsAvailable("transformers")).toBe(true);
+    });
+
+    test("should return true for transformers regardless of env vars", () => {
+      vi.stubGlobal("process", {
+        env: {},
+      });
+
+      expect(areCredentialsAvailable("transformers")).toBe(true);
     });
   });
 });

--- a/src/store/embeddings/EmbeddingFactory.ts
+++ b/src/store/embeddings/EmbeddingFactory.ts
@@ -11,10 +11,11 @@ import {
 import type { AppConfig } from "../../utils/config";
 import { MissingCredentialsError } from "../errors";
 import { FixedDimensionEmbeddings } from "./FixedDimensionEmbeddings";
+import { TransformersJSEmbeddings } from "./TransformersJSEmbeddings";
 
 /**
  * Supported embedding model providers. Each provider requires specific environment
- * variables to be set for API access.
+ * variables to be set for API access, except 'transformers' which runs locally.
  */
 export type EmbeddingProvider =
   | "openai"
@@ -22,7 +23,8 @@ export type EmbeddingProvider =
   | "gemini"
   | "aws"
   | "microsoft"
-  | "sagemaker";
+  | "sagemaker"
+  | "transformers";
 
 /**
  * Error thrown when an invalid or unsupported embedding provider is specified.
@@ -31,7 +33,7 @@ export class UnsupportedProviderError extends Error {
   constructor(provider: string) {
     super(
       `❌ Unsupported embedding provider: ${provider}\n` +
-        "   Supported providers: openai, vertex, gemini, aws, microsoft, sagemaker\n" +
+        "   Supported providers: openai, vertex, gemini, aws, microsoft, sagemaker, transformers\n" +
         "   See README.md for configuration options or run with --help for more details.",
     );
     this.name = "UnsupportedProviderError";
@@ -93,6 +95,10 @@ export function areCredentialsAvailable(provider: EmbeddingProvider): boolean {
       );
     }
 
+    case "transformers":
+      // Transformers.js runs locally - no credentials needed
+      return true;
+
     default:
       return false;
   }
@@ -110,6 +116,7 @@ export function areCredentialsAvailable(provider: EmbeddingProvider): boolean {
  * - Google GenAI (Gemini): GOOGLE_API_KEY
  * - AWS: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION (or BEDROCK_AWS_REGION)
  * - Microsoft: AZURE_OPENAI_API_KEY, AZURE_OPENAI_API_INSTANCE_NAME, AZURE_OPENAI_API_DEPLOYMENT_NAME, AZURE_OPENAI_API_VERSION
+ * - Transformers: No credentials required (runs locally via ONNX)
  *
  * @param providerAndModel - The provider and model name in the format "provider:model_name"
  *                          or just "model_name" for OpenAI models.
@@ -261,6 +268,18 @@ export function createEmbeddingModel(
         azureOpenAIApiDeploymentName: process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME,
         azureOpenAIApiVersion: process.env.AZURE_OPENAI_API_VERSION,
         deploymentName: model,
+      });
+    }
+
+    case "transformers": {
+      const device =
+        process.env.TRANSFORMERS_DEVICE?.toLowerCase() === "webgpu" ? "webgpu" : "cpu";
+
+      return new TransformersJSEmbeddings({
+        modelName: model,
+        device,
+        normalize: true,
+        stripNewLines: baseConfig.stripNewLines,
       });
     }
 

--- a/src/store/embeddings/TransformersJSEmbeddings.test.ts
+++ b/src/store/embeddings/TransformersJSEmbeddings.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { TransformersJSEmbeddings } from "./TransformersJSEmbeddings";
+
+// Mock the @huggingface/transformers pipeline
+vi.mock("@huggingface/transformers", async (importOriginal) => {
+  const original = await importOriginal();
+
+  const mockEncoder = async (
+    texts: string | string[],
+    _options: { pooling?: string; normalize?: boolean } = {},
+  ) => {
+    const docs = Array.isArray(texts) ? texts : [texts];
+    const dimension = 384;
+
+    // Create mock tensor data
+    const data = new Float32Array(docs.length * dimension);
+    for (let i = 0; i < data.length; i++) {
+      data[i] = Math.random() * 0.1;
+    }
+
+    return {
+      data,
+      dims: [docs.length, dimension],
+      tolist: () => Array.from(data),
+    };
+  };
+
+  const mockPipeline = vi.fn();
+  mockPipeline.mockResolvedValue(mockEncoder);
+
+  return {
+    ...(original as any),
+    pipeline: mockPipeline,
+    env: {},
+  };
+});
+
+describe("TransformersJSEmbeddings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.TRANSFORMERS_DEVICE;
+  });
+
+  test("should embed single query", async () => {
+    const embeddings = new TransformersJSEmbeddings({
+      modelName: "sentence-transformers/all-MiniLM-L6-v2",
+    });
+
+    const vector = await embeddings.embedQuery("Hello world");
+
+    expect(vector).toBeInstanceOf(Array);
+    expect(vector.length).toBeGreaterThan(0);
+    expect(vector.every((v: number) => typeof v === "number")).toBe(true);
+  });
+
+  test("should embed multiple documents in batch", async () => {
+    const embeddings = new TransformersJSEmbeddings();
+    const docs = ["Document 1", "Document 2", "Document 3"];
+
+    const vectors = await embeddings.embedDocuments(docs);
+
+    expect(vectors).toBeInstanceOf(Array);
+    expect(vectors.length).toBe(3);
+    expect(vectors.every((v: number[]) => v.length > 0)).toBe(true);
+  });
+
+  test("should auto-detect vector dimension", async () => {
+    const embeddings = new TransformersJSEmbeddings({
+      modelName: "sentence-transformers/all-MiniLM-L6-v2",
+    });
+
+    const dimension = await embeddings.getVectorDimension();
+
+    expect(dimension).toBeGreaterThan(0);
+    expect(typeof dimension).toBe("number");
+  });
+
+  test("should cache dimension after first detection", async () => {
+    const embeddings = new TransformersJSEmbeddings();
+
+    const dim1 = await embeddings.getVectorDimension();
+    const dim2 = await embeddings.getVectorDimension();
+
+    expect(dim1).toBe(dim2);
+  });
+
+  test("should handle empty document array", async () => {
+    const embeddings = new TransformersJSEmbeddings();
+
+    const vectors = await embeddings.embedDocuments([]);
+
+    expect(vectors).toEqual([]);
+  });
+});

--- a/src/store/embeddings/TransformersJSEmbeddings.ts
+++ b/src/store/embeddings/TransformersJSEmbeddings.ts
@@ -1,0 +1,169 @@
+import { env, type FeatureExtractionPipeline, pipeline } from "@huggingface/transformers";
+import { Embeddings } from "@langchain/core/embeddings";
+
+// Configure Transformers.js global cache directory once at module load time.
+// `env.cacheDir` is a singleton shared across all pipeline instances, so it
+// must be set before any `pipeline()` call — module-level init is the safest.
+const cacheDir = process.env.TRANSFORMERS_CACHE;
+if (cacheDir) {
+  env.cacheDir = cacheDir;
+}
+
+/**
+ * Configuration options for Transformers.js embeddings.
+ */
+export interface TransformersJSEmbeddingsParams {
+  /**
+   * Model to use for embeddings. Defaults to BAAI/bge-small-en-v1.5.
+   * Supports any sentence-transformers model available on HuggingFace.
+   */
+  modelName?: string;
+
+  /**
+   * Device to run inference on. Defaults to "cpu".
+   * Set to "webgpu" to enable GPU acceleration (requires compatible hardware).
+   * Can also be set via TRANSFORMERS_DEVICE environment variable.
+   */
+  device?: "cpu" | "webgpu";
+
+  /**
+   * Whether to normalize embeddings to unit length. Defaults to true.
+   */
+  normalize?: boolean;
+
+  /**
+   * Whether to strip newlines from input text. Defaults to true.
+   */
+  stripNewLines?: boolean;
+}
+
+/**
+ * Transformers.js-based embeddings implementation using ONNX runtime.
+ * Provides offline, local embedding generation without external API dependencies.
+ *
+ * Uses @huggingface/transformers to load and run sentence-transformers models
+ * via ONNX runtime in Node.js. Automatically uses all available CPU cores.
+ *
+ * @example
+ * ```typescript
+ * const embeddings = new TransformersJSEmbeddings({
+ *   modelName: "BAAI/bge-small-en-v1.5",
+ *   normalize: true,
+ * });
+ *
+ * const vector = await embeddings.embedQuery("Hello world");
+ * const vectors = await embeddings.embedDocuments(["Doc 1", "Doc 2"]);
+ * ```
+ */
+export class TransformersJSEmbeddings extends Embeddings {
+  private modelName: string;
+  private device: "cpu" | "webgpu";
+  private normalize: boolean;
+  private stripNewLines: boolean;
+
+  private encoder: FeatureExtractionPipeline | null = null;
+  private encoderPromise: Promise<FeatureExtractionPipeline> | null = null;
+  private vectorDimension: number | null = null;
+
+  constructor(params: TransformersJSEmbeddingsParams = {}) {
+    super({});
+
+    this.modelName = params.modelName || "BAAI/bge-small-en-v1.5";
+
+    const envDevice = process.env.TRANSFORMERS_DEVICE?.toLowerCase();
+    this.device = params.device ?? (envDevice === "webgpu" ? "webgpu" : "cpu");
+
+    this.normalize = params.normalize ?? true;
+    this.stripNewLines = params.stripNewLines ?? true;
+  }
+
+  /**
+   * Lazily initializes the embedding pipeline.
+   * Downloads and caches the model on first use.
+   */
+  private async getEncoder(): Promise<FeatureExtractionPipeline> {
+    if (this.encoderPromise === null) {
+      this.encoderPromise = pipeline("feature-extraction", this.modelName, {
+        device: this.device,
+      });
+    }
+
+    const encoder = await this.encoderPromise;
+
+    this.encoder = encoder;
+    return encoder;
+  }
+
+  /**
+   * Gets the vector dimension for this model.
+   * Auto-detects on first inference.
+   */
+  async getVectorDimension(): Promise<number> {
+    if (this.vectorDimension !== null) {
+      return this.vectorDimension;
+    }
+
+    const encoder = await this.getEncoder();
+    const testOutput = await encoder("test", {
+      pooling: "mean",
+      normalize: this.normalize,
+    });
+
+    this.vectorDimension = testOutput.dims[1];
+    return this.vectorDimension as number;
+  }
+
+  /**
+   * Embeds a single query text.
+   *
+   * @param text The text to embed
+   * @returns Promise resolving to the embedding vector
+   */
+  async embedQuery(text: string): Promise<number[]> {
+    const processedText = this.stripNewLines ? text.replaceAll(/\n/g, " ") : text;
+    const encoder = await this.getEncoder();
+
+    const output = await encoder(processedText, {
+      pooling: "mean",
+      normalize: this.normalize,
+    });
+
+    const vector = Array.from(output.data) as number[];
+    return vector;
+  }
+
+  /**
+   * Embeds multiple documents in batch.
+   *
+   * @param documents Array of texts to embed
+   * @returns Promise resolving to array of embedding vectors
+   */
+  async embedDocuments(documents: string[]): Promise<number[][]> {
+    if (documents.length === 0) {
+      return [];
+    }
+
+    const processedDocs = this.stripNewLines
+      ? documents.map((doc) => doc.replaceAll(/\n/g, " "))
+      : documents;
+
+    const encoder = await this.getEncoder();
+
+    const output = await encoder(processedDocs, {
+      pooling: "mean",
+      normalize: this.normalize,
+    });
+
+    const vectors: number[][] = [];
+    const tensor = output.data;
+    const dimension = output.dims[1];
+
+    for (let i = 0; i < documents.length; i++) {
+      const start = i * dimension;
+      const end = start + dimension;
+      vectors.push(Array.from(tensor.slice(start, end)));
+    }
+
+    return vectors;
+  }
+}

--- a/src/store/embeddings/TransformersJSEmbeddings.ts
+++ b/src/store/embeddings/TransformersJSEmbeddings.ts
@@ -1,12 +1,32 @@
-import { env, type FeatureExtractionPipeline, pipeline } from "@huggingface/transformers";
+import type { FeatureExtractionPipeline } from "@huggingface/transformers";
 import { Embeddings } from "@langchain/core/embeddings";
 
-// Configure Transformers.js global cache directory once at module load time.
-// `env.cacheDir` is a singleton shared across all pipeline instances, so it
-// must be set before any `pipeline()` call — module-level init is the safest.
-const cacheDir = process.env.TRANSFORMERS_CACHE;
-if (cacheDir) {
-  env.cacheDir = cacheDir;
+let transformersJSImportPromise: Promise<typeof import("@huggingface/transformers")> | null = null;
+
+async function getTransformersJS() {
+  if (!transformersJSImportPromise) {
+    transformersJSImportPromise = import("@huggingface/transformers");
+  }
+
+  return transformersJSImportPromise;
+}
+
+async function pipeline(
+  task: "feature-extraction",
+  model: string,
+  options?: { device?: "cpu" | "webgpu" },
+): Promise<FeatureExtractionPipeline> {
+  const { env, pipeline: transformersPipeline } = await getTransformersJS();
+  const cacheDir = process.env.TRANSFORMERS_CACHE;
+
+  // `env.cacheDir` is a singleton shared across all pipeline instances, so it
+  // must be set before any `pipeline()` call. Do it lazily so importing this
+  // module does not eagerly load Transformers.js when it is never used.
+  if (cacheDir) {
+    env.cacheDir = cacheDir;
+  }
+
+  return (await transformersPipeline(task, model, options)) as FeatureExtractionPipeline;
 }
 
 /**

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EmbeddingConfig } from "../store/embeddings/EmbeddingConfig";
 import { expandConfiguredRoot } from "./accessPolicy";
 import {
   camelToUpperSnake,
@@ -668,5 +669,119 @@ describe("Auto-generated Environment Variable Overrides", () => {
     await expect(expandConfiguredRoot("$DOCUMENTS")).resolves.toBeNull();
 
     homedirSpy.mockRestore();
+  });
+});
+
+describe("Smart Defaults for vectorDimension", () => {
+  let tmpDir: string;
+
+  // Reset singleton at module load to ensure clean state before any test runs
+  EmbeddingConfig.resetInstance();
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "docs-mcp-smart-defaults-test-"));
+    EmbeddingConfig.resetInstance();
+    vi.clearAllMocks();
+    // Clear any env vars that might affect tests
+    delete process.env.DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION;
+    delete process.env.DOCS_MCP_EMBEDDING_MODEL;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    EmbeddingConfig.resetInstance();
+    delete process.env.DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION;
+    delete process.env.DOCS_MCP_EMBEDDING_MODEL;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it("applies known dimension for transformers models with known dimensions", () => {
+    process.env.DOCS_MCP_EMBEDDING_MODEL = "transformers:BAAI/bge-small-en-v1.5";
+
+    const config = loadConfig(
+      {},
+      { configPath: path.join(tmpDir, "smart-default.yaml") },
+    );
+
+    expect(config.embeddings.vectorDimension).toBe(384);
+  });
+
+  it("keeps default 1536 for non-transformers models", () => {
+    process.env.DOCS_MCP_EMBEDDING_MODEL = "openai:text-embedding-3-small";
+
+    const config = loadConfig(
+      {},
+      { configPath: path.join(tmpDir, "non-transformers.yaml") },
+    );
+
+    expect(config.embeddings.vectorDimension).toBe(1536);
+  });
+
+  it("keeps default 1536 for models without provider prefix (defaults to openai)", () => {
+    process.env.DOCS_MCP_EMBEDDING_MODEL = "text-embedding-3-small";
+
+    const config = loadConfig({}, { configPath: path.join(tmpDir, "no-provider.yaml") });
+
+    expect(config.embeddings.vectorDimension).toBe(1536);
+  });
+
+  it("respects explicit DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION override", () => {
+    process.env.DOCS_MCP_EMBEDDING_MODEL = "transformers:BAAI/bge-small-en-v1.5";
+    process.env.DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION = "1024";
+
+    const config = loadConfig({}, { configPath: path.join(tmpDir, "override.yaml") });
+
+    expect(config.embeddings.vectorDimension).toBe(1024);
+  });
+
+  it("respects explicit vectorDimension in config file", () => {
+    const configPath = path.join(tmpDir, "explicit-dim.yaml");
+    fs.writeFileSync(
+      configPath,
+      `app:\n  embeddingModel: transformers:BAAI/bge-small-en-v1.5\nembeddings:\n  vectorDimension: 768\n`,
+    );
+
+    const config = loadConfig({}, { configPath });
+
+    expect(config.embeddings.vectorDimension).toBe(768);
+  });
+
+  it("respects CLI arg for vectorDimension", () => {
+    process.env.DOCS_MCP_EMBEDDING_MODEL = "transformers:BAAI/bge-small-en-v1.5";
+    process.env.DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION = "768";
+
+    const config = loadConfig({}, { configPath: path.join(tmpDir, "cli-override.yaml") });
+
+    expect(config.embeddings.vectorDimension).toBe(768);
+  });
+
+  it("returns 1536 for unknown transformers models (no known dimension)", () => {
+    process.env.DOCS_MCP_EMBEDDING_MODEL = "transformers:unknown/repo";
+
+    const config = loadConfig(
+      {},
+      { configPath: path.join(tmpDir, "unknown-model.yaml") },
+    );
+
+    expect(config.embeddings.vectorDimension).toBe(1536);
+  });
+
+  it("handles case-insensitive transformers provider", () => {
+    process.env.DOCS_MCP_EMBEDDING_MODEL = "TRANSFORMERS:BAAI/bge-small-en-v1.5";
+
+    const config = loadConfig({}, { configPath: path.join(tmpDir, "case-test.yaml") });
+
+    // The provider detection is case-sensitive, so TRANSFORMERS won't match "transformers"
+    // and will fall back to 1536
+    expect(config.embeddings.vectorDimension).toBe(1536);
+  });
+
+  it("handles quoted model spec from Docker compose", () => {
+    process.env.DOCS_MCP_EMBEDDING_MODEL = '"transformers:BAAI/bge-small-en-v1.5"';
+
+    const config = loadConfig({}, { configPath: path.join(tmpDir, "quoted.yaml") });
+
+    expect(config.embeddings.vectorDimension).toBe(384);
   });
 });

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import envPaths from "env-paths";
 import yaml from "yaml";
 import { z } from "zod";
+import { EmbeddingConfig } from "../store/embeddings/EmbeddingConfig";
 import { normalizeEnvValue } from "./env";
 import { logger } from "./logger";
 
@@ -488,6 +489,32 @@ export function loadConfig(
     setAtPath(mergedInput, ["app", "embeddingModel"], "text-embedding-3-small");
   }
 
+  // Smart default for vectorDimension based on embedding provider
+  // Only applies when DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION is not explicitly set
+  // and the model is a transformers provider (avoids 1536d padding for 384d/768d models)
+  if (
+    !process.env.DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION &&
+    getAtPath(mergedInput, ["embeddings", "vectorDimension"]) ===
+      DEFAULT_CONFIG.embeddings.vectorDimension
+  ) {
+    const modelSpec = getAtPath(mergedInput, ["app", "embeddingModel"]);
+    if (typeof modelSpec === "string" && modelSpec) {
+      const normalizedSpec = normalizeEnvValue(modelSpec);
+      const colonIndex = normalizedSpec.indexOf(":");
+      const provider =
+        colonIndex === -1 ? "openai" : normalizedSpec.substring(0, colonIndex);
+
+      if (provider === "transformers") {
+        const model =
+          colonIndex === -1 ? normalizedSpec : normalizedSpec.substring(colonIndex + 1);
+        const knownDims = EmbeddingConfig.getKnownModelDimensions(model);
+        if (knownDims !== null) {
+          setAtPath(mergedInput, ["embeddings", "vectorDimension"], knownDims);
+        }
+      }
+    }
+  }
+
   const parseResult = AppConfigSchema.safeParse(mergedInput);
   if (parseResult.success) {
     return parseResult.data;
@@ -685,7 +712,17 @@ function deepMerge(target: unknown, source: unknown): unknown {
 
   const t = target as ConfigObject;
   const s = source as ConfigObject;
-  const output = { ...t };
+  const output: ConfigObject = {};
+
+  // Copy all keys from target first (deep copy to avoid mutating defaults)
+  for (const key of Object.keys(t)) {
+    const tValue = t[key];
+    if (typeof tValue === "object" && tValue !== null && !Array.isArray(tValue)) {
+      output[key] = deepMerge(tValue, {});
+    } else {
+      output[key] = tValue;
+    }
+  }
 
   for (const key of Object.keys(s)) {
     const sValue = s[key];


### PR DESCRIPTION

Add Transformers.js support for completely local, offline embedding inference on CPU-only servers without requiring Ollama or external APIs.

This PR adds native Transformers.js support, enabling:
- Zero dependencies: No Ollama, Docker, or external services needed
- CPU-only inference: Works on any server without GPU
- Offline operation: Models cache locally after first download
- Full privacy: All embeddings generated locally, no data leaves your server