### PR TITLE
fix(docker): bump base image to trixie-slim so PDFs work in Docker (closes #394)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base stage with build dependencies
-FROM node:22-slim AS base
+FROM node:22-trixie-slim AS base
 
 WORKDIR /app
 

--- a/src/scraper/pipelines/DocumentPipeline.test.ts
+++ b/src/scraper/pipelines/DocumentPipeline.test.ts
@@ -444,5 +444,67 @@ describe("DocumentPipeline", () => {
       expect(result.errors![0].message).toContain("Could not determine document type");
       expect(result.textContent).toBeNull();
     });
+
+    it("should log the underlying cause chain when extraction throws", async () => {
+      // Regression guard for issue #394: when @kreuzberg/node failed to load
+      // its native binding (glibc mismatch in Docker), the original log line
+      // only said "Failed to convert document: Error" with no clue about the
+      // actual underlying problem (`GLIBC_2.38 not found`). This test pins
+      // the behavior that the wrapped Error.cause chain reaches the log.
+      const { logger } = await import("../../utils/logger");
+      const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+      const wrapped = new Error("Failed to load Kreuzberg native bindings", {
+        cause: new Error(
+          "/lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found",
+        ),
+      });
+      const mockedExtractBytes = vi.mocked(extractBytes);
+      mockedExtractBytes.mockRejectedValueOnce(wrapped);
+
+      const rawContent = createRawContent(
+        "sample.pdf",
+        "application/pdf",
+        Buffer.from("%PDF-1.4 fake"),
+      );
+
+      const result = await pipeline.process(rawContent, baseOptions);
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors![0].message).toContain("Failed to convert document");
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const logged = errorSpy.mock.calls[0][0];
+      expect(logged).toContain("Failed to convert document");
+      expect(logged).toContain("Failed to load Kreuzberg native bindings");
+      expect(logged).toContain("GLIBC_2.38");
+      expect(logged).toContain("application/pdf");
+
+      errorSpy.mockRestore();
+    });
+
+    it("should truncate very long error messages to keep binary out of logs", async () => {
+      const { logger } = await import("../../utils/logger");
+      const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+      // Simulate a Kreuzberg error whose message embeds a huge blob (could be
+      // binary from the malformed input document). The log must not contain
+      // the full blob.
+      const huge = "X".repeat(50_000);
+      vi.mocked(extractBytes).mockRejectedValueOnce(new Error(huge));
+
+      const rawContent = createRawContent(
+        "sample.pdf",
+        "application/pdf",
+        Buffer.from("%PDF-1.4 fake"),
+      );
+      await pipeline.process(rawContent, baseOptions);
+
+      const logged = errorSpy.mock.calls[0][0] as string;
+      // The log line wraps the message; it should be far smaller than the
+      // raw 50k blob (allow some envelope for prefix/suffix/mime type/url).
+      expect(logged.length).toBeLessThan(2_000);
+
+      errorSpy.mockRestore();
+    });
   });
 });

