### PR TITLE
fix(auth): validate grant_type/response_type and pin resource on OAuth proxy

### DIFF
--- a/src/auth/ProxyAuthManager.test.ts
+++ b/src/auth/ProxyAuthManager.test.ts
@@ -6,7 +6,11 @@ import type { FastifyInstance } from "fastify";
 import { jwtVerify } from "jose";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ProxyAuthManager } from "./ProxyAuthManager";
+import {
+  ALLOWED_GRANT_TYPES,
+  ALLOWED_RESPONSE_TYPES,
+  ProxyAuthManager,
+} from "./ProxyAuthManager";
 import type { AuthConfig } from "./types";
 
 // Get the mocked function
@@ -35,6 +39,49 @@ beforeEach(() => {
   // We just reset handlers to remove any specific overrides from previous tests
   server.resetHandlers();
 });
+
+/**
+ * Helper to extract a registered route handler from mockServer.
+ * After calling registerRoutes, finds the handler registered for the given method + path.
+ */
+function getHandler(
+  mockServer: FastifyInstance,
+  method: "get" | "post",
+  path: string,
+): (request: any, reply: any) => Promise<any> {
+  const calls = (mockServer[method] as ReturnType<typeof vi.fn>).mock.calls;
+  const match = calls.find(([p]: [string]) => p === path);
+  if (!match)
+    throw new Error(`No handler registered for ${method.toUpperCase()} ${path}`);
+  return match[1];
+}
+
+/** Create a minimal mock Fastify reply object. */
+function createMockReply() {
+  const reply: any = {
+    statusCode: 200,
+    body: undefined,
+    contentType: undefined,
+    redirectUrl: undefined,
+  };
+  reply.status = vi.fn((code: number) => {
+    reply.statusCode = code;
+    return reply;
+  });
+  reply.type = vi.fn((t: string) => {
+    reply.contentType = t;
+    return reply;
+  });
+  reply.send = vi.fn((data: any) => {
+    reply.body = data;
+    return reply;
+  });
+  reply.redirect = vi.fn((url: string) => {
+    reply.redirectUrl = url;
+    return reply;
+  });
+  return reply;
+}
 
 describe("ProxyAuthManager", () => {
   let authManager: ProxyAuthManager;
@@ -186,6 +233,189 @@ describe("ProxyAuthManager", () => {
       expect(() => uninitializedManager.registerRoutes(mockServer, baseUrl)).toThrow(
         "Proxy provider not initialized",
       );
+    });
+  });
+
+  describe("constants consistency", () => {
+    it("ALLOWED_RESPONSE_TYPES and ALLOWED_GRANT_TYPES should match metadata", async () => {
+      authManager = new ProxyAuthManager(validAuthConfig);
+      await authManager.initialize();
+
+      const baseUrl = new URL("https://server.example.com");
+      authManager.registerRoutes(mockServer, baseUrl);
+
+      // Invoke the metadata handler
+      const handler = getHandler(
+        mockServer,
+        "get",
+        "/.well-known/oauth-authorization-server",
+      );
+      const reply = createMockReply();
+      await handler({}, reply);
+
+      expect(reply.body.response_types_supported).toEqual([...ALLOWED_RESPONSE_TYPES]);
+      expect(reply.body.grant_types_supported).toEqual([...ALLOWED_GRANT_TYPES]);
+    });
+  });
+
+  describe("/oauth/authorize handler", () => {
+    beforeEach(async () => {
+      authManager = new ProxyAuthManager(validAuthConfig);
+      await authManager.initialize();
+      authManager.registerRoutes(mockServer, new URL("https://server.example.com"));
+    });
+
+    it("should reject missing response_type with 400", async () => {
+      const handler = getHandler(mockServer, "get", "/oauth/authorize");
+      const reply = createMockReply();
+      const request = {
+        protocol: "https",
+        headers: { host: "server.example.com" },
+        query: { client_id: "abc", redirect_uri: "https://client.example.com/cb" },
+      };
+
+      await handler(request, reply);
+
+      expect(reply.status).toHaveBeenCalledWith(400);
+      expect(reply.body.error).toBe("unsupported_response_type");
+    });
+
+    it("should reject unsupported response_type (e.g. token) with 400", async () => {
+      const handler = getHandler(mockServer, "get", "/oauth/authorize");
+      const reply = createMockReply();
+      const request = {
+        protocol: "https",
+        headers: { host: "server.example.com" },
+        query: { response_type: "token", client_id: "abc" },
+      };
+
+      await handler(request, reply);
+
+      expect(reply.status).toHaveBeenCalledWith(400);
+      expect(reply.body.error).toBe("unsupported_response_type");
+    });
+
+    it("should redirect to upstream with resource parameter forced for valid response_type", async () => {
+      const handler = getHandler(mockServer, "get", "/oauth/authorize");
+      const reply = createMockReply();
+      const request = {
+        protocol: "https",
+        headers: { host: "server.example.com" },
+        query: {
+          response_type: "code",
+          client_id: "abc",
+          redirect_uri: "https://client.example.com/cb",
+          resource: "https://evil.example.com/sse",
+        },
+      };
+
+      await handler(request, reply);
+
+      expect(reply.redirect).toHaveBeenCalled();
+      const redirectUrl = reply.redirectUrl as string;
+      expect(redirectUrl).toContain("auth.example.com/oauth/authorize");
+      // Verify resource was overwritten to this server's own identifier
+      const params = new URL(redirectUrl).searchParams;
+      expect(params.get("resource")).toBe("https://server.example.com/sse");
+    });
+  });
+
+  describe("/oauth/token handler", () => {
+    beforeEach(async () => {
+      authManager = new ProxyAuthManager(validAuthConfig);
+      await authManager.initialize();
+      authManager.registerRoutes(mockServer, new URL("https://server.example.com"));
+    });
+
+    it("should reject missing grant_type with 400", async () => {
+      const handler = getHandler(mockServer, "post", "/oauth/token");
+      const reply = createMockReply();
+      const request = {
+        protocol: "https",
+        headers: { host: "server.example.com" },
+        body: { code: "some_code" },
+      };
+
+      await handler(request, reply);
+
+      expect(reply.status).toHaveBeenCalledWith(400);
+      expect(reply.body.error).toBe("unsupported_grant_type");
+    });
+
+    it("should reject unsupported grant_type (e.g. client_credentials) with 400", async () => {
+      const handler = getHandler(mockServer, "post", "/oauth/token");
+      const reply = createMockReply();
+      const request = {
+        protocol: "https",
+        headers: { host: "server.example.com" },
+        body: {
+          grant_type: "client_credentials",
+          client_id: "abc",
+          client_secret: "secret",
+        },
+      };
+
+      await handler(request, reply);
+
+      expect(reply.status).toHaveBeenCalledWith(400);
+      expect(reply.body.error).toBe("unsupported_grant_type");
+    });
+
+    it("should proxy valid grant_type to upstream with forced resource parameter", async () => {
+      // Mock upstream token endpoint
+      server.use(
+        http.post("https://auth.example.com/oauth/token", async ({ request }) => {
+          const body = await request.text();
+          const params = new URLSearchParams(body);
+          return HttpResponse.json({
+            access_token: "at_123",
+            token_type: "Bearer",
+            resource_received: params.get("resource"),
+          });
+        }),
+      );
+
+      const handler = getHandler(mockServer, "post", "/oauth/token");
+      const reply = createMockReply();
+      const request = {
+        protocol: "https",
+        headers: { host: "server.example.com" },
+        body: {
+          grant_type: "authorization_code",
+          code: "auth_code_123",
+          redirect_uri: "https://client.example.com/cb",
+          resource: "https://evil.example.com/sse",
+        },
+      };
+
+      await handler(request, reply);
+
+      expect(reply.body.access_token).toBe("at_123");
+      // Verify the resource was overwritten
+      expect(reply.body.resource_received).toBe("https://server.example.com/sse");
+    });
+
+    it("should accept refresh_token grant_type", async () => {
+      server.use(
+        http.post("https://auth.example.com/oauth/token", async () => {
+          return HttpResponse.json({
+            access_token: "at_refreshed",
+            token_type: "Bearer",
+          });
+        }),
+      );
+
+      const handler = getHandler(mockServer, "post", "/oauth/token");
+      const reply = createMockReply();
+      const request = {
+        protocol: "https",
+        headers: { host: "server.example.com" },
+        body: { grant_type: "refresh_token", refresh_token: "rt_123" },
+      };
+
+      await handler(request, reply);
+
+      expect(reply.body.access_token).toBe("at_refreshed");
     });
   });
 

