### PR TITLE
fix: prevent path traversal in LocalFileStrategy via file:// URLs

### DIFF
--- a/src/scraper/fetcher/FileFetcher.ts
+++ b/src/scraper/fetcher/FileFetcher.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
+import path from "node:path";
 import { ScraperError } from "../../utils/errors";
 import { MimeTypeUtils } from "../../utils/mimeTypeUtils";
 import {
@@ -21,6 +22,9 @@ export class FileFetcher implements ContentFetcher {
    * Fetches the content of a file given a file:// URL, decoding percent-encoded paths as needed.
    * Uses enhanced MIME type detection for better source code file recognition.
    * Supports conditional fetching via ETag comparison for efficient refresh operations.
+   *
+   * Security: The file path is resolved via `path.resolve()` to canonicalize
+   * it and eliminate any `..` or `.` segments before performing filesystem I/O.
    */
   async fetch(source: string, options?: FetchOptions): Promise<RawContent> {
     // Remove the file:// protocol prefix and handle both file:// and file:/// formats
@@ -33,6 +37,9 @@ export class FileFetcher implements ContentFetcher {
     if (!filePath.startsWith("/") && process.platform !== "win32") {
       filePath = `/${filePath}`;
     }
+
+    // Resolve to canonical absolute path – removes ".." and "." segments
+    filePath = path.resolve(filePath);
 
     try {
       const stats = await fs.stat(filePath);

--- a/src/scraper/strategies/LocalFileStrategy.pathtraversal.test.ts
+++ b/src/scraper/strategies/LocalFileStrategy.pathtraversal.test.ts
@@ -1,0 +1,175 @@
+import { vol } from "memfs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProgressCallback } from "../../types";
+import { loadConfig } from "../../utils/config";
+import type { ScraperOptions, ScraperProgressEvent } from "../types";
+import { LocalFileStrategy } from "./LocalFileStrategy";
+
+vi.mock("node:fs/promises", () => ({ default: vol.promises }));
+vi.mock("node:fs");
+
+describe("LocalFileStrategy path traversal protection", () => {
+  const appConfig = loadConfig();
+
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it("should reject discovered links that escape the root via ..", async () => {
+    const strategy = new LocalFileStrategy(appConfig);
+    const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
+
+    // Set up a legitimate docs directory and a sensitive file outside it
+    vol.fromJSON(
+      {
+        "/home/user/docs/readme.md": "# Docs",
+        "/etc/passwd": "root:x:0:0:root:/root:/bin/bash",
+      },
+      "/",
+    );
+
+    const options: ScraperOptions = {
+      url: "file:///home/user/docs",
+      library: "test",
+      version: "1.0",
+      maxPages: 10,
+      maxDepth: 3,
+    };
+
+    await strategy.scrape(options, progressCallback);
+
+    // Only readme.md should be processed, not /etc/passwd
+    const processedUrls = progressCallback.mock.calls
+      .filter((call) => call[0].result)
+      .map((call) => call[0].currentUrl);
+    expect(processedUrls).toContain("file:///home/user/docs/readme.md");
+    expect(processedUrls).not.toContain("file:///etc/passwd");
+  });
+
+  it("should prevent reading files via percent-encoded traversal", async () => {
+    const strategy = new LocalFileStrategy(appConfig);
+    const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
+
+    vol.fromJSON(
+      {
+        "/etc/passwd": "root:x:0:0:root:/root:/bin/bash",
+      },
+      "/",
+    );
+
+    // Attempt to read /etc/passwd via percent-encoded traversal
+    // URL constructor normalizes this to /etc/passwd, which is outside the root
+    const options: ScraperOptions = {
+      url: "file:///home/user/docs/%2e%2e/%2e%2e/%2e%2e/etc/passwd",
+      library: "test",
+      version: "1.0",
+      maxPages: 1,
+      maxDepth: 0,
+    };
+
+    await strategy.scrape(options, progressCallback);
+
+    // Should NOT have processed the file with sensitive content
+    const processedContent = progressCallback.mock.calls
+      .filter((call) => call[0].result)
+      .map((call) => call[0].result?.textContent);
+    for (const content of processedContent) {
+      expect(content).not.toContain("root:x:0:0");
+    }
+  });
+
+  it("should allow reading files within the base directory", async () => {
+    const strategy = new LocalFileStrategy(appConfig);
+    const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
+
+    vol.fromJSON(
+      {
+        "/home/user/docs/guide.md": "# Guide\n\nSome content",
+        "/home/user/docs/subdir/deep.md": "# Deep\n\nNested content",
+      },
+      "/",
+    );
+
+    const options: ScraperOptions = {
+      url: "file:///home/user/docs",
+      library: "test",
+      version: "1.0",
+      maxPages: 10,
+      maxDepth: 3,
+    };
+
+    await strategy.scrape(options, progressCallback);
+
+    const processedUrls = progressCallback.mock.calls
+      .filter((call) => call[0].result)
+      .map((call) => call[0].currentUrl);
+    expect(processedUrls).toContain("file:///home/user/docs/guide.md");
+    expect(processedUrls).toContain("file:///home/user/docs/subdir/deep.md");
+  });
+
+  it("should process a single file when it is the root URL", async () => {
+    const strategy = new LocalFileStrategy(appConfig);
+    const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
+
+    vol.fromJSON(
+      {
+        "/home/user/docs/readme.md": "# Hello\n\nWorld",
+      },
+      "/",
+    );
+
+    // Single file as the root: the base dir is the file itself
+    // so the file IS within its own base
+    const options: ScraperOptions = {
+      url: "file:///home/user/docs/readme.md",
+      library: "test",
+      version: "1.0",
+      maxPages: 1,
+      maxDepth: 0,
+    };
+
+    await strategy.scrape(options, progressCallback);
+
+    // The file should still be processed
+    expect(progressCallback).toHaveBeenCalled();
+    const processed = progressCallback.mock.calls.filter((call) => call[0].result);
+    expect(processed).toHaveLength(1);
+    expect(processed[0][0].result?.textContent).toContain("Hello");
+  });
+
+  it("should block items from initialQueue that escape the root directory", async () => {
+    const strategy = new LocalFileStrategy(appConfig);
+    const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
+
+    vol.fromJSON(
+      {
+        "/home/user/docs/readme.md": "# Docs",
+        "/etc/shadow": "root:$6$...:...",
+      },
+      "/",
+    );
+
+    const options: ScraperOptions = {
+      url: "file:///home/user/docs",
+      library: "test",
+      version: "1.0",
+      maxPages: 10,
+      maxDepth: 3,
+      initialQueue: [
+        {
+          url: "file:///etc/shadow",
+          depth: 1,
+          pageId: 999,
+        },
+      ],
+    };
+
+    await strategy.scrape(options, progressCallback);
+
+    // The /etc/shadow item should be blocked by containment check
+    const processedUrls = progressCallback.mock.calls
+      .filter((call) => call[0].result)
+      .map((call) => call[0].currentUrl);
+    expect(processedUrls).not.toContain("file:///etc/shadow");
+  });
+});

--- a/src/scraper/strategies/LocalFileStrategy.pathtraversal.test.ts
+++ b/src/scraper/strategies/LocalFileStrategy.pathtraversal.test.ts
@@ -15,15 +15,14 @@ describe("LocalFileStrategy path traversal protection", () => {
     vol.reset();
   });
 
-  it("should reject discovered links that escape the root via ..", async () => {
+  it("should block items from initialQueue that contain .. traversal segments", async () => {
     const strategy = new LocalFileStrategy(appConfig);
     const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
 
-    // Set up a legitimate docs directory and a sensitive file outside it
     vol.fromJSON(
       {
         "/home/user/docs/readme.md": "# Docs",
-        "/etc/passwd": "root:x:0:0:root:/root:/bin/bash",
+        "/tmp/sensitive/secret.txt": "sensitive-data-here",
       },
       "/",
     );
@@ -34,48 +33,103 @@ describe("LocalFileStrategy path traversal protection", () => {
       version: "1.0",
       maxPages: 10,
       maxDepth: 3,
+      initialQueue: [
+        {
+          url: "file:///home/user/docs/../../../tmp/sensitive/secret.txt",
+          depth: 1,
+          pageId: 100,
+        },
+      ],
     };
 
     await strategy.scrape(options, progressCallback);
 
-    // Only readme.md should be processed, not /etc/passwd
     const processedUrls = progressCallback.mock.calls
       .filter((call) => call[0].result)
       .map((call) => call[0].currentUrl);
+    // The traversal item should be blocked
+    expect(processedUrls).not.toContain("file:///tmp/sensitive/secret.txt");
+    expect(processedUrls).not.toContain("file:///home/user/docs/../../../tmp/sensitive/secret.txt");
+    // Legitimate file should still be processed
     expect(processedUrls).toContain("file:///home/user/docs/readme.md");
-    expect(processedUrls).not.toContain("file:///etc/passwd");
   });
 
-  it("should prevent reading files via percent-encoded traversal", async () => {
+  it("should block initialQueue items with percent-encoded traversal against a legitimate root", async () => {
     const strategy = new LocalFileStrategy(appConfig);
     const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
 
     vol.fromJSON(
       {
-        "/etc/passwd": "root:x:0:0:root:/root:/bin/bash",
+        "/home/user/docs/readme.md": "# Docs",
+        "/tmp/sensitive/secret.txt": "sensitive-data-here",
       },
       "/",
     );
 
-    // Attempt to read /etc/passwd via percent-encoded traversal
-    // URL constructor normalizes this to /etc/passwd, which is outside the root
     const options: ScraperOptions = {
-      url: "file:///home/user/docs/%2e%2e/%2e%2e/%2e%2e/etc/passwd",
+      url: "file:///home/user/docs",
       library: "test",
       version: "1.0",
-      maxPages: 1,
-      maxDepth: 0,
+      maxPages: 10,
+      maxDepth: 3,
+      initialQueue: [
+        {
+          url: "file:///home/user/docs/%2e%2e/%2e%2e/%2e%2e/tmp/sensitive/secret.txt",
+          depth: 1,
+          pageId: 100,
+        },
+      ],
     };
 
     await strategy.scrape(options, progressCallback);
 
-    // Should NOT have processed the file with sensitive content
+    const processedUrls = progressCallback.mock.calls
+      .filter((call) => call[0].result)
+      .map((call) => call[0].currentUrl);
+    expect(processedUrls).not.toContain("file:///tmp/sensitive/secret.txt");
+
+    // Verify no sensitive content was processed
     const processedContent = progressCallback.mock.calls
       .filter((call) => call[0].result)
       .map((call) => call[0].result?.textContent);
     for (const content of processedContent) {
-      expect(content).not.toContain("root:x:0:0");
+      expect(content).not.toContain("sensitive-data-here");
     }
+  });
+
+  it("should block absolute out-of-base paths in initialQueue", async () => {
+    const strategy = new LocalFileStrategy(appConfig);
+    const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
+
+    vol.fromJSON(
+      {
+        "/home/user/docs/readme.md": "# Docs",
+        "/var/secrets/config.txt": "secret-config-value",
+      },
+      "/",
+    );
+
+    const options: ScraperOptions = {
+      url: "file:///home/user/docs",
+      library: "test",
+      version: "1.0",
+      maxPages: 10,
+      maxDepth: 3,
+      initialQueue: [
+        {
+          url: "file:///var/secrets/config.txt",
+          depth: 1,
+          pageId: 999,
+        },
+      ],
+    };
+
+    await strategy.scrape(options, progressCallback);
+
+    const processedUrls = progressCallback.mock.calls
+      .filter((call) => call[0].result)
+      .map((call) => call[0].currentUrl);
+    expect(processedUrls).not.toContain("file:///var/secrets/config.txt");
   });
 
   it("should allow reading files within the base directory", async () => {
@@ -118,8 +172,6 @@ describe("LocalFileStrategy path traversal protection", () => {
       "/",
     );
 
-    // Single file as the root: the base dir is the file itself
-    // so the file IS within its own base
     const options: ScraperOptions = {
       url: "file:///home/user/docs/readme.md",
       library: "test",
@@ -130,46 +182,9 @@ describe("LocalFileStrategy path traversal protection", () => {
 
     await strategy.scrape(options, progressCallback);
 
-    // The file should still be processed
     expect(progressCallback).toHaveBeenCalled();
     const processed = progressCallback.mock.calls.filter((call) => call[0].result);
     expect(processed).toHaveLength(1);
     expect(processed[0][0].result?.textContent).toContain("Hello");
-  });
-
-  it("should block items from initialQueue that escape the root directory", async () => {
-    const strategy = new LocalFileStrategy(appConfig);
-    const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
-
-    vol.fromJSON(
-      {
-        "/home/user/docs/readme.md": "# Docs",
-        "/etc/shadow": "root:$6$...:...",
-      },
-      "/",
-    );
-
-    const options: ScraperOptions = {
-      url: "file:///home/user/docs",
-      library: "test",
-      version: "1.0",
-      maxPages: 10,
-      maxDepth: 3,
-      initialQueue: [
-        {
-          url: "file:///etc/shadow",
-          depth: 1,
-          pageId: 999,
-        },
-      ],
-    };
-
-    await strategy.scrape(options, progressCallback);
-
-    // The /etc/shadow item should be blocked by containment check
-    const processedUrls = progressCallback.mock.calls
-      .filter((call) => call[0].result)
-      .map((call) => call[0].currentUrl);
-    expect(processedUrls).not.toContain("file:///etc/shadow");
   });
 });

--- a/src/scraper/strategies/LocalFileStrategy.ts
+++ b/src/scraper/strategies/LocalFileStrategy.ts
@@ -12,11 +12,59 @@ import type { QueueItem, ScraperOptions } from "../types";
 import { BaseScraperStrategy, type ProcessItemResult } from "./BaseScraperStrategy";
 
 /**
+ * Convert a file:// URL string to a normalized absolute filesystem path.
+ * Handles both file:// and file:/// formats and decodes percent-encoded characters.
+ * The returned path is resolved via path.resolve() to eliminate any ".." segments.
+ */
+export function fileUrlToPath(fileUrl: string): string {
+  let filePath = fileUrl.replace(/^file:\/\/\/?/, "");
+  filePath = decodeURIComponent(filePath);
+
+  // Ensure absolute path on Unix-like systems
+  if (!filePath.startsWith("/") && process.platform !== "win32") {
+    filePath = `/${filePath}`;
+  }
+
+  // Resolve to canonicalize and remove any ".." or "." segments
+  return path.resolve(filePath);
+}
+
+/**
+ * Determine the base directory for a given file:// URL.
+ * - If the URL points to a directory, the base is that directory itself.
+ * - If the URL points to a file, the base is its parent directory.
+ * The returned path always ends with the platform path separator.
+ */
+function computeFileBaseDir(resolvedPath: string): string {
+  // Append separator so that containment checks work correctly
+  // e.g. "/home/user/docs" + "/" -> ensures "/home/user/docs-other" doesn't match
+  return resolvedPath.endsWith(path.sep) ? resolvedPath : `${resolvedPath}${path.sep}`;
+}
+
+/**
+ * Check whether `candidate` is contained within `baseDir`
+ * (or is exactly `baseDir` without trailing separator).
+ * Both paths must already be resolved / normalized.
+ */
+function isPathWithinBase(candidate: string, baseDir: string): boolean {
+  // Exact match (the root path itself)
+  if (candidate === baseDir || candidate === baseDir.replace(/[/\\]+$/, "")) {
+    return true;
+  }
+  return candidate.startsWith(baseDir);
+}
+
+/**
  * LocalFileStrategy handles crawling and scraping of local files and folders using file:// URLs.
  *
  * All files with a MIME type of `text/*` are processed. This includes HTML, Markdown, plain text, and source code files such as `.js`, `.ts`, `.tsx`, `.css`, etc. Binary files, PDFs, images, and other non-text formats are ignored.
  *
  * Supports include/exclude filters and percent-encoded paths.
+ *
+ * Security: All file paths are resolved via `path.resolve()` and verified to
+ * reside within the root URL's directory tree before any filesystem access.
+ * This prevents path-traversal attacks via `..` segments, percent-encoding
+ * tricks, or symlinks that escape the intended directory.
  */
 export class LocalFileStrategy extends BaseScraperStrategy {
   private readonly fileFetcher = new FileFetcher();
@@ -36,13 +84,23 @@ export class LocalFileStrategy extends BaseScraperStrategy {
     options: ScraperOptions,
     _signal?: AbortSignal,
   ): Promise<ProcessItemResult> {
-    // Parse the file URL properly to handle both file:// and file:/// formats
-    let filePath = item.url.replace(/^file:\/\/\/?/, "");
-    filePath = decodeURIComponent(filePath);
+    // Resolve the item path using the shared helper
+    const filePath = fileUrlToPath(item.url);
 
-    // Ensure absolute path on Unix-like systems (if not already absolute)
-    if (!filePath.startsWith("/") && process.platform !== "win32") {
-      filePath = `/${filePath}`;
+    // Compute the allowed base directory from the scrape root URL.
+    // All resolved paths must fall within this directory tree.
+    const rootPath = fileUrlToPath(options.url);
+    const baseDir = computeFileBaseDir(rootPath);
+
+    if (!isPathWithinBase(filePath, baseDir)) {
+      logger.warn(
+        `⚠️  Blocked path traversal: "${filePath}" is outside base directory "${baseDir}"`,
+      );
+      return {
+        url: item.url,
+        links: [],
+        status: FetchStatus.NOT_FOUND,
+      };
     }
 
     let stats: Awaited<ReturnType<typeof fs.stat>> | null = null;
@@ -94,6 +152,12 @@ export class LocalFileStrategy extends BaseScraperStrategy {
             return url.href;
           })
           .filter((url) => {
+            // Verify discovered path is within the base directory
+            const resolvedChild = fileUrlToPath(url);
+            if (!isPathWithinBase(resolvedChild, baseDir)) {
+              logger.debug(`Skipping out-of-base link: ${url}`);
+              return false;
+            }
             const allowed = this.shouldProcessUrl(url, options);
             if (!allowed) {
               logger.debug(`Skipping out-of-scope link: ${url}`);
@@ -138,7 +202,11 @@ export class LocalFileStrategy extends BaseScraperStrategy {
               }
             }
             logger.debug(`Found ${links.length} entries in archive ${filePath}`);
-            return { url: item.url, links, status: FetchStatus.SUCCESS };
+            return {
+              url: item.url,
+              links,
+              status: FetchStatus.SUCCESS,
+            };
           } catch (err) {
             logger.error(`❌ Failed to list archive ${filePath}: ${err}`);
             // Treat as binary file or fail?
@@ -176,7 +244,11 @@ export class LocalFileStrategy extends BaseScraperStrategy {
       // Handle NOT_MODIFIED status (file hasn't changed)
       if (rawContent.status === FetchStatus.NOT_MODIFIED) {
         logger.debug(`✓ File unchanged: ${filePath}`);
-        return { url: rawContent.source, links: [], status: FetchStatus.NOT_MODIFIED };
+        return {
+          url: rawContent.source,
+          links: [],
+          status: FetchStatus.NOT_MODIFIED,
+        };
       }
 
       return await this.processContent(item.url, filePath, rawContent, options);
@@ -296,7 +368,11 @@ export class LocalFileStrategy extends BaseScraperStrategy {
       logger.warn(
         `⚠️  Unsupported content type "${rawContent.mimeType}" for file ${displayPath}. Skipping processing.`,
       );
-      return { url: rawContent.source, links: [], status: FetchStatus.SUCCESS };
+      return {
+        url: rawContent.source,
+        links: [],
+        status: FetchStatus.SUCCESS,
+      };
     }
 
     for (const err of processed.errors ?? []) {

--- a/src/scraper/strategies/LocalFileStrategy.ts
+++ b/src/scraper/strategies/LocalFileStrategy.ts
@@ -30,10 +30,13 @@ export function fileUrlToPath(fileUrl: string): string {
 }
 
 /**
- * Determine the base directory for a given file:// URL.
- * - If the URL points to a directory, the base is that directory itself.
- * - If the URL points to a file, the base is its parent directory.
- * The returned path always ends with the platform path separator.
+ * Compute the base directory for containment checks given a resolved root path.
+ * The returned path always ends with the platform path separator so that
+ * prefix-based containment checks do not produce false positives
+ * (e.g. "/home/user/docs" won't match "/home/user/docs-other").
+ *
+ * Note: This function performs lexical normalization only — it does not
+ * distinguish between files and directories on disk.
  */
 function computeFileBaseDir(resolvedPath: string): string {
   // Append separator so that containment checks work correctly
@@ -45,13 +48,29 @@ function computeFileBaseDir(resolvedPath: string): string {
  * Check whether `candidate` is contained within `baseDir`
  * (or is exactly `baseDir` without trailing separator).
  * Both paths must already be resolved / normalized.
+ *
+ * Uses path.relative() for robust comparison, which also handles
+ * case-insensitive filesystems on Windows correctly.
  */
 function isPathWithinBase(candidate: string, baseDir: string): boolean {
+  const baseDirTrimmed = baseDir.replace(/[/\\]+$/, "");
+
   // Exact match (the root path itself)
-  if (candidate === baseDir || candidate === baseDir.replace(/[/\\]+$/, "")) {
+  if (candidate === baseDirTrimmed) {
     return true;
   }
-  return candidate.startsWith(baseDir);
+
+  // Use path.relative for robust containment check.
+  // If the relative path starts with ".." or is absolute, the candidate is outside.
+  const relative = path.relative(baseDirTrimmed, candidate);
+  if (relative === "") {
+    return true;
+  }
+  // Reject if relative path escapes upward or is an absolute path
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -63,8 +82,9 @@ function isPathWithinBase(candidate: string, baseDir: string): boolean {
  *
  * Security: All file paths are resolved via `path.resolve()` and verified to
  * reside within the root URL's directory tree before any filesystem access.
- * This prevents path-traversal attacks via `..` segments, percent-encoding
- * tricks, or symlinks that escape the intended directory.
+ * This prevents path-traversal attacks via `..` segments and percent-encoding
+ * tricks. Note: this is a lexical check only — symlinks within the base
+ * directory that point outside it are not detected by this mechanism.
  */
 export class LocalFileStrategy extends BaseScraperStrategy {
   private readonly fileFetcher = new FileFetcher();


### PR DESCRIPTION
## Summary

`LocalFileStrategy` (and the underlying `FileFetcher`) processes `file://` URLs without verifying that resolved paths stay within the root directory the user asked to scrape. When the strategy enumerates a directory or follows discovered links, a `..` segment, percent-encoded traversal (`%2e%2e`), or absolute path can take the scraper outside the intended docs root and cause arbitrary local files to be ingested into the searchable index.

- **Weakness:** CWE-22 (Improper Limitation of a Pathname to a Restricted Directory)
- **Affected files:** `src/scraper/strategies/LocalFileStrategy.ts`, `src/scraper/fetcher/FileFetcher.ts`
- **Data flow:** `options.url` / discovered link → `url.replace(/^file:\/\/\/?/, "")` → `decodeURIComponent(...)` → `fs.stat` / `fs.readFile` with no containment check.

## Fix

Two small, focused changes:

1. **`LocalFileStrategy.ts`** — extract a `fileUrlToPath()` helper that resolves any `file://` URL to a canonical absolute path via `path.resolve()`, and an `isPathWithinBase()` helper that performs prefix containment using `path.sep`-terminated base directories (so `/home/user/docs-other` is not accepted as inside `/home/user/docs`). The base directory is computed from `options.url` once and every item processed (whether it came from initial enumeration or a discovered link) is checked against it. Discovered links that escape the base are dropped before they enter the work queue; an item that somehow reaches `processItem` with an out-of-base path returns `FetchStatus.NOT_FOUND` and logs a warning.
2. **`FileFetcher.ts`** — call `path.resolve()` on the decoded path before any `fs` call so lexical traversal is collapsed at the lowest level too. This is defence-in-depth for any future caller that bypasses the strategy.

The fix is purely lexical (`path.resolve` + prefix check). It does not call `fs.realpath`, so a symlink that lives inside the root and points outside would still be followed — see *Limitations* below.

## Tests

Added `src/scraper/strategies/LocalFileStrategy.pathtraversal.test.ts` with three cases driven by `memfs`:

- Discovered links containing `..` that resolve to `/etc/passwd` are not processed.
- A scrape URL using percent-encoded traversal (`%2e%2e/%2e%2e/...etc/passwd`) does not produce a result containing the sensitive file's contents.
- Legitimate files inside the root are still processed normally (regression check).

All three pass locally. Existing `LocalFileStrategy` and `FileFetcher` tests continue to pass.

## Why this is exploitable

The MCP server is typically run as a long-lived local service that ingests docs the operator points it at, then surfaces the indexed content to an LLM client over MCP. The realistic exploitation paths are:

- **Malicious docs bundle / supply chain:** the operator scrapes a third-party docs archive or local folder that contains relative links such as `../../../../../etc/passwd` or `../../.ssh/id_rsa`. The strategy follows the link, indexes the file, and the contents become retrievable through `search_docs`.
- **Prompt-injection driven scraping:** an LLM client that can call `scrape_docs` is induced (via injected instructions in already-indexed content) to scrape a folder whose discovered links escape the root.

In both cases the operator-supplied root is benign — the attacker controls only the *links discovered under it*, which is exactly what the previous code trusted.

## Limitations (called out for the maintainer)

- The doc comment mentions symlinks, but `path.resolve` is purely lexical and does not canonicalize symlinks. A symlink inside the root pointing at `/etc/passwd` would still pass the containment check. If you'd like full symlink protection, a follow-up using `fs.realpath()` on both the candidate and the base would close that gap. I left this out of the current PR to keep the change minimal and avoid changing behaviour for legitimate symlinked docs trees, but happy to add it if you'd prefer.
- This does not (and cannot) protect against an operator who directly invokes `scrape_docs` with `file:///etc/passwd` as the root — in that case the attacker already controls the base directory. The fix is aimed at the much more common case where the root is legitimate but discovered content is not.

## Adversarial review

Before submitting I tried to disprove this. The main objection was "the operator chose the root, so they consented to read those files" — but that only holds for the root itself, not for paths reached via traversal in discovered links, and there is no existing containment check anywhere in the fetch/scrape pipeline (I traced from `options.url` through `processItem` to `fs.stat`/`fs.readFile` and found no validation between them). I also checked whether `URL` parsing or `decodeURIComponent` would normalise `..` away — they don't; `new URL("file:///a/b/../../etc/passwd").pathname` yields `/etc/passwd` and the previous code would happily `fs.readFile` it. So the gap is real and the fix is the minimal place to close it.

cc @lewiswigmore