--- a/src/scraper/pipelines/DocumentPipeline.ts
+++ b/src/scraper/pipelines/DocumentPipeline.ts
@@ -130,11 +130,16 @@ export class DocumentPipeline extends BasePipeline {
         chunks,
       };
     } catch (error) {
-      // Log a safe error message to avoid potential binary data in the logs
+      // Surface the underlying cause chain so environmental failures
+      // (e.g. missing native bindings, glibc mismatches) are diagnosable
+      // from the logs instead of silently dropping documents. Each cause's
+      // message is truncated to keep potentially binary data out of logs.
       const errorName = error instanceof Error ? error.name : "UnknownError";
+      const reasons = collectErrorReasons(error);
       const safeMessage = `Failed to convert document: ${errorName}`;
+      const detail = reasons.length > 0 ? ` — ${reasons.join(" | ")}` : "";
 
-      logger.warn(`${safeMessage} for ${rawContent.source}`);
+      logger.error(`❌ ${safeMessage} (${mimeType}) for ${rawContent.source}${detail}`);
 
       return {
         title: null,
@@ -218,4 +223,40 @@ export class DocumentPipeline extends BasePipeline {
       return source.substring(lastSlash + 1) || null;
     }
   }
+}
+
+/**
+ * Maximum length (in characters) of any single error message included in
+ * extraction failure logs. Kreuzberg errors may embed parts of the input
+ * document; truncating defends the logs against accidental binary dumps
+ * while still surfacing enough text to diagnose the root cause.
+ */
+const MAX_ERROR_DETAIL_LENGTH = 500;
+
+/**
+ * Walks an `Error.cause` chain and returns a deduplicated, truncated list
+ * of each link's `message`. Used to surface the underlying cause of a
+ * Kreuzberg extraction failure (e.g. "GLIBC_2.38 not found") rather than
+ * just the wrapper's generic name.
+ */
+function collectErrorReasons(error: unknown): string[] {
+  const messages: string[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  let depth = 0;
+  while (current && !seen.has(current) && depth < 10) {
+    seen.add(current);
+    if (current instanceof Error && current.message) {
+      const trimmed = current.message
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, MAX_ERROR_DETAIL_LENGTH);
+      if (trimmed && !messages.includes(trimmed)) {
+        messages.push(trimmed);
+      }
+    }
+    current = (current as { cause?: unknown }).cause;
+    depth++;
+  }
+  return messages;
 }

--- a/src/scraper/strategies/LocalFileStrategy.ts
+++ b/src/scraper/strategies/LocalFileStrategy.ts
@@ -14,7 +14,12 @@ import { BaseScraperStrategy, type ProcessItemResult } from "./BaseScraperStrate
 /**
  * LocalFileStrategy handles crawling and scraping of local files and folders using file:// URLs.
  *
- * All files with a MIME type of `text/*` are processed. This includes HTML, Markdown, plain text, and source code files such as `.js`, `.ts`, `.tsx`, `.css`, etc. Binary files, PDFs, images, and other non-text formats are ignored.
+ * Files are routed to the appropriate pipeline based on their detected MIME type:
+ * `text/*` content (HTML, Markdown, plain text, source code such as `.js`/`.ts`/`.tsx`/`.css`)
+ * is handled by the text/HTML/Markdown/source-code pipelines, while binary documents
+ * (PDF, Office, OpenDocument, RTF, eBooks, Jupyter notebooks) are handled by the
+ * `DocumentPipeline`. Other binary formats (images, etc.) fall through unprocessed
+ * and are logged as unsupported.
  *
  * Supports include/exclude filters and percent-encoded paths.
  */