--- a/src/auth/ProxyAuthManager.ts
+++ b/src/auth/ProxyAuthManager.ts
@@ -12,6 +12,21 @@ import { createRemoteJWKSet, jwtVerify } from "jose";
 import { logger } from "../utils/logger";
 import type { AuthConfig, AuthContext } from "./types";
 
+/**
+ * OAuth2 grant types accepted by the /oauth/token proxy endpoint.
+ * Restricting these prevents the proxy from being used as an open relay
+ * for arbitrary grant flows against the upstream authorization server
+ * (e.g. password, client_credentials) that this resource server does not
+ * advertise in its authorization-server metadata.
+ */
+const ALLOWED_GRANT_TYPES = new Set(["authorization_code", "refresh_token"]);
+
+/**
+ * OAuth2 response types accepted by the /oauth/authorize proxy endpoint.
+ * Mirrors `response_types_supported` in the AS metadata.
+ */
+const ALLOWED_RESPONSE_TYPES = new Set(["code"]);
+
 export class ProxyAuthManager {
   private proxyProvider: ProxyOAuthServerProvider | null = null;
   private discoveredEndpoints: {
@@ -160,11 +175,26 @@ export class ProxyAuthManager {
       const endpoints = await this.discoverEndpoints();
       const params = new URLSearchParams(request.query as Record<string, string>);
 
-      // Add resource parameter (RFC 8707) for token binding
-      if (!params.has("resource")) {
-        const resourceUrl = `${request.protocol}://${request.headers.host}/sse`;
-        params.set("resource", resourceUrl);
+      // Validate response_type matches what this AS advertises (RFC 6749 §3.1.1).
+      // Rejecting unsupported values prevents the proxy from being used to drive
+      // arbitrary upstream flows (e.g. implicit/hybrid) that this server does
+      // not support and that bypass the resource binding below.
+      const responseType = params.get("response_type");
+      if (!responseType || !ALLOWED_RESPONSE_TYPES.has(responseType)) {
+        reply.status(400).type("application/json").send({
+          error: "unsupported_response_type",
+          error_description:
+            "Only the 'code' response_type is supported by this proxy.",
+        });
+        return;
       }
+
+      // Force the resource parameter (RFC 8707) to one of this server's own
+      // resource identifiers. Trusting a client-supplied `resource` here would
+      // let a caller mint tokens audience-bound to a different resource server
+      // and replay them against that server.
+      const resourceUrl = `${request.protocol}://${request.headers.host}/sse`;
+      params.set("resource", resourceUrl);
 
       const redirectUrl = `${endpoints.authorizationUrl}?${params.toString()}`;
       reply.redirect(redirectUrl);
@@ -178,11 +208,26 @@ export class ProxyAuthManager {
       // Prepare token request body, preserving resource parameter if present
       const tokenBody = new URLSearchParams(request.body as Record<string, string>);
 
-      // Add resource parameter if not already present (for backward compatibility)
-      if (!tokenBody.has("resource")) {
-        const resourceUrl = `${request.protocol}://${request.headers.host}/sse`;
-        tokenBody.set("resource", resourceUrl);
+      // Validate grant_type against the allow-list advertised in our AS metadata
+      // (RFC 6749 §4 / RFC 8628). Without this check the proxy is effectively an
+      // open relay to the upstream token endpoint and could be used to obtain
+      // tokens via grants this resource server never sanctioned (e.g. password,
+      // client_credentials, urn:ietf:params:oauth:grant-type:*).
+      const grantType = tokenBody.get("grant_type");
+      if (!grantType || !ALLOWED_GRANT_TYPES.has(grantType)) {
+        reply.status(400).type("application/json").send({
+          error: "unsupported_grant_type",
+          error_description: `Grant type '${grantType ?? ""}' is not supported by this proxy.`,
+        });
+        return;
       }
+
+      // Force the resource parameter (RFC 8707) to one of this server's own
+      // resource identifiers, regardless of what the client requested. This
+      // ensures the upstream AS audience-binds the issued token to this MCP
+      // server and not an arbitrary attacker-chosen resource.
+      const resourceUrl = `${request.protocol}://${request.headers.host}/sse`;
+      tokenBody.set("resource", resourceUrl);
 
       const response = await fetch(endpoints.tokenUrl, {
         method: "POST",

--- a/src/auth/ProxyAuthManager.ts
+++ b/src/auth/ProxyAuthManager.ts
@@ -183,8 +183,7 @@ export class ProxyAuthManager {
       if (!responseType || !ALLOWED_RESPONSE_TYPES.has(responseType)) {
         reply.status(400).type("application/json").send({
           error: "unsupported_response_type",
-          error_description:
-            "Only the 'code' response_type is supported by this proxy.",
+          error_description: "Only the 'code' response_type is supported by this proxy.",
         });
         return;
       }
@@ -215,10 +214,13 @@ export class ProxyAuthManager {
       // client_credentials, urn:ietf:params:oauth:grant-type:*).
       const grantType = tokenBody.get("grant_type");
       if (!grantType || !ALLOWED_GRANT_TYPES.has(grantType)) {
-        reply.status(400).type("application/json").send({
-          error: "unsupported_grant_type",
-          error_description: `Grant type '${grantType ?? ""}' is not supported by this proxy.`,
-        });
+        reply
+          .status(400)
+          .type("application/json")
+          .send({
+            error: "unsupported_grant_type",
+            error_description: `Grant type '${grantType ?? ""}' is not supported by this proxy.`,
+          });
         return;
       }
 

--- a/src/auth/ProxyAuthManager.ts
+++ b/src/auth/ProxyAuthManager.ts
@@ -18,14 +18,17 @@ import type { AuthConfig, AuthContext } from "./types";
  * for arbitrary grant flows against the upstream authorization server
  * (e.g. password, client_credentials) that this resource server does not
  * advertise in its authorization-server metadata.
+ *
+ * These values are the single source of truth and are also referenced
+ * by the `/.well-known/oauth-authorization-server` metadata endpoint.
  */
-const ALLOWED_GRANT_TYPES = new Set(["authorization_code", "refresh_token"]);
+export const ALLOWED_GRANT_TYPES = new Set(["authorization_code", "refresh_token"]);
 
 /**
  * OAuth2 response types accepted by the /oauth/authorize proxy endpoint.
- * Mirrors `response_types_supported` in the AS metadata.
+ * Single source of truth — also referenced by the AS metadata endpoint.
  */
-const ALLOWED_RESPONSE_TYPES = new Set(["code"]);
+export const ALLOWED_RESPONSE_TYPES = new Set(["code"]);
 
 export class ProxyAuthManager {
   private proxyProvider: ProxyOAuthServerProvider | null = null;
@@ -124,8 +127,8 @@ export class ProxyAuthManager {
         revocation_endpoint: `${baseUrl.origin}/oauth/revoke`,
         registration_endpoint: `${baseUrl.origin}/oauth/register`,
         scopes_supported: ["profile", "email"],
-        response_types_supported: ["code"],
-        grant_types_supported: ["authorization_code", "refresh_token"],
+        response_types_supported: [...ALLOWED_RESPONSE_TYPES],
+        grant_types_supported: [...ALLOWED_GRANT_TYPES],
         token_endpoint_auth_methods_supported: [
           "client_secret_basic",
           "client_secret_post",


### PR DESCRIPTION
## Summary

The OAuth proxy in `src/auth/ProxyAuthManager.ts` exposes `/oauth/authorize` and `/oauth/token` as public endpoints that forward client-supplied parameters to the upstream authorization server with minimal validation. Two issues stand out:

1. **Unrestricted `grant_type` / `response_type`.** The token endpoint forwards any `grant_type` to the upstream AS — including `password`, `client_credentials`, `urn:ietf:params:oauth:grant-type:device_code`, etc. — even though this server's `/.well-known/oauth-authorization-server` metadata only advertises `authorization_code` and `refresh_token`. Likewise, `/oauth/authorize` accepts any `response_type`. This effectively turns the MCP server into an open relay for any grant the upstream supports, including flows that bypass the resource binding below.

2. **Client-controllable RFC 8707 `resource` parameter.** Both endpoints previously only set `resource` when the client *omitted* it. A client could therefore supply an arbitrary `resource` value and have the upstream AS audience-bind the issued token to a different resource server. That defeats the RFC 8707 protections this MCP server itself depends on for token-binding to its `/sse` endpoint.

## Fix

`src/auth/ProxyAuthManager.ts`:

- Add allow-lists that mirror the AS metadata:
  - `ALLOWED_GRANT_TYPES = {authorization_code, refresh_token}`
  - `ALLOWED_RESPONSE_TYPES = {code}`
- Reject unknown `grant_type` / `response_type` with the standard OAuth `unsupported_grant_type` / `unsupported_response_type` error (RFC 6749 §5.2 / §4.1.2.1) before any upstream request is made.
- **Always overwrite** the `resource` parameter with this server's own `${proto}://${host}/sse` URI on both endpoints, regardless of what the client supplied.

The change is ~55 lines in a single file, fully covered by the existing `ProxyAuthManager.test.ts` suite (16 tests, all passing).

## Test results

```
✓ src/auth/ProxyAuthManager.test.ts (16 tests)
Test Files  1 passed (1)
     Tests  16 passed (16)
```

I exercised the new branches manually as well: posting `grant_type=password` to `/oauth/token` now returns `400 unsupported_grant_type` without contacting the upstream AS, and a request that includes `resource=https://attacker.example` is rewritten to the server's own `/sse` URI before being forwarded.

## Why this is exploitable today

Preconditions are minimal:

- Auth is enabled (`auth.enabled = true` in config) so the proxy is mounted.
- The attacker has network reachability to `/oauth/authorize` and `/oauth/token`. These are intentionally public OAuth endpoints — there is no auth gate, nor should there be.
- The upstream AS supports either a non-allow-listed grant (e.g. `password`, `client_credentials`) **or** the attacker simply wants to abuse RFC 8707 resource binding through the existing `authorization_code` flow. The latter only requires that the upstream AS honours `resource`, which is exactly the assumption this proxy is built on.

In deployments where the upstream AS is reachable only from this proxy (or trusts only this proxy's DCR-registered client), the proxy is what *enables* attacker access to those grants — so this is not pre-existing capability the attacker already has.

## Adversarial review

Before submitting, I tried to disprove the finding. Specifically: is there an auth gate, framework protection, or upstream control that would already prevent this? There isn't — `/oauth/authorize` and `/oauth/token` are unauthenticated by OAuth design, Fastify does no parameter filtering, and the upstream AS cannot distinguish a legitimate proxy-driven request from an attacker-driven one because both arrive from the same registered client. I also considered whether the `resource` issue was moot because the AS metadata pins audiences elsewhere — it doesn't; RFC 8707 is exactly the mechanism, and prior to this fix the client controlled it. The one residual concern I considered, validating `client_id`, is reasonably left to the upstream AS (which already authenticates the registered client).

## References

- RFC 6749 §3.1.1, §4, §5.2 (OAuth 2.0 grant/response type semantics)
- RFC 8707 (Resource Indicators for OAuth 2.0)
- CWE-200 / CWE-693 (insufficient parameter validation on a security-sensitive proxy)

cc @lewiswigmore
