### PR TITLE
fix(auth): follow-up to #395 — Host pinning, JSON robustness, RFC 6749 error codes

### DIFF
--- a/docs/infrastructure/authentication.md
+++ b/docs/infrastructure/authentication.md
@@ -40,7 +40,7 @@ The server includes a built-in OAuth2 proxy that enables seamless integration wi
 - **Dynamic Client Registration (DCR)** - RFC 7591 compliant automatic client registration
 - **Resource Parameter Support** - RFC 8707 compliant multi-transport resource identification
 - **Multi-Transport Detection** - Automatic resource URL detection for SSE and HTTP transports
-- **Standard OAuth Flows** - Authorization Code, Client Credentials, and refresh token support
+- **Standard OAuth Flows** - Authorization Code and refresh token support
 - **Smart Discovery** - Uses OAuth2 authorization server discovery (RFC 8414) for comprehensive endpoint detection including DCR and JWKS
 
 ### Authentication Flow

--- a/src/auth/ProxyAuthManager.test.ts
+++ b/src/auth/ProxyAuthManager.test.ts
@@ -40,20 +40,23 @@ beforeEach(() => {
   server.resetHandlers();
 });
 
+type RouteHandler = (request: any, reply: any) => Promise<any>;
+
 /**
- * Helper to extract a registered route handler from mockServer.
- * After calling registerRoutes, finds the handler registered for the given method + path.
+ * Extract a registered route handler from mockServer. After registerRoutes
+ * has been called, finds the handler bound to the given method + path on the
+ * mocked Fastify instance.
  */
 function getHandler(
   mockServer: FastifyInstance,
   method: "get" | "post",
   path: string,
-): (request: any, reply: any) => Promise<any> {
-  const calls = (mockServer[method] as ReturnType<typeof vi.fn>).mock.calls;
-  const match = calls.find(([p]: [string]) => p === path);
+): RouteHandler {
+  const mockFn = vi.mocked(mockServer[method] as (...args: unknown[]) => unknown);
+  const match = mockFn.mock.calls.find((call) => call[0] === path);
   if (!match)
     throw new Error(`No handler registered for ${method.toUpperCase()} ${path}`);
-  return match[1];
+  return match[1] as RouteHandler;
 }
 
 /** Create a minimal mock Fastify reply object. */
@@ -265,7 +268,7 @@ describe("ProxyAuthManager", () => {
       authManager.registerRoutes(mockServer, new URL("https://server.example.com"));
     });
 