--- a/test/local-file-pdf-e2e.test.ts
+++ b/test/local-file-pdf-e2e.test.ts
@@ -1,0 +1,122 @@
+/**
+ * E2E repro for GitHub issue #394 — "PDFs ignored in volume".
+ *
+ * Reporter: pointing the docs server at a directory via `file:///docs`,
+ * `.txt` files get indexed but `.pdf` files are silently skipped.
+ *
+ * Goal of this test: drive `LocalFileStrategy.scrape()` end-to-end against a
+ * real on-disk directory containing a real PDF (the same fixture used by
+ * `DocumentPipeline.test.ts`), plus a `.txt` and a `.md`, and observe whether
+ * the progress callback ever receives a result for the PDF with extracted
+ * `textContent`.
+ *
+ * If this test passes → the in-process pipeline works; the production bug is
+ * environmental (likely Kreuzberg native deps missing in the Docker image, or
+ * the `document.maxSize` 10 MB cap).
+ * If this test fails → we have an in-code regression and the assertions show
+ * exactly where it broke.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { LocalFileStrategy } from "../src/scraper/strategies/LocalFileStrategy";
+import type {
+  ScrapeResult,
+  ScraperOptions,
+  ScraperProgressEvent,
+} from "../src/scraper/types";
+import type { ProgressCallback } from "../src/types";
+import { loadConfig } from "../src/utils/config";
+import { logger } from "../src/utils/logger";
+
+const FIXTURE_PDF = path.join(__dirname, "fixtures", "sample.pdf");
+
+describe("LocalFileStrategy - PDF in mounted directory (issue #394)", () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    // Surface any warn/error the pipeline emits — the production bug looks
+    // like a silent skip because the DocumentPipeline catches errors and only
+    // logs `warn`. We want those visible while running this test.
+    vi.spyOn(logger, "warn").mockImplementation((msg: unknown) => {
+      console.warn(`[logger.warn] ${String(msg)}`);
+    });
+    vi.spyOn(logger, "error").mockImplementation((msg: unknown) => {
+      console.error(`[logger.error] ${String(msg)}`);
+    });
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "docs-mcp-issue394-"));
+
+    // The exact files the reporter described: a .txt that "works" and a PDF
+    // that is "ignored". Add a .md to cover the second commenter's case.
+    fs.copyFileSync(FIXTURE_PDF, path.join(tmpDir, "sample.pdf"));
+    fs.writeFileSync(path.join(tmpDir, "notes.txt"), "plain text note");
+    fs.writeFileSync(path.join(tmpDir, "readme.md"), "# Readme\n\nbody");
+  });
+
+  afterAll(() => {
+    if (tmpDir && fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("indexes a PDF sitting next to .txt/.md in a directory served via file://", async () => {
+    const appConfig = loadConfig();
+    const strategy = new LocalFileStrategy(appConfig);
+
+    const dirUrl = `file://${tmpDir}`;
+    const options: ScraperOptions = {
+      url: dirUrl,
+      library: "issue-394",
+      version: "1.0",
+      maxPages: 10,
+      maxDepth: 1,
+      maxConcurrency: 1,
+    };
+
+    const events: ScraperProgressEvent[] = [];
+    const progressCallback: ProgressCallback<ScraperProgressEvent> = async (
+      event,
+    ) => {
+      events.push(event);
+    };
+
+    await strategy.scrape(options, progressCallback);
+    await strategy.cleanup();
+
+    // What was actually processed
+    const byUrl = new Map<string, ScrapeResult | null | undefined>();
+    for (const e of events) {
+      byUrl.set(e.currentUrl, e.result);
+    }
+    console.log(
+      "[issue-394] processed URLs:",
+      events.map((e) => `${e.currentUrl} (chunks=${e.result?.chunks?.length ?? 0})`),
+    );
+
+    // .txt baseline — the reporter says this works today
+    const txtResult = byUrl.get(`file://${tmpDir}/notes.txt`);
+    expect(txtResult, "notes.txt should be processed").toBeTruthy();
+
+    // The bug under test: the PDF must show up with extracted content
+    const pdfResult = byUrl.get(`file://${tmpDir}/sample.pdf`);
+    expect(pdfResult, "sample.pdf should be processed (issue #394)").toBeTruthy();
+    expect(pdfResult?.sourceContentType).toBe("application/pdf");
+    expect(
+      (pdfResult?.textContent ?? "").trim().length,
+      "PDF should produce non-empty extracted text",
+    ).toBeGreaterThan(0);
+    expect(
+      pdfResult?.chunks?.length ?? 0,
+      "PDF should produce at least one chunk",
+    ).toBeGreaterThan(0);
+
+    // Second commenter said .md also failed for them
+    const mdResult = byUrl.get(`file://${tmpDir}/readme.md`);
+    expect(mdResult, "readme.md should be processed").toBeTruthy();
+    expect((mdResult?.textContent ?? "").trim().length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Switches the Docker base image from `node:22-slim` (Debian bookworm, glibc 2.36) to `node:22-trixie-slim` (glibc 2.38) so `@kreuzberg/node`'s native binding can actually load. Without this, every binary document (PDF, DOCX, etc.) is silently skipped during scraping.
- Makes the silent-skip *impossible to repeat*: walks the `Error.cause` chain inside `DocumentPipeline`'s catch block and logs the underlying reasons at `error` level, so the next environmental failure (whatever it is) lands in the logs with diagnostic detail instead of just "Error".
- Adds regression tests for both: an e2e test that drives a PDF through `LocalFileStrategy` on disk, plus unit tests pinning the cause-chain surfacing + log-truncation.
- Fixes the stale comment in `LocalFileStrategy` that claimed PDFs were ignored by design.

## Background

Reporter on #394: with the Docker image and a mounted volume, `.txt` files indexed via `file:///docs` work but PDFs are ignored. Reproduced.

Root cause (after unwrapping the chained `Error.cause` inside `@kreuzberg/node`):

```
/lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
(required by .../node-linux-arm64-gnu/kreuzberg-node.linux-arm64-gnu.node)
```

`node:22-slim` is Debian bookworm = glibc 2.36; Kreuzberg's binding requires 2.38. The binding throws on load, `DocumentPipeline.process()` caught the error and only emitted a `logger.warn` containing `error.name` (literally `"Error"`) — so at default log levels the user saw nothing, the PDF just didn't appear in the index. The same is true for the x86_64 binding (upstream CI builds all linux variants against the same glibc baseline).

Verified that downgrading isn't viable: every published 4.x version of `@kreuzberg/node` (4.3.8 → 4.9.7) requires glibc 2.38.

## Why trixie

- **glibc**: 2.36 → 2.38, which unblocks Kreuzberg.
- **Chromium**: unchanged. Both bases ship `Chromium 148.0.7778.167`; only the underlying shared libs differ. Playwright sees the exact same browser binary.
- **Image size**: 2.89 GB → 2.94 GB (+~50 MB, ≈1.7%). The +29 MB on the `chromium` apt layer is Debian packaging differences, not a Chromium bump.

Alternatives considered: pinning Kreuzberg (no compatible version), Alpine + musl bindings (Playwright/Alpine pain), replacing Kreuzberg (architectural).

## Better diagnostics for next time

The catch block in `DocumentPipeline.process()` used to log only `error.name`, deliberately to avoid dumping potentially binary error payloads from malformed documents. That defensive intent is preserved, but now we *also* walk the `Error.cause` chain and include each link's message in a single `logger.error` line. To honor the original "don't dump binary" intent:

- Each message is whitespace-collapsed and truncated to 500 chars
- The chain walk is capped at 10 levels and deduplicated
- Loop guard via a `seen` set prevents infinite recursion on cyclic causes

Two new unit tests pin this: one asserts the GLIBC-style cause reaches the log when `extractBytes` throws a wrapped error, the other asserts that a 50 KB error message can't blow up the log line.

## Verification

**1. PDF extraction via the reported flow:**
```
$ docker run -v /tmp/issue394-docs:/docs:ro -v /tmp/issue394-data:/data \
    docs-mcp-server scrape issue394 file:///docs --max-depth 1
Successfully scraped 2 pages
```

**2. JS-rendered web scrape (proves Playwright still works on trixie):**
```
$ docker run ... scrape playwright-test https://playwright.dev/ \
    --scrape-mode playwright --max-pages 1 --max-depth 0
Successfully scraped 1 pages
```
SQLite store afterwards: `pages: 1`, `documents: 5` chunks, FTS index populated with real semantic chunks (heading paths, content). A static-only fetch would have returned an empty body for this SPA.

**3. New regression tests:**
- `test/local-file-pdf-e2e.test.ts` — drives `LocalFileStrategy.scrape()` end-to-end against a real on-disk directory containing `tests/fixtures/sample.pdf` + `.txt` + `.md` and asserts the PDF produces non-empty extracted text and at least one chunk. Runs in ~1.4 s.
- `src/scraper/pipelines/DocumentPipeline.test.ts` — two new cases for the cause-chain surfacing and the binary-data truncation guard. 38 → 39 → 40 tests in the suite, all green.

## Test plan
- [x] CI: existing test suite passes on the new base
- [x] CI: build pipeline produces an image and pushes successfully
- [x] Manual: run the published image with a mounted volume containing a PDF and verify it indexes (per #394 reporter's workflow)
- [x] Manual: run a Playwright-mode scrape against a JS-rendered site to verify no Chromium/dep regressions

Closes #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)