-    it("should reject missing response_type with 400", async () => {
+    it("should reject missing response_type with 400 invalid_request", async () => {
       const handler = getHandler(mockServer, "get", "/oauth/authorize");
       const reply = createMockReply();
       const request = {
@@ -277,7 +280,7 @@ describe("ProxyAuthManager", () => {
       await handler(request, reply);
 
       expect(reply.status).toHaveBeenCalledWith(400);
-      expect(reply.body.error).toBe("unsupported_response_type");
+      expect(reply.body.error).toBe("invalid_request");
     });
 
     it("should reject unsupported response_type (e.g. token) with 400", async () => {
@@ -295,12 +298,17 @@ describe("ProxyAuthManager", () => {
       expect(reply.body.error).toBe("unsupported_response_type");
     });
 
-    it("should redirect to upstream with resource parameter forced for valid response_type", async () => {
+    it("should pin resource to baseUrl regardless of client-supplied resource or Host header", async () => {
+      // Combined coverage of both audience-binding attack vectors:
+      //   - client passes a malicious `resource` query param
+      //   - client spoofs the `Host` header
+      // Both must be ignored; the pinned value must come from the trusted
+      // `baseUrl` passed to registerRoutes.
       const handler = getHandler(mockServer, "get", "/oauth/authorize");
       const reply = createMockReply();
       const request = {
         protocol: "https",
-        headers: { host: "server.example.com" },
+        headers: { host: "attacker.example.com" },
         query: {
           response_type: "code",
           client_id: "abc",
@@ -312,10 +320,7 @@ describe("ProxyAuthManager", () => {
       await handler(request, reply);
 
       expect(reply.redirect).toHaveBeenCalled();
-      const redirectUrl = reply.redirectUrl as string;
-      expect(redirectUrl).toContain("auth.example.com/oauth/authorize");
-      // Verify resource was overwritten to this server's own identifier
-      const params = new URL(redirectUrl).searchParams;
+      const params = new URL(reply.redirectUrl as string).searchParams;
       expect(params.get("resource")).toBe("https://server.example.com/sse");
     });
   });
@@ -327,7 +332,7 @@ describe("ProxyAuthManager", () => {
       authManager.registerRoutes(mockServer, new URL("https://server.example.com"));
     });
 
-    it("should reject missing grant_type with 400", async () => {
+    it("should reject missing grant_type with 400 invalid_request", async () => {
       const handler = getHandler(mockServer, "post", "/oauth/token");
       const reply = createMockReply();
       const request = {
@@ -339,7 +344,7 @@ describe("ProxyAuthManager", () => {
       await handler(request, reply);
 
       expect(reply.status).toHaveBeenCalledWith(400);
-      expect(reply.body.error).toBe("unsupported_grant_type");
+      expect(reply.body.error).toBe("invalid_request");
     });
 
     it("should reject unsupported grant_type (e.g. client_credentials) with 400", async () => {
@@ -361,16 +366,21 @@ describe("ProxyAuthManager", () => {
       expect(reply.body.error).toBe("unsupported_grant_type");
     });
 
-    it("should proxy valid grant_type to upstream with forced resource parameter", async () => {
-      // Mock upstream token endpoint
+    it("should proxy valid grant_type and pin resource on the upstream request, ignoring client resource and Host", async () => {
+      // Combined coverage of both audience-binding attack vectors against the
+      // token endpoint:
+      //   - client passes a malicious `resource` form field
+      //   - client spoofs the `Host` header
+      // Asserts the byte that actually reaches the upstream AS, which is what
+      // ultimately controls token audience binding.
+      let receivedResource: string | null = null;
       server.use(
         http.post("https://auth.example.com/oauth/token", async ({ request }) => {
-          const body = await request.text();
-          const params = new URLSearchParams(body);
+          const params = new URLSearchParams(await request.text());
+          receivedResource = params.get("resource");
           return HttpResponse.json({
             access_token: "at_123",
             token_type: "Bearer",
-            resource_received: params.get("resource"),
           });
         }),
       );
@@ -379,7 +389,7 @@ describe("ProxyAuthManager", () => {
       const reply = createMockReply();
       const request = {
         protocol: "https",
-        headers: { host: "server.example.com" },
+        headers: { host: "attacker.example.com" },
         body: {
           grant_type: "authorization_code",
           code: "auth_code_123",
@@ -391,18 +401,37 @@ describe("ProxyAuthManager", () => {
       await handler(request, reply);
 
       expect(reply.body.access_token).toBe("at_123");
-      // Verify the resource was overwritten
-      expect(reply.body.resource_received).toBe("https://server.example.com/sse");
+      expect(receivedResource).toBe("https://server.example.com/sse");
     });
 
-    it("should accept refresh_token grant_type", async () => {
-      server.use(
-        http.post("https://auth.example.com/oauth/token", async () => {
-          return HttpResponse.json({
-            access_token: "at_refreshed",
-            token_type: "Bearer",
-          });
+    it.each([
+      {
+        name: "HTML body",
+        response: new HttpResponse("<html>502 Bad Gateway</html>", {
+          status: 502,
+          headers: { "Content-Type": "text/html" },
         }),
+      },
+      {
+        name: "empty body",
+        response: new HttpResponse(null, { status: 502 }),
+      },
+      {
+        name: "JSON null literal",
+        response: new HttpResponse("null", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      },
+    ])("should return a 502 JSON error when the upstream returns $name", async ({
+      response: upstreamResponse,
+    }) => {
+      // Defends against upstream non-object responses (HTML pages, empty
+      // bodies, bare `null`) turning into an unhandled 500 or a misleading
+      // `null` payload. Clients must always see a parseable OAuth-style
+      // error envelope.
+      server.use(
+        http.post("https://auth.example.com/oauth/token", () => upstreamResponse),
       );
 
       const handler = getHandler(mockServer, "post", "/oauth/token");
@@ -410,12 +439,46 @@ describe("ProxyAuthManager", () => {
       const request = {
         protocol: "https",
         headers: { host: "server.example.com" },
-        body: { grant_type: "refresh_token", refresh_token: "rt_123" },
+        body: { grant_type: "authorization_code", code: "abc" },
       };
 
       await handler(request, reply);
 
-      expect(reply.body.access_token).toBe("at_refreshed");
+      expect(reply.status).toHaveBeenCalledWith(502);
+      expect(reply.body.error).toBe("server_error");
+    });
+  });
+
+  describe("/.well-known/oauth-protected-resource metadata", () => {
+    beforeEach(async () => {
+      authManager = new ProxyAuthManager(validAuthConfig);
+      await authManager.initialize();
+      authManager.registerRoutes(mockServer, new URL("https://server.example.com"));
+    });
+
+    it("should pin all metadata identifiers to baseUrl, ignoring Host", async () => {
+      // RFC 9728 metadata tells clients which resource to audience-bind tokens
+      // to; if we derived `resource` from `request.headers.host`, an attacker
+      // who can reach this endpoint with a spoofed Host could publish a
+      // metadata document pointing clients at the wrong resource.
+      const handler = getHandler(
+        mockServer,
+        "get",
+        "/.well-known/oauth-protected-resource",
+      );
+      const reply = createMockReply();
+      await handler(
+        { protocol: "https", headers: { host: "attacker.example.com" } },
+        reply,
+      );
+
+      expect(reply.body.resource).toBe("https://server.example.com/sse");
+      expect(reply.body.resource_server_metadata_url).toBe(
+        "https://server.example.com/.well-known/oauth-protected-resource",
+      );
+      expect(
+        reply.body.mcp_transports.map((t: { endpoint: string }) => t.endpoint),
+      ).toEqual(["https://server.example.com/sse", "https://server.example.com/mcp"]);
     });
   });
 

--- a/src/auth/ProxyAuthManager.ts
+++ b/src/auth/ProxyAuthManager.ts
@@ -30,6 +30,48 @@ export const ALLOWED_GRANT_TYPES = new Set(["authorization_code", "refresh_token
  */
 export const ALLOWED_RESPONSE_TYPES = new Set(["code"]);
 
+/**
+ * Forward a proxied upstream response to the client as JSON, defending against
+ * the upstream returning a non-JSON body (e.g. an HTML 502 page from an
+ * intermediate proxy). Calling `response.json()` directly would throw a
+ * SyntaxError in that case, leaving Fastify to emit an unhandled 500 with no
+ * useful error envelope. Instead we surface a spec-shaped OAuth error so the
+ * MCP client sees a parseable JSON body.
+ */
+async function sendUpstreamJsonResponse(
+  reply: import("fastify").FastifyReply,
+  response: Response,
+  upstream: string,
+): Promise<void> {
+  const text = await response.text();
+  // Both /oauth/token and /oauth/register are specified to return a JSON
+  // object; an empty body — like a non-JSON body — is treated as an upstream
+  // failure rather than silently forwarded. Forwarding `null` would technically
+  // be valid JSON but defeats the purpose of this helper: clients expect an
+  // object they can read `.error` / `.access_token` from.
+  if (text.length > 0) {
+    try {
+      const data = JSON.parse(text);
+      if (data !== null && typeof data === "object") {
+        reply.status(response.status).type("application/json").send(data);
+        return;
+      }
+    } catch {
+      // fall through to the error envelope below
+    }
+  }
+  logger.warn(
+    `Upstream ${upstream} endpoint returned a non-JSON-object body (status=${response.status}, bytes=${text.length})`,
+  );
+  reply
+    .status(502)
+    .type("application/json")
+    .send({
+      error: "server_error",
+      error_description: `Upstream ${upstream} endpoint returned an invalid response.`,
+    });
+}
+
 export class ProxyAuthManager {
   private proxyProvider: ProxyOAuthServerProvider | null = null;
   private discoveredEndpoints: {
@@ -140,30 +182,37 @@ export class ProxyAuthManager {
       reply.type("application/json").send(metadata);
     });
 
-    // OAuth2 Protected Resource Metadata (RFC 9728)
-    server.get("/.well-known/oauth-protected-resource", async (request, reply) => {
-      const baseUrl = `${request.protocol}://${request.headers.host}`;
+    // OAuth2 Protected Resource Metadata (RFC 9728).
+    //
+    // Identifiers here are derived from the trusted `baseUrl` (config-driven),
+    // not from `request.headers.host`. The Host header is client-controlled,
+    // and this metadata is consumed by clients to decide which resource server
+    // to bind tokens to — so trusting the Host header here would reintroduce
+    // the audience-binding attack vector that the OAuth proxy itself defends
+    // against.
+    server.get("/.well-known/oauth-protected-resource", async (_request, reply) => {
+      const origin = baseUrl.origin;
       const metadata = {
-        resource: `${baseUrl}/sse`,
+        resource: `${origin}/sse`,
         authorization_servers: [this.config.issuerUrl],
         scopes_supported: ["profile", "email"],
         bearer_methods_supported: ["header"],
         resource_name: "Documentation MCP Server",
         resource_documentation: "https://github.com/arabold/docs-mcp-server#readme",
         // Enhanced metadata for better discoverability
-        resource_server_metadata_url: `${baseUrl}/.well-known/oauth-protected-resource`,
+        resource_server_metadata_url: `${origin}/.well-known/oauth-protected-resource`,
         authorization_server_metadata_url: `${this.config.issuerUrl}/.well-known/openid-configuration`,
         jwks_uri: `${this.config.issuerUrl}/.well-known/jwks.json`,
         // Supported MCP transports
         mcp_transports: [
           {
             transport: "sse",
-            endpoint: `${baseUrl}/sse`,
+            endpoint: `${origin}/sse`,
             description: "Server-Sent Events transport",
           },
           {
             transport: "http",
-            endpoint: `${baseUrl}/mcp`,
+            endpoint: `${origin}/mcp`,
             description: "Streaming HTTP transport",
           },
         ],
@@ -172,18 +221,31 @@ export class ProxyAuthManager {
       reply.type("application/json").send(metadata);
     });
 
+    // Resource identifier pinned to the trusted `baseUrl` (config-derived),
+    // NOT to `request.headers.host`. The Host header is client-controlled and
+    // can be spoofed when the deployment lacks strict Host validation upstream,
+    // which would reintroduce the very audience-binding attack this proxy is
+    // meant to prevent.
+    const pinnedResourceUrl = `${baseUrl.origin}/sse`;
+
     // OAuth2 Authorization endpoint
     server.get("/oauth/authorize", async (request, reply) => {
-      // In a proxy setup, redirect to the upstream authorization server
-      const endpoints = await this.discoverEndpoints();
       const params = new URLSearchParams(request.query as Record<string, string>);
 
-      // Validate response_type matches what this AS advertises (RFC 6749 §3.1.1).
-      // Rejecting unsupported values prevents the proxy from being used to drive
-      // arbitrary upstream flows (e.g. implicit/hybrid) that this server does
-      // not support and that bypass the resource binding below.
+      // Validate response_type matches what this AS advertises (RFC 6749 §3.1.1
+      // and §4.1.2.1). A missing parameter is `invalid_request`; a value that
+      // is present but unsupported is `unsupported_response_type`. Validation
+      // runs before upstream discovery so that bogus requests do not incur a
+      // network round-trip to the authorization server.
       const responseType = params.get("response_type");
-      if (!responseType || !ALLOWED_RESPONSE_TYPES.has(responseType)) {
+      if (!responseType) {
+        reply.status(400).type("application/json").send({
+          error: "invalid_request",
+          error_description: "Missing required parameter 'response_type'.",
+        });
+        return;
+      }
+      if (!ALLOWED_RESPONSE_TYPES.has(responseType)) {
         reply.status(400).type("application/json").send({
           error: "unsupported_response_type",
           error_description: "Only the 'code' response_type is supported by this proxy.",
@@ -191,48 +253,54 @@ export class ProxyAuthManager {
         return;
       }
 
-      // Force the resource parameter (RFC 8707) to one of this server's own
-      // resource identifiers. Trusting a client-supplied `resource` here would
-      // let a caller mint tokens audience-bound to a different resource server
-      // and replay them against that server.
-      const resourceUrl = `${request.protocol}://${request.headers.host}/sse`;
-      params.set("resource", resourceUrl);
+      // Force the resource parameter (RFC 8707) to this server's own resource
+      // identifier. Trusting a client-supplied `resource` here would let a
+      // caller mint tokens audience-bound to a different resource server and
+      // replay them against that server.
+      params.set("resource", pinnedResourceUrl);
 
+      const endpoints = await this.discoverEndpoints();
       const redirectUrl = `${endpoints.authorizationUrl}?${params.toString()}`;
       reply.redirect(redirectUrl);
     });
 
     // OAuth2 Token endpoint
     server.post("/oauth/token", async (request, reply) => {
-      // Proxy token requests to the upstream server
-      const endpoints = await this.discoverEndpoints();
-
-      // Prepare token request body, preserving resource parameter if present
       const tokenBody = new URLSearchParams(request.body as Record<string, string>);
 
-      // Validate grant_type against the allow-list advertised in our AS metadata
-      // (RFC 6749 §4 / RFC 8628). Without this check the proxy is effectively an
-      // open relay to the upstream token endpoint and could be used to obtain
-      // tokens via grants this resource server never sanctioned (e.g. password,
-      // client_credentials, urn:ietf:params:oauth:grant-type:*).
+      // Validate grant_type against the allow-list advertised in our AS
+      // metadata (RFC 6749 §4 / §5.2). A missing parameter is `invalid_request`;
+      // a present-but-unsupported value is `unsupported_grant_type`. Without
+      // this check the proxy is effectively an open relay to the upstream token
+      // endpoint and could be used to obtain tokens via grants this resource
+      // server never sanctioned (e.g. password, client_credentials,
+      // urn:ietf:params:oauth:grant-type:*).
       const grantType = tokenBody.get("grant_type");
-      if (!grantType || !ALLOWED_GRANT_TYPES.has(grantType)) {
+      if (!grantType) {
+        reply.status(400).type("application/json").send({
+          error: "invalid_request",
+          error_description: "Missing required parameter 'grant_type'.",
+        });
+        return;
+      }
+      if (!ALLOWED_GRANT_TYPES.has(grantType)) {
         reply
           .status(400)
           .type("application/json")
           .send({
             error: "unsupported_grant_type",
-            error_description: `Grant type '${grantType ?? ""}' is not supported by this proxy.`,
+            error_description: `Grant type '${grantType}' is not supported by this proxy.`,
           });
         return;
       }
 
-      // Force the resource parameter (RFC 8707) to one of this server's own
-      // resource identifiers, regardless of what the client requested. This
-      // ensures the upstream AS audience-binds the issued token to this MCP
-      // server and not an arbitrary attacker-chosen resource.
-      const resourceUrl = `${request.protocol}://${request.headers.host}/sse`;
-      tokenBody.set("resource", resourceUrl);
+      // Force the resource parameter (RFC 8707) to this server's own resource
+      // identifier, regardless of what the client requested. This ensures the
+      // upstream AS audience-binds the issued token to this MCP server and not
+      // an arbitrary attacker-chosen resource.
+      tokenBody.set("resource", pinnedResourceUrl);
+
+      const endpoints = await this.discoverEndpoints();
 
       const response = await fetch(endpoints.tokenUrl, {
         method: "POST",
@@ -242,8 +310,7 @@ export class ProxyAuthManager {
         body: tokenBody.toString(),
       });
 
-      const data = await response.json();
-      reply.status(response.status).type("application/json").send(data);
+      await sendUpstreamJsonResponse(reply, response, "token");
     });
 
     // OAuth2 Token Revocation endpoint
@@ -278,8 +345,7 @@ export class ProxyAuthManager {
           body: JSON.stringify(request.body),
         });
 
-        const data = await response.json();
-        reply.status(response.status).type("application/json").send(data);
+        await sendUpstreamJsonResponse(reply, response, "register");
       } else {
         reply.status(404).send({ error: "Dynamic client registration not supported" });
       }

--- a/test/auth-e2e.test.ts
+++ b/test/auth-e2e.test.ts
@@ -179,6 +179,90 @@ describe("Authentication End-to-End Tests", () => {
     }, 10000);
   });
 
+  describe("OAuth Proxy Endpoint Hardening", () => {
+    // These tests exercise the rejection paths added in the OAuth proxy
+    // hardening change. They run entirely against the local server — the
+    // proxy validates and short-circuits before any upstream AS discovery,
+    // so a reachable Clerk instance is not required for these cases.
+
+    it("should reject /oauth/token requests with missing grant_type as invalid_request", async () => {
+      if (!process.env.DOCS_MCP_AUTH_ISSUER_URL || !process.env.DOCS_MCP_AUTH_AUDIENCE) {
+        console.log("⚠️  Skipping test - authentication not configured");
+        return;
+      }
+
+      const response = await fetch(`${baseUrl}/oauth/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ code: "anything" }).toString(),
+      });
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("invalid_request");
+    }, 10000);
+
+    it("should reject /oauth/token requests with unsupported grant_type", async () => {
+      if (!process.env.DOCS_MCP_AUTH_ISSUER_URL || !process.env.DOCS_MCP_AUTH_AUDIENCE) {
+        console.log("⚠️  Skipping test - authentication not configured");
+        return;
+      }
+
+      const response = await fetch(`${baseUrl}/oauth/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "client_credentials",
+          client_id: "x",
+          client_secret: "y",
+        }).toString(),
+      });
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("unsupported_grant_type");
+    }, 10000);
+
+    it("should reject /oauth/authorize requests with unsupported response_type", async () => {
+      if (!process.env.DOCS_MCP_AUTH_ISSUER_URL || !process.env.DOCS_MCP_AUTH_AUDIENCE) {
+        console.log("⚠️  Skipping test - authentication not configured");
+        return;
+      }
+
+      const url = new URL(`${baseUrl}/oauth/authorize`);
+      url.searchParams.set("response_type", "token");
+      url.searchParams.set("client_id", "x");
+
+      const response = await fetch(url.toString(), { redirect: "manual" });
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("unsupported_response_type");
+    }, 10000);
+
+    it("should advertise only allow-listed grant/response types in AS metadata", async () => {
+      if (!process.env.DOCS_MCP_AUTH_ISSUER_URL || !process.env.DOCS_MCP_AUTH_AUDIENCE) {
+        console.log("⚠️  Skipping test - authentication not configured");
+        return;
+      }
+
+      const response = await fetch(
+        `${baseUrl}/.well-known/oauth-authorization-server`,
+      );
+      expect(response.status).toBe(200);
+      const metadata = (await response.json()) as {
+        response_types_supported: string[];
+        grant_types_supported: string[];
+      };
+
+      expect(metadata.response_types_supported).toEqual(["code"]);
+      expect(metadata.grant_types_supported).toEqual([
+        "authorization_code",
+        "refresh_token",
+      ]);
+    }, 10000);
+  });
+
   describe("Environment Variable Configuration", () => {
     it("should load authentication configuration from environment variables", () => {
       // Skip if no auth config


### PR DESCRIPTION
## Summary

Follow-up to #395 addressing the issues raised in code review. Builds on top of that PR's commits; should merge after #395.

**What changes on top of #395:**

- **Host-header injection on resource pinning** — the original PR derives the RFC 8707 `resource` from `${request.protocol}://${request.headers.host}`. The Host header is client-controllable, so without strict upstream Host validation an attacker could reintroduce the audience-binding attack #395 was closing. This PR pins the resource to the trusted `baseUrl.origin` (config-driven, passed into `registerRoutes`) on both `/oauth/authorize` and `/oauth/token`.
- **Same fix for `/.well-known/oauth-protected-resource`** — the RFC 9728 metadata document was deriving its `resource`, `resource_server_metadata_url`, and `mcp_transports` endpoints from the Host header. Since clients use this document to decide which resource to audience-bind tokens to, the Host-injection class applies here too. Now derived from `baseUrl.origin`.
- **RFC 6749 error-code precision** — `unsupported_grant_type` / `unsupported_response_type` are reserved for *present but unsupported* values. A missing parameter is `invalid_request` per RFC 6749 §4.1.2.1 / §5.2. Split into two branches per handler.
- **Validation before discovery** — moved param validation ahead of `discoverEndpoints()` so bogus requests fail without a network round-trip to the AS.
- **Robust upstream JSON parsing** — `await response.json()` on the upstream `/oauth/token` and `/oauth/register` responses would throw on non-JSON bodies (e.g. an HTML 502 from an intermediate proxy), turning an upstream failure into an unhandled 500. New `sendUpstreamJsonResponse` helper returns a spec-shaped 502 OAuth error envelope in that case.
- **Docs** — removed the stale "Client Credentials" claim from `docs/infrastructure/authentication.md`. That grant is not (and was never) advertised in the AS metadata, and is now explicitly rejected.
- **Test helper typing** — replaced an unsafe cast in `getHandler` so the test file typechecks cleanly under `tsc --noEmit`.

## Test coverage

Consolidated to 9 high-signal unit tests for the new behavior (after auditing for redundancy):

- Missing-vs-unsupported error codes for both endpoints (4 tests)
- Combined resource + Host pinning on `/oauth/authorize` (asserts the redirect URL)
- Combined resource + Host pinning on `/oauth/token` (asserts the byte that actually reaches the upstream AS)
- `/.well-known/oauth-protected-resource` pinning under a spoofed Host
- 502 fallback for non-JSON upstream bodies
- Constants-consistency test pre-existing from #395

Plus 4 e2e tests in `test/auth-e2e.test.ts` exercising the real Fastify routes (env-gated to match existing e2e style).

**Verification:** all 30 auth tests pass (`vitest run src/auth`), full repo `tsc --noEmit` is clean.

## Why a separate PR

#395 is from a first-time contributor and is already focused — keeping the additional hardening as a follow-up makes both diffs easier to review.

## Test plan

- [ ] `npx vitest run src/auth` — all green
- [ ] `npx tsc --noEmit` — clean
- [ ] Manual: confirm AS metadata at `/.well-known/oauth-authorization-server` still lists `["authorization_code","refresh_token"]` / `["code"]`
- [ ] Manual: confirm `/oauth/token` with `grant_type=client_credentials` returns 400 `unsupported_grant_type` without contacting upstream
- [ ] Manual: confirm a request with `Host: attacker.example.com` to `/.well-known/oauth-protected-resource` still returns the configured base URL as the resource

🤖 Generated with [Claude Code](https://claude.com/claude-code)