### PR TITLE
fix(scraper): keep user path as scope anchor on depth-0 redirect (#381)

### DIFF
--- a/openspec/changes/fix-subpages-scope-after-redirect/.openspec.yaml
+++ b/openspec/changes/fix-subpages-scope-after-redirect/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/fix-subpages-scope-after-redirect/design.md
+++ b/openspec/changes/fix-subpages-scope-after-redirect/design.md
@@ -1,0 +1,150 @@
+## Context
+
+The scraper exposes three crawl scopes — `subpages`, `hostname`, `domain` — defined in [src/scraper/utils/scope.ts](src/scraper/utils/scope.ts). At depth 0 the strategy fetches the user-provided URL, then sets `canonicalBaseUrl` to the *post-redirect* URL ([src/scraper/strategies/WebScraperStrategy.ts:174-177](src/scraper/strategies/WebScraperStrategy.ts:174)). `BaseScraperStrategy.shouldProcessUrl` ([src/scraper/strategies/BaseScraperStrategy.ts:103](src/scraper/strategies/BaseScraperStrategy.ts:103)) then feeds that base into `isInScope` for every discovered link.
+
+This change began as a fix for issue #381: Document360-backed help sites redirect `/foo` → `/foo~7400049439868183793`, and the current depth-0 overwrite adopts the suffixed path as the scope base. Child links use the unsuffixed clean form `/foo/api-introduction~...` and get filtered out — only 1 page is scraped.
+
+Investigation surfaced four additional behaviors that are either silent bugs or undocumented edge cases:
+
+- **`computeBaseDirectory`'s dot heuristic over-fires.** "Last segment contains a dot ⇒ treat as file, use parent dir" turns `/v1.0` into base `/` (whole hostname) and `/foo.html` into base `/` (whole hostname). The heuristic was added in commit [`5aaa7bb`](https://github.com/arabold/docs-mcp-server/commit/5aaa7bb) (Aug 15 2025) 28 minutes before the depth-0 redirect overwrite in [`6403325`](https://github.com/arabold/docs-mcp-server/commit/6403325) — both authored by the same person in the same session. The heuristic was a deliberate choice (an explicit test covers `/api/index.html` as start URL), but the dot rule is too coarse.
+- **Port is ignored.** `subpages`/`hostname` compare `URL.hostname`, treating `https://x:8443/api` and `https://x:9000/api` as equivalent.
+- **Hostname trailing dot is not normalized.** `example.com.` and `example.com` are technically the same DNS name but compare unequal.
+- **Undefined scope at the strategy layer skips filtering entirely.** Entry points (`ScrapeTool`, web UI) default to `subpages`, but a programmatic caller passing `undefined` gets unrestricted crawling.
+
+There is no spec covering scope behavior. These rules live implicitly in `scope.ts` and a handful of test cases in `WebScraperStrategy.test.ts`. This proposal both fixes issue #381 *and* captures the full contract in a new `scraping-scope` capability so the next implementer cannot regress these without breaking documented requirements.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix issue #381: `scope=subpages` works correctly when the depth-0 response redirects siblingwise.
+- Fix silent over-broad-crawl bugs: `/v1.0`-style version paths and `/foo.html`-style file paths no longer accidentally crawl the entire hostname.
+- Preserve the deliberate `/api/index.html` behavior with a tightened, well-bounded heuristic.
+- Tighten port and trailing-dot handling so equivalent hostnames are treated equivalently and distinct ports are treated distinctly.
+- Eliminate the "undefined scope = no filtering" footgun at the strategy layer.
+- Pin the full set of scope rules down in a new spec capability with concrete examples per requirement.
+- Rewrite the scope test cluster as a comprehensive matrix that mirrors the spec.
+
+**Non-Goals:**
+- Changing `scope=hostname` or `scope=domain` to span protocols (mixed http/https crawling). Protocol equality remains required for all three scopes.
+- Changing the include/exclude pattern system or the default exclusion patterns. Patterns will get their own capability spec eventually.
+- Auto-detecting which redirects are "legitimate" (site reorganizations) versus "platform suffixes." Users are responsible for resubmitting with the redirected URL when they want the new path.
+- Touching `HtmlPlaywrightMiddleware`, refresh-mode queue handling, the hash-routed SPA feature, or any caller of `ScraperOptions`.
+
+## Decisions
+
+### Decision 1: Depth-0 redirect — adopt protocol/host always, adopt path only if descendant
+
+At depth 0, build `canonicalBaseUrl` as follows:
+
+```
+final         = new URL(rawContent.source)        // post-redirect URL
+userPath      = new URL(options.url).pathname
+
+if isPathDescendant(userPath, final.pathname):
+  canonicalBaseUrl = final                        // adopt redirected path
+else:
+  canonicalBaseUrl = new URL(userPath, final)     // keep user path, adopt protocol+host
+  log.warn("Depth-0 redirect changed path siblingwise; …")
+```
+
+Where `isPathDescendant(parent, child)` returns true if `child === parent` after trailing-slash normalization, OR `child` starts with `parent + "/"`.
+
+**Rationale**: The user typed a path; that path is their intent. Hostnames must be adopted from the redirect (without that, all links would fail the hostname check), but pathnames should respect user intent unless the redirect simply normalizes the path (trailing slash, index file) in which case the redirected path is identical-or-narrower and safe to adopt.
+
+**Alternatives considered:**
+
+- **Always use user-provided URL.** Simplest, but breaks the existing protocol/host redirect support that commit `6403325` introduced. Rejected.
+- **Always use redirected URL (current behavior).** Status quo. Silently scrapes wrong subtree on site reorgs and breaks on platform-suffix redirects. The bug we're fixing. Rejected.
+- **Heuristic on the redirected path's last segment.** Fragile — every KB platform uses different schemes. Rejected.
+
+### Decision 2: Tighten `computeBaseDirectory` to recognize only `index` and `index.<ext>`
+
+Replace the heuristic "last segment contains a dot ⇒ file" with "last segment matches `/^index(\.[a-z0-9]+)?$/i` ⇒ directory-index file." The extension is optional so that clean-URL routes like `/api/index` (no extension) are treated the same as `/api/index.html` — both are conventionally "the directory's index page."
+
+```
+computeBaseDirectory(pathname):
+  if pathname is empty or "/":              return "/"
+  if pathname ends with "/":                return pathname
+  if last segment matches /^index(\.[a-z0-9]+)?$/i:
+                                            return parent directory (with trailing slash)
+                                            return pathname + "/"
+```
+
+**Rationale**: The history (28 minutes between the dot heuristic and the redirect overwrite, same author, same session) and the explicit `/api/index.html` test in `5aaa7bb` make clear the dot heuristic was a deliberate `/index.html` accommodation. The bug is that it fires on far too much. Tightening to `index(.<ext>)?` preserves the deliberate behavior, extends it consistently to extensionless index conventions, kills the silent over-broad-crawl on `/v1.0` and `/foo.html`, and is trivially predictable.
+
+**Alternatives considered:**
+
+- **Remove all heuristics, treat every path as directory.** Simpler. Loses the `/api/index.html` deliberate case. Rejected once history confirmed the case is intentional.
+- **Use a broader extension allowlist** (`.html`, `.htm`, `.php`, `.aspx`, etc.). More inclusive but bigger guess surface. The `/api/index.html` case is the documented one; covering `/api/main.aspx` etc. is speculative. Rejected in favor of the minimum that preserves the documented behavior.
+- **Detect at fetch time using Content-Type.** Would handle clean-URL platforms but introduces a fetch-dependent path computation. Rejected — too clever, harder to spec.
+
+### Decision 3: Compare on `host` (hostname + port) for subpages/hostname; domain stays on primary domain
+
+`URL.host` includes the optional port (`example.com:8443`); `URL.hostname` does not. Today's code uses `hostname` everywhere, so different-port URLs on the same host are considered the same scope. That's wrong for `subpages` and `hostname` — they describe "same service" boundaries.
+
+For `domain` scope, primary-domain extraction (via PSL) is hostname-based and naturally port-agnostic. Stays as-is.
+
+### Decision 4: Normalize trailing dot on hostnames
+
+Strip a single trailing `.` from both base and target hostnames before comparison. `example.com.` and `example.com` resolve to the same DNS name and should be treated as equivalent.
+
+### Decision 5: Keep protocol equality required for all scopes
+
+Status quo. A `https://x/` page linking to `http://x/api` is out of scope even under `hostname`/`domain`. Spec'd explicitly so the rule is visible.
+
+**Rationale**: Mixed-protocol crawling is a security concern (HTTPS pages should not be inferring trust into HTTP siblings), and modern docs sites are uniformly one protocol. The depth-0 redirect logic still correctly handles `http`→`https` upgrades by adopting the redirected protocol. No conflict.
+
+### Decision 6: Default `scope` to `"subpages"` inside `shouldProcessUrl`
+
+Today, `BaseScraperStrategy.shouldProcessUrl` skips scope filtering entirely when `options.scope` is falsy:
+
+```ts
+if (options.scope) {
+  // …isInScope check…
+}
+```
+
+Entry points default to `subpages`, so users never see this. But a programmatic caller could pass `undefined` and get unrestricted crawling. Change to:
+
+```ts
+const scope = options.scope ?? "subpages";
+// always run isInScope
+```
+
+The strategy layer becomes self-defending — no caller can bypass scope by omission.
+
+### Decision 7: Surface siblingwise redirects via warning log
+
+When `isPathDescendant(userPath, final.pathname)` is false at depth 0, emit a `logger.warn` describing the user-provided URL, the redirected URL, the resulting scope anchor (user-provided path), and a suggested action (resubmit with the redirected URL if the new path is intended). Only emit once per scrape and only when the depth-0 redirect actually triggers the rule.
+
+**Rationale**: Without this, a user typing `/v1` and getting redirected to `/v2/` would see "1 page scraped" with no explanation. The warning makes the implicit visible.
+
+### Decision 8: New capability `scraping-scope`, not amendment to an existing spec
+
+Closest existing capability is `scraper-isolation` (per-scrape strategy instance isolation), which is orthogonal. No spec currently covers scope behavior. A new `scraping-scope` capability gives this contract a stable home.
+
+### Decision 9: Rewrite the scope test cluster from scratch
+
+The current scope tests in `WebScraperStrategy.test.ts` (the three `scope=subpages/hostname/domain` tests around lines 125–291, plus the `index.html` and base-href integration tests around 903–1054) were written before any of the edge cases above were understood. None simulate a depth-0 redirect, none cover port or trailing-dot, and the `index.html` test passes by accident under the old broad heuristic. Patching them piecemeal is messier than a clean rewrite.
+
+Plan: replace those tests with a comprehensive matrix that mirrors the new spec — one integration test per scenario in the spec, plus expanded unit tests on `scope.ts` (the existing `src/scraper/utils/scope.test.ts` is 93 lines and covers a partial slice of `computeBaseDirectory` and `isInScope`; it needs to be rewritten/extended, and one assertion — `computeBaseDirectory("/deep/path/file.md")` currently expected to return `"/deep/path/"` — will be inverted under the new heuristic). Tests that are *not* about scope (cleanup, refresh, hash-routed SPA support) remain untouched. The cross-origin `<base href>` test is part of the scope cluster and is rewritten under the new `host`-based comparison.
+
+## Risks / Trade-offs
+
+- **Site-reorg redirects (`/v1` → `/v2/`) change behavior** → Today: 400 pages on `/v2/*` scraped silently. After fix: 1 page + warning. **Mitigation**: warning log tells users exactly what happened and how to resubmit. Silently rewriting the user's URL is the very class of bug we're fixing for issue #381.
+
+- **`/v1.0` and `/foo.html` start URLs now scope narrowly instead of crawling the whole hostname** → Strict bug fix. Anyone who was getting the old behavior was getting hostname-scope semantics under a subpages-scope label without knowing. **Mitigation**: PR description must call this out explicitly so anyone relying on it can switch to `scope: hostname`.
+
+- **`/api/index.html` start URL still works only because of the tightened heuristic.** If the heuristic ever drifts (e.g. someone tries to make it stricter still), this case regresses. **Mitigation**: an explicit scenario in the spec for `/api/index.html` → base `/api/`, plus a unit test in `scope.test.ts`, locks it in.
+
+- **Port-aware comparison could break someone running their docs on `https://x.com/` while linking to `https://x.com:443/`** → Browsers normalize port `443` away from the URL when it matches the protocol default; `new URL("https://x.com:443/").host === "x.com"`. So this should not occur in practice. Other defaulted ports (80 for http) normalize the same way. **Verified** via Node URL parser.
+
+- **Trailing-dot normalization is hostname-only.** Path-segment trailing dots are not normalized (and shouldn't be — they're meaningful in some routes).
+
+- **Warning could be noisy on multi-redirect chains** → If `followRedirects=true` chains several hops, the final URL might legitimately differ from the user's URL even when paths are "the same." **Mitigation**: descendant check is path-only and tolerates trailing slash + `index.<ext>` variants via base-directory computation, which covers the vast majority of multi-hop legitimate cases.
+
+- **Test rewrite is a larger diff than a targeted fix.** ~6–8 tests removed, ~15 new tests added (scope.test.ts + new scope cluster in WebScraperStrategy.test.ts). **Mitigation**: the test rewrite is the spec's executable form; cohesion is the point. PR will be reviewed scope-by-scope.
+
+## Migration Plan
+
+No data migration. Behavior change is bounded to scope-filtering logic. Deployment is a normal release; rollback is reverting the change. The new spec doc is purely additive.

--- a/openspec/changes/fix-subpages-scope-after-redirect/proposal.md
+++ b/openspec/changes/fix-subpages-scope-after-redirect/proposal.md
@@ -10,7 +10,7 @@ Issue #381 surfaced one concrete failure (`scope=subpages` discovers only the de
 - `isInScope` SHALL compare on `URL.host` (hostname + optional port) for `subpages` and `hostname` scopes. `domain` scope continues to use primary-domain extraction (port-agnostic).
 - Hostname comparison SHALL strip a single trailing `.` from hostnames before comparison so `example.com.` and `example.com` are treated as equivalent.
 - `BaseScraperStrategy.shouldProcessUrl` SHALL default `scope` to `"subpages"` when undefined, preventing programmatic callers from accidentally bypassing scope filtering.
-- A new `scraping-scope` capability SHALL document all three scopes, depth-0 redirect handling, host/protocol/path comparison rules, base-directory computation (with concrete examples), filter ordering, and the start-URL exemption.
+- A new `scraping-scope` capability SHALL document all three scopes, depth-0 redirect handling, host/protocol/path comparison rules, base-directory computation (with concrete examples), filter ordering, the start-URL exemption, and the orthogonality between scope filtering and the `preserveHashes` option (scope acts on pathname; hashes are a queue-identity concern handled separately).
 - **BREAKING (behavioral, no API change)**:
   1. Start URLs whose redirect changes the path siblingwise (`/v1` → `/v2/`) now scrape only the depth-0 page plus a warning instead of silently following the redirect into a different subtree.
   2. Start URLs like `/v1.0`, `/v2.1`, `/foo.html`, `/changelog.md` no longer accidentally crawl the entire hostname under `scope=subpages`. They now scope to themselves and their descendants.

--- a/openspec/changes/fix-subpages-scope-after-redirect/proposal.md
+++ b/openspec/changes/fix-subpages-scope-after-redirect/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Issue #381 surfaced one concrete failure (`scope=subpages` discovers only the depth-0 page when the start URL responds with a path-changing redirect, e.g. Document360's `/foo` → `/foo~hash`). Investigating it revealed that the scraping-scope rules — three modes, redirect handling, hostname/host/protocol comparison semantics, and a base-directory heuristic — are entirely implicit in code. No spec exists, several edge cases behave surprisingly, and two of those behaviors are silent bugs (paths like `/v1.0` or `/foo.html` as start URL with `scope=subpages` accidentally crawl the entire hostname). This change fixes the depth-0 redirect bug, fixes the silent over-broad-crawl bugs, tightens four related edge cases, and pins the full contract down in a new `scraping-scope` capability spec so the next implementer cannot regress these without breaking documented requirements.
+
+## What Changes
+
+- For `scope=subpages`, at depth 0 the scope base SHALL adopt the **protocol and hostname** of the post-redirect URL but keep the **user-provided pathname** as the scope anchor — unless the redirected path is a path-descendant of the user-provided path, in which case the redirected path is adopted.
+- A warning SHALL be logged at depth 0 when the redirect is siblingwise (path changes in a way that is not a descendant), so users understand why few pages were discovered.
+- `computeBaseDirectory` heuristic is tightened: only path segments matching `/^index(\.[a-z0-9]+)?$/i` are treated as a directory-index file (parent directory used as base). This covers `/index`, `/index.html`, `/index.htm`, `/Index.HTML`, etc. All other paths are treated as directories. This fixes the silent over-broad-crawl on paths like `/v1.0`, `/v2.1`, `/foo.html`, and `/changelog.md` while preserving the deliberate `/api/index.html` behavior.
+- `isInScope` SHALL compare on `URL.host` (hostname + optional port) for `subpages` and `hostname` scopes. `domain` scope continues to use primary-domain extraction (port-agnostic).
+- Hostname comparison SHALL strip a single trailing `.` from hostnames before comparison so `example.com.` and `example.com` are treated as equivalent.
+- `BaseScraperStrategy.shouldProcessUrl` SHALL default `scope` to `"subpages"` when undefined, preventing programmatic callers from accidentally bypassing scope filtering.
+- A new `scraping-scope` capability SHALL document all three scopes, depth-0 redirect handling, host/protocol/path comparison rules, base-directory computation (with concrete examples), filter ordering, and the start-URL exemption.
+- **BREAKING (behavioral, no API change)**:
+  1. Start URLs whose redirect changes the path siblingwise (`/v1` → `/v2/`) now scrape only the depth-0 page plus a warning instead of silently following the redirect into a different subtree.
+  2. Start URLs like `/v1.0`, `/v2.1`, `/foo.html`, `/changelog.md` no longer accidentally crawl the entire hostname under `scope=subpages`. They now scope to themselves and their descendants.
+  3. `subpages`/`hostname` scope now distinguishes ports — `https://x:8443/api` and `https://x:9000/api` are different scopes.
+  4. Programmatic callers passing `scope: undefined` now get `subpages` semantics instead of unrestricted crawling.
+
+## Capabilities
+
+### New Capabilities
+- `scraping-scope`: Defines the three crawl scopes (`subpages`, `hostname`, `domain`), how each filters discovered URLs, how host/protocol/path equality are evaluated, how the depth-0 redirect interacts with the scope base, base-directory computation rules with concrete examples, and the ordering of scope vs. include/exclude/custom filters.
+
+### Modified Capabilities
+<!-- None — scope rules are currently undocumented; this change captures them in a new spec rather than amending existing ones. -->
+
+## Impact
+
+- **Code**:
+  - [src/scraper/utils/scope.ts](src/scraper/utils/scope.ts) — tighten `computeBaseDirectory` (index.* only), add `isPathDescendant`, add `stripTrailingDot`, switch to `host` comparison for subpages/hostname, normalize trailing dot.
+  - [src/scraper/strategies/WebScraperStrategy.ts:174-177](src/scraper/strategies/WebScraperStrategy.ts:174) — replace unconditional `canonicalBaseUrl` overwrite with conditional descendant-adoption + warning log.
+  - [src/scraper/strategies/BaseScraperStrategy.ts:103-114](src/scraper/strategies/BaseScraperStrategy.ts:103) — default `scope` to `"subpages"` in `shouldProcessUrl` when undefined.
+- **APIs**: No changes to `ScraperOptions`, CLI flags, MCP tools, or Web UI.
+- **Tests**:
+  - Expand [src/scraper/utils/scope.test.ts](src/scraper/utils/scope.test.ts) (an existing 93-line file) into exhaustive table-driven coverage of `computeBaseDirectory`, `isPathDescendant`, `stripTrailingDot`, and `isInScope`. One existing assertion will change under the new heuristic (the `"treats file-looking path as its parent directory"` case, which currently expects `computeBaseDirectory("/deep/path/file.md")` to return `"/deep/path/"`); this is intentional and aligns with the bug fix.
+  - Rewrite the scope test cluster in [src/scraper/strategies/WebScraperStrategy.test.ts](src/scraper/strategies/WebScraperStrategy.test.ts) (the three `scope=subpages`/`hostname`/`domain` tests plus the index.html and base-href tests) into a comprehensive matrix covering: each scope mode, depth-0 redirect shapes (hash-suffix, trailing slash, index.html, siblingwise reorg, protocol upgrade, apex↔www), port differences, trailing-dot hostnames, version paths (`/v1.0`), `.html` start URLs, start-URL exemption, and filter ordering.
+- **Backwards compatibility**: Four observable behavior changes listed above. All are surfaced via the warning log (for the siblingwise-redirect case) or yield strictly narrower-than-today scope (for the `/v1.0` and `/foo.html` cases — fixing silent over-broad-crawl bugs). No API or config-shape changes.
+- **Refresh mode**: Unaffected — `initialQueue` items are filtered with the same `shouldProcessUrl` path, which now uses the corrected scope base.

--- a/openspec/changes/fix-subpages-scope-after-redirect/specs/scraping-scope/spec.md
+++ b/openspec/changes/fix-subpages-scope-after-redirect/specs/scraping-scope/spec.md
@@ -1,0 +1,316 @@
+## ADDED Requirements
+
+### Requirement: Default scope is subpages
+
+When a caller of the scraper does not supply a `scope` value, the scraper SHALL apply `scope=subpages` for all link filtering. This applies at the strategy layer, not only at entry points, so programmatic callers cannot accidentally bypass scope filtering by omission.
+
+#### Scenario: ScraperOptions with scope undefined
+- **WHEN** a caller invokes the scraper with `scope: undefined`
+- **THEN** discovered links are filtered as if `scope: "subpages"` had been passed
+
+#### Scenario: ScraperOptions with scope explicitly set
+- **WHEN** a caller invokes the scraper with `scope: "hostname"`
+- **THEN** discovered links are filtered using `hostname` semantics
+
+### Requirement: Start URL is exempt from scope filtering
+
+The user-provided URL SHALL be added to the queue and fetched at depth 0 regardless of any scope rule. Scope filtering applies only to URLs *discovered* during crawling.
+
+#### Scenario: Start URL outside its own subpages base after redirect
+- **WHEN** the user-provided URL is `https://example.com/foo`
+- **AND** the depth-0 response redirects to `https://example.com/foo~hash`
+- **THEN** the depth-0 page is fetched and returned to the caller
+- **AND** discovered links from that page are filtered using the resolved scope base (see "Depth-0 redirect adopts protocol and hostname" and related requirements below)
+
+### Requirement: Filter ordering for discovered links
+
+Discovered links SHALL be filtered in this order, with each filter able to reject before later filters run:
+1. URL parse — invalid URLs are rejected.
+2. Archive-extension filter — links ending in `.zip`, `.tar`, `.gz`, or `.tgz` (case-insensitive) are rejected during crawl.
+3. Scope check — `isInScope(canonicalBaseUrl, target, scope)` must return true.
+4. Pattern check — `shouldIncludeUrl(target, includePatterns, excludePatterns)` must return true (default exclusion patterns apply when no user excludePatterns are provided).
+5. Optional `shouldFollowLink` callback — if configured, must return true.
+
+#### Scenario: Scope reject short-circuits pattern check
+- **WHEN** scope is `subpages` with base `https://example.com/api/`
+- **AND** a discovered link is `https://other.com/api/intro`
+- **THEN** the link is rejected by scope before patterns are evaluated
+
+#### Scenario: Archive link rejected before scope check
+- **WHEN** a discovered link is `https://example.com/api/dump.zip`
+- **THEN** the link is rejected by the archive-extension filter regardless of scope
+
+### Requirement: Protocol equality is required for all scopes
+
+`isInScope` SHALL return false when the target URL's protocol differs from the scope base URL's protocol, regardless of which scope mode is in use. Mixed-protocol crawling (e.g. a `https://` page linking to its `http://` sibling) is not supported.
+
+#### Scenario: HTTPS base, HTTP target, hostname scope
+- **WHEN** scope base is `https://example.com/api/`
+- **AND** discovered URL is `http://example.com/api/intro`
+- **AND** scope is `hostname`
+- **THEN** the URL is NOT in scope
+
+#### Scenario: HTTPS base, HTTPS target after http→https redirect
+- **WHEN** the user-provided URL is `http://example.com/api`
+- **AND** the depth-0 response redirects to `https://example.com/api`
+- **AND** a discovered link is `https://example.com/api/intro`
+- **THEN** the URL is in scope (the redirect adoption made the base protocol `https:`)
+
+### Requirement: Subpages and hostname scope compare on host (hostname + port)
+
+For `subpages` and `hostname` scopes, the host comparison SHALL use `URL.host` (hostname plus optional port) rather than `URL.hostname` alone. Different ports on the same hostname represent different services and are different scopes.
+
+#### Scenario: Different ports on same hostname
+- **WHEN** scope base is `https://example.com:8443/api/`
+- **AND** discovered URL is `https://example.com:9000/api/intro`
+- **AND** scope is `hostname`
+- **THEN** the URL is NOT in scope
+
+#### Scenario: Default port normalization
+- **WHEN** scope base is `https://example.com/api/`
+- **AND** discovered URL is `https://example.com:443/api/intro`
+- **THEN** the URL is in scope (the URL parser normalizes default ports away from `host`)
+
+### Requirement: Hostname comparison normalizes a single trailing dot
+
+Before comparison, both the base URL's host and the target URL's host SHALL have a single trailing `.` stripped from the hostname portion. This rule applies uniformly to all three scopes (`subpages`, `hostname`, and `domain`). `example.com.` and `example.com` are treated as equivalent.
+
+#### Scenario: Trailing dot on base hostname under subpages scope
+- **WHEN** scope base is `https://example.com./api/`
+- **AND** discovered URL is `https://example.com/api/intro`
+- **AND** scope is `subpages`
+- **THEN** the URL is in scope
+
+#### Scenario: Trailing dot on target hostname under hostname scope
+- **WHEN** scope base is `https://example.com/api/`
+- **AND** discovered URL is `https://example.com./other`
+- **AND** scope is `hostname`
+- **THEN** the URL is in scope
+
+#### Scenario: Trailing dot under domain scope
+- **WHEN** scope base is `https://docs.example.com./`
+- **AND** discovered URL is `https://api.example.com/v1`
+- **AND** scope is `domain`
+- **THEN** the URL is in scope
+
+### Requirement: Subpages scope filters by base directory path-prefix
+
+For `scope=subpages`, after protocol/host equality is established, the target URL SHALL be considered in scope when its pathname starts with the scope base URL's *base directory* (computed per the "Base directory computation" requirement). Path comparison is case-sensitive.
+
+#### Scenario: Descendant path
+- **WHEN** scope base is `https://docs.example.com/api/`
+- **AND** discovered URL is `https://docs.example.com/api/guides/intro`
+- **THEN** the URL is in scope
+
+#### Scenario: Sibling path
+- **WHEN** scope base is `https://docs.example.com/api/`
+- **AND** discovered URL is `https://docs.example.com/blog/post`
+- **THEN** the URL is NOT in scope
+
+#### Scenario: Mixed-case paths
+- **WHEN** scope base is `https://docs.example.com/Api/`
+- **AND** discovered URL is `https://docs.example.com/api/intro`
+- **THEN** the URL is NOT in scope (path comparison is case-sensitive)
+
+### Requirement: Base directory computation
+
+The base directory of a pathname for `scope=subpages` SHALL be computed as follows:
+
+- Empty pathname or `/` → `/`.
+- Pathname ending in `/` → the pathname unchanged.
+- Pathname whose last segment matches `/^index(\.[a-z0-9]+)?$/i` (case-insensitive, extension optional) → the parent directory (the pathname with the last segment removed, ending in `/`).
+- All other pathnames → the pathname with `/` appended.
+
+This deliberately tight heuristic preserves the documented `/path/index.html`-as-start-URL behavior (sibling pages under `/path/` remain in scope), extends it consistently to extensionless `index` paths (clean-URL routing convention), and avoids misclassifying version-like or file-extension paths.
+
+#### Scenario: Root path
+- **WHEN** pathname is `/`
+- **THEN** base directory is `/`
+
+#### Scenario: Directory with trailing slash
+- **WHEN** pathname is `/api/`
+- **THEN** base directory is `/api/`
+
+#### Scenario: Directory without trailing slash
+- **WHEN** pathname is `/api`
+- **THEN** base directory is `/api/`
+
+#### Scenario: Path with index.html last segment
+- **WHEN** pathname is `/api/index.html`
+- **THEN** base directory is `/api/`
+
+#### Scenario: Path with index.htm last segment
+- **WHEN** pathname is `/api/index.htm`
+- **THEN** base directory is `/api/`
+
+#### Scenario: Path with mixed-case Index.HTML last segment
+- **WHEN** pathname is `/api/Index.HTML`
+- **THEN** base directory is `/api/`
+
+#### Scenario: Version-like path with dot
+- **WHEN** pathname is `/v1.0`
+- **THEN** base directory is `/v1.0/`
+
+#### Scenario: Nested version-like path with dot
+- **WHEN** pathname is `/api/v2.0`
+- **THEN** base directory is `/api/v2.0/`
+
+#### Scenario: Non-index file-like last segment
+- **WHEN** pathname is `/foo.html`
+- **THEN** base directory is `/foo.html/`
+
+#### Scenario: Non-index markdown file
+- **WHEN** pathname is `/changelog.md`
+- **THEN** base directory is `/changelog.md/`
+
+#### Scenario: Extensionless index
+- **WHEN** pathname is `/api/index`
+- **THEN** base directory is `/api/`
+
+#### Scenario: Extensionless Index with mixed case
+- **WHEN** pathname is `/api/Index`
+- **THEN** base directory is `/api/`
+
+#### Scenario: Path that starts with index but is not exactly index
+- **WHEN** pathname is `/api/indexes`
+- **THEN** base directory is `/api/indexes/` (`indexes` is not `index` or `index.<ext>`)
+
+### Requirement: Hostname scope ignores pathname
+
+For `scope=hostname`, after protocol equality is established, a target URL SHALL be considered in scope when its host (per the trailing-dot and port-aware rules) exactly matches the scope base URL's host, regardless of pathname.
+
+#### Scenario: Same host, unrelated path
+- **WHEN** scope base is `https://docs.example.com/api/`
+- **AND** discovered URL is `https://docs.example.com/blog/post`
+- **AND** scope is `hostname`
+- **THEN** the URL is in scope
+
+#### Scenario: Subdomain rejected
+- **WHEN** scope base is `https://docs.example.com/api/`
+- **AND** discovered URL is `https://api.example.com/v1`
+- **AND** scope is `hostname`
+- **THEN** the URL is NOT in scope
+
+### Requirement: Domain scope spans the primary domain including subdomains
+
+For `scope=domain`, after protocol equality is established, a target URL SHALL be considered in scope when its hostname's primary domain matches that of the scope base URL's hostname, regardless of pathname or port. The primary domain is extracted using the Public Suffix List with the following special cases:
+
+- IPv4 and IPv6 literals are returned as-is and compared verbatim.
+- Single-label hostnames (e.g. `localhost`) are returned as-is and compared verbatim.
+- GitHub Pages user/org subdomains (`<user>.github.io`) are treated as their own primary domain so different users' GitHub Pages do not collide.
+
+#### Scenario: Different subdomain, same primary domain
+- **WHEN** scope base is `https://docs.example.com/`
+- **AND** discovered URL is `https://api.example.com/v1`
+- **AND** scope is `domain`
+- **THEN** the URL is in scope
+
+#### Scenario: Different primary domain
+- **WHEN** scope base is `https://docs.example.com/`
+- **AND** discovered URL is `https://example.org/page`
+- **AND** scope is `domain`
+- **THEN** the URL is NOT in scope
+
+#### Scenario: GitHub Pages users are isolated
+- **WHEN** scope base is `https://userA.github.io/proj/`
+- **AND** discovered URL is `https://userB.github.io/other/`
+- **AND** scope is `domain`
+- **THEN** the URL is NOT in scope
+
+#### Scenario: IPv4 hosts compare verbatim
+- **WHEN** scope base is `http://192.168.1.10/`
+- **AND** discovered URL is `http://192.168.1.20/`
+- **AND** scope is `domain`
+- **THEN** the URL is NOT in scope
+
+#### Scenario: localhost compares verbatim
+- **WHEN** scope base is `http://localhost:3000/`
+- **AND** discovered URL is `http://localhost:4000/`
+- **AND** scope is `domain`
+- **THEN** the URL is in scope (port is ignored for domain scope; both hosts are `localhost`)
+
+### Requirement: Depth-0 redirect adopts protocol and host of redirected URL
+
+When the depth-0 fetch follows a redirect, the scope base URL's protocol and host (hostname plus optional port) SHALL be replaced with those of the post-redirect URL for all subsequent link filtering. This ensures protocol upgrades (`http`→`https`), host changes (apex↔`www`), and port changes do not cause every discovered link to be filtered out by the host check.
+
+#### Scenario: Protocol upgrade redirect
+- **WHEN** the user-provided URL is `http://example.com/api`
+- **AND** the depth-0 response redirects to `https://example.com/api`
+- **THEN** the scope base host is `example.com` and the scope base protocol is `https:`
+- **AND** child links beginning with `https://example.com/api/` are in scope
+
+#### Scenario: Apex to www redirect
+- **WHEN** the user-provided URL is `https://example.com/api`
+- **AND** the depth-0 response redirects to `https://www.example.com/api`
+- **THEN** the scope base host is `www.example.com`
+- **AND** child links on `www.example.com/api/` are in scope
+
+#### Scenario: Port change via redirect
+- **WHEN** the user-provided URL is `https://example.com/api`
+- **AND** the depth-0 response redirects to `https://example.com:8443/api`
+- **THEN** the scope base host is `example.com:8443`
+- **AND** child links on `example.com:8443/api/` are in scope but `example.com/api/...` is not
+
+### Requirement: Depth-0 redirect to descendant path adopts the redirected path
+
+When the depth-0 fetch redirects to a URL whose pathname is a path-descendant of the user-provided URL's pathname, the scope base URL's pathname SHALL be replaced with the redirected pathname. A pathname `child` is a path-descendant of `parent` when, after treating `parent` as a directory (trailing slash appended if missing), `child` equals `parent` or starts with `parent + "/"`.
+
+#### Scenario: Trailing slash redirect
+- **WHEN** the user-provided URL is `https://example.com/api`
+- **AND** the depth-0 response redirects to `https://example.com/api/`
+- **THEN** the scope base pathname is `/api/`
+
+#### Scenario: Directory index redirect
+- **WHEN** the user-provided URL is `https://example.com/api`
+- **AND** the depth-0 response redirects to `https://example.com/api/index.html`
+- **THEN** the scope base directory is `/api/`
+- **AND** sibling URLs under `/api/` remain in scope
+
+#### Scenario: Deeper-descendant redirect
+- **WHEN** the user-provided URL is `https://example.com/api`
+- **AND** the depth-0 response redirects to `https://example.com/api/v2/intro`
+- **THEN** the scope base pathname is `/api/v2/intro` (the redirected path itself)
+- **AND** the resulting base directory is `/api/v2/intro/` (the redirected path treated as a directory, per the base-directory computation rule)
+- **AND** descendant links under `/api/v2/intro/...` are in scope, while sibling links under `/api/` are not
+
+### Requirement: Depth-0 redirect to siblingwise path keeps user-provided path
+
+When the depth-0 fetch redirects to a URL whose pathname is NOT a path-descendant of the user-provided URL's pathname, the scope base URL's pathname SHALL remain the user-provided pathname (while protocol and host adopt the redirect, per the protocol/host requirement). This preserves user intent when a server appends a platform-specific suffix or redirects to a reorganized location.
+
+#### Scenario: Document360-style hash-suffix redirect (issue #381)
+- **WHEN** the user-provided URL is `https://help.example.com/en/integrations/peoplevox-api-guide`
+- **AND** the depth-0 response redirects to `https://help.example.com/en/integrations/peoplevox-api-guide~7400049439868183793`
+- **THEN** the scope base pathname is `/en/integrations/peoplevox-api-guide`
+- **AND** child links like `/en/integrations/peoplevox-api-guide/api-introduction~...` are in scope
+
+#### Scenario: Site reorganization redirect
+- **WHEN** the user-provided URL is `https://example.com/v1/api`
+- **AND** the depth-0 response redirects to `https://example.com/v2/api`
+- **THEN** the scope base pathname is `/v1/api`
+- **AND** child links under `/v2/api/` are NOT in scope
+
+#### Scenario: Dead URL redirected to homepage
+- **WHEN** the user-provided URL is `https://example.com/removed-section`
+- **AND** the depth-0 response redirects to `https://example.com/`
+- **THEN** the scope base pathname is `/removed-section`
+- **AND** the scope does NOT expand to the whole host
+
+### Requirement: Siblingwise depth-0 redirect emits a warning
+
+When the depth-0 redirect changes the path siblingwise (the redirected pathname is not a path-descendant of the user-provided pathname), the scraper SHALL log a warning that identifies the user-provided URL, the redirected URL, and the resulting scope anchor (user-provided path), and suggests resubmitting with the redirected URL if the new path is intended. The warning SHALL fire at most once per scrape and SHALL NOT fire when the redirected pathname is a descendant or equal to the user-provided pathname.
+
+#### Scenario: Hash-suffix redirect surfaces warning
+- **WHEN** the user-provided URL is `https://help.example.com/foo`
+- **AND** the depth-0 response redirects to `https://help.example.com/foo~abc`
+- **THEN** a warning is logged that mentions both URLs and the scope anchor
+- **AND** the scrape continues using the user-provided pathname as the scope anchor
+
+#### Scenario: Descendant redirect does not warn
+- **WHEN** the user-provided URL is `https://example.com/api`
+- **AND** the depth-0 response redirects to `https://example.com/api/`
+- **THEN** no scope-redirect warning is logged
+
+#### Scenario: No redirect does not warn
+- **WHEN** the user-provided URL is `https://example.com/api`
+- **AND** the depth-0 response is served directly with no redirect
+- **THEN** no scope-redirect warning is logged

--- a/openspec/changes/fix-subpages-scope-after-redirect/specs/scraping-scope/spec.md
+++ b/openspec/changes/fix-subpages-scope-after-redirect/specs/scraping-scope/spec.md
@@ -295,6 +295,48 @@ When the depth-0 fetch redirects to a URL whose pathname is NOT a path-descendan
 - **THEN** the scope base pathname is `/removed-section`
 - **AND** the scope does NOT expand to the whole host
 
+### Requirement: Hash fragments do not participate in scope filtering
+
+Scope filtering SHALL operate on `URL.protocol`, `URL.host`, and `URL.pathname`, all of which exclude the fragment by definition. Hash fragments are a client-side routing concern controlled by the `preserveHashes` option, which determines whether `URL.hash` participates in queue identity and dedup. Scope decisions are independent of hash values: two URLs with the same protocol/host/pathname but different hashes are equivalent under every scope mode. This is the mechanism by which hash-routed SPAs (issue #379) are crawlable — distinct hash routes share a pathname and therefore share a scope verdict.
+
+The depth-0 redirect adoption rules apply to the post-redirect URL as returned by the fetcher; if `preserveHashes` is enabled, the user-requested hash is restored to that URL by the URL-normalization layer when the pre- and post-redirect paths match (so `https://x/docs#/guide` → `https://x/docs/` yields `effectiveSource = https://x/docs/#/guide`). The scope-base pathname computed from `effectiveSource` is unaffected by this restoration.
+
+#### Scenario: Hash-routed siblings on the same pathname all pass subpages scope
+- **WHEN** the user-provided URL is `https://docs.example.com/`
+- **AND** the page contains hash-routed links `#/Docs/welcome`, `#/Docs/api`, `#/Docs/config`
+- **AND** `preserveHashes` is enabled
+- **AND** scope is `subpages`
+- **THEN** every hash-routed target is in scope (each has pathname `/`, which equals the scope-base directory `/`)
+- **AND** each distinct hash route is fetched as a separate page
+
+#### Scenario: Hash route to a different pathname is filtered by subpages scope
+- **WHEN** scope base is `https://example.com/foo/`
+- **AND** discovered URL is `https://example.com/bar#/section`
+- **AND** scope is `subpages`
+- **THEN** the URL is NOT in scope (pathname `/bar` does not start with `/foo/`; the hash does not rescue it)
+
+#### Scenario: Descendant redirect with restored hash preserves the scope contract
+- **WHEN** the user-provided URL is `https://example.com/docs#/guide`
+- **AND** `preserveHashes` is enabled
+- **AND** the depth-0 response redirects to `https://example.com/docs/`
+- **THEN** the restored `effectiveSource` is `https://example.com/docs/#/guide`
+- **AND** the scope base pathname is `/docs/` (the hash is ignored for scope purposes)
+- **AND** subsequent hash-routed links like `https://example.com/docs/#/api` are in scope
+
+#### Scenario: Siblingwise redirect with hash drops the hash and warns
+- **WHEN** the user-provided URL is `https://example.com/foo#/guide`
+- **AND** `preserveHashes` is enabled
+- **AND** the depth-0 response redirects to `https://example.com/bar`
+- **THEN** the hash is NOT restored (the URL-normalization layer restores only when pre- and post-redirect paths match)
+- **AND** the siblingwise-redirect warning is logged
+- **AND** the scope base pathname remains `/foo`
+
+#### Scenario: Hash routes are equivalent under hostname and domain scope
+- **WHEN** scope base is `https://example.com/`
+- **AND** discovered URLs are `https://example.com/#/a` and `https://example.com/#/b`
+- **AND** scope is `hostname` (or `domain`)
+- **THEN** both URLs are in scope (host/domain check ignores pathname and therefore ignores hash)
+
 ### Requirement: Siblingwise depth-0 redirect emits a warning
 
 When the depth-0 redirect changes the path siblingwise (the redirected pathname is not a path-descendant of the user-provided pathname), the scraper SHALL log a warning that identifies the user-provided URL, the redirected URL, and the resulting scope anchor (user-provided path), and suggests resubmitting with the redirected URL if the new path is intended. The warning SHALL fire at most once per scrape and SHALL NOT fire when the redirected pathname is a descendant or equal to the user-provided pathname.

--- a/openspec/changes/fix-subpages-scope-after-redirect/tasks.md
+++ b/openspec/changes/fix-subpages-scope-after-redirect/tasks.md
@@ -1,0 +1,70 @@
+## 1. Scope module — helpers and rewrites
+
+- [x] 1.1 Add `stripTrailingDot(hostname: string): string` in [src/scraper/utils/scope.ts](src/scraper/utils/scope.ts) that strips a single trailing `.` from a hostname.
+- [x] 1.2 Add `isPathDescendant(parentPath: string, childPath: string): boolean` in [src/scraper/utils/scope.ts](src/scraper/utils/scope.ts). Treats `parentPath` as a directory (trailing slash appended if missing); returns true when `childPath` equals the normalized parent or starts with it.
+- [x] 1.3 Rewrite `computeBaseDirectory(pathname: string): string` in [src/scraper/utils/scope.ts](src/scraper/utils/scope.ts) per the spec's "Base directory computation" requirement: empty/`/` → `/`; trailing slash → as-is; last segment matching `/^index(\.[a-z0-9]+)?$/i` (extension optional) → parent directory; otherwise → pathname + `/`.
+- [x] 1.4 Update `isInScope` in [src/scraper/utils/scope.ts](src/scraper/utils/scope.ts) so that `subpages` and `hostname` cases compare on `URL.host` with `stripTrailingDot` applied. `domain` case continues to use `extractPrimaryDomain` (port-agnostic), also with `stripTrailingDot` applied to both hostnames.
+
+## 2. Depth-0 scope-base resolution
+
+- [x] 2.1 In [src/scraper/strategies/WebScraperStrategy.ts:174-177](src/scraper/strategies/WebScraperStrategy.ts:174), replace the unconditional `this.canonicalBaseUrl = new URL(effectiveSource)` with the conditional rule from the spec: build a URL from `final.protocol`/`final.host` and either `final.pathname` (when `isPathDescendant(userPath, final.pathname)`) or `userPath` (otherwise).
+- [x] 2.2 When the path-descendant check fails at depth 0, emit `logger.warn` identifying both URLs and the resulting scope anchor, with a suggestion to resubmit with the redirected URL. Fire at most once per scrape. The descendant check (failure ⇒ warn, success ⇒ no warn) is the sole predicate; the no-redirect case is covered automatically because equal paths satisfy the descendant predicate.
+
+## 3. Strategy-layer default scope
+
+- [x] 3.1 In [src/scraper/strategies/BaseScraperStrategy.ts:103-114](src/scraper/strategies/BaseScraperStrategy.ts:103), change `shouldProcessUrl` so that `scope` defaults to `"subpages"` when `options.scope` is undefined; `isInScope` runs unconditionally.
+
+## 4. Unit tests for scope.ts (rewrite existing file)
+
+- [x] 4.1 Rewrite [src/scraper/utils/scope.test.ts](src/scraper/utils/scope.test.ts) (an existing 93-line file with partial coverage of `computeBaseDirectory` and `isInScope`). Preserve the file's existing test scenarios that remain valid under the new behavior (`/api/`, `/api`, `/api/index.html`, `/`, hostname/domain subdomain cases, GitHub Pages cases). Update the now-incorrect assertion: `computeBaseDirectory("/deep/path/file.md")` currently expects `"/deep/path/"`; under the tightened heuristic this becomes `"/deep/path/file.md/"`. Either remove or invert that case (intent is bug-fix per proposal).
+- [x] 4.2 Expand the `describe("computeBaseDirectory")` block to cover every scenario in the spec's "Base directory computation" requirement: `/`, `/api/`, `/api`, `/api/index.html`, `/api/index.htm`, `/api/Index.HTML`, `/api/index`, `/api/Index`, `/api/indexes`, `/v1.0`, `/api/v2.0`, `/foo.html`, `/changelog.md`, empty string.
+- [x] 4.3 Add a `describe("isPathDescendant")` block with: equal paths, equal paths after trailing-slash normalization, descendant path, sibling path sharing a prefix (`/foo` vs `/foo~abc`), unrelated path, root path as parent, empty path edge case.
+- [x] 4.4 Add a `describe("stripTrailingDot")` block: hostname without dot unchanged, single trailing dot stripped, multiple dots (only one stripped), empty string.
+- [x] 4.5 Expand the `describe("isInScope")` blocks to cover each scenario in the spec: protocol equality required, host with port comparison (subpages and hostname), trailing-dot normalization for all three scopes, mixed-case paths (case-sensitive), subpages descendant/sibling, hostname same-host/subdomain, domain PSL behavior with IP/localhost/github.io cases.
+
+## 5. Rewrite scope tests in WebScraperStrategy.test.ts
+
+- [x] 5.1 Remove the existing scope test cluster from [src/scraper/strategies/WebScraperStrategy.test.ts](src/scraper/strategies/WebScraperStrategy.test.ts): the three `scope=subpages`/`hostname`/`domain` tests (lines ~125–291), the index.html nested-descendant test (~903–941), the upward-relative-with-hostname-scope test (~943–982), the directory-base parity test (~984–1017), and the cross-origin `<base href>` test (~1019–1054). Do NOT remove tests outside this cluster (cleanup, refresh-mode, hash-routed SPA, maxDepth/maxPages limits — those are about other concerns).
+- [x] 5.2 Add a fresh `describe("scope filtering")` block. For each scope mode and each spec scenario that requires integration coverage, add a test that mocks the fetcher (returning a page with curated link set) and asserts which links are followed. Cover:
+  - `subpages` — base URL `https://example.com/api/`: descendant in scope, sibling not, subdomain not, different host not.
+  - `subpages` — `/api/index.html` start URL with no redirect: siblings under `/api/` followed (verifies the tightened heuristic preserves this).
+  - `subpages` — `/api/index` start URL (extensionless) with no redirect: siblings under `/api/` followed.
+  - `subpages` — `/v1.0` start URL with no redirect: only `/v1.0/...` followed (verifies the silent over-broad-crawl bug is fixed).
+  - `subpages` — `/foo.html` start URL with no redirect: only `/foo.html` itself fetched.
+  - `subpages` — mixed-case path: `/Api/` and `/api/intro` do NOT match.
+  - `hostname` — same host all paths followed; subdomain rejected.
+  - `hostname` — different ports rejected (`https://x:8443/` vs `https://x:9000/`).
+  - `hostname` — trailing-dot normalization: `example.com.` and `example.com` treated equal.
+  - `hostname` — protocol mismatch rejected (`http://x/` from `https://x/` base).
+  - `domain` — same primary domain across subdomains accepted; different primary domain rejected; GitHub Pages users isolated; localhost accepted across ports.
+- [x] 5.3 Add a `describe("depth-0 redirect handling")` block covering each redirect-scenario from the spec:
+  - Hash-suffix redirect (issue #381): user URL `https://example.com/foo`, mock returns `source: "https://example.com/foo~abc"`, page contains `<a href="/foo/child">`. Expect child fetched.
+  - Trailing-slash redirect: `/api` → `/api/`. Expect children under `/api/` fetched.
+  - Directory-index redirect: `/api` → `/api/index.html`. Expect siblings under `/api/` fetched.
+  - Deeper-descendant redirect: `/api` → `/api/v2/intro`. Expect children under `/api/v2/` fetched.
+  - Site-reorg redirect: `/v1/api` → `/v2/api`, page contains `<a href="/v2/api/child">`. Expect child NOT fetched, warning logged.
+  - Dead-URL redirect: `/removed` → `/`, page contains `<a href="/home/intro">`. Expect child NOT fetched, warning logged.
+  - Protocol upgrade: `http://example.com/api` → `https://example.com/api`. Expect `https://example.com/api/child` fetched.
+  - Apex→www: `https://example.com/api` → `https://www.example.com/api`. Expect `https://www.example.com/api/child` fetched.
+  - Port change via redirect: `https://example.com/api` → `https://example.com:8443/api`. Expect `https://example.com:8443/api/child` fetched.
+- [x] 5.4 Rewrite the cross-origin `<base href>` test under the new `host`-based comparison: a page with `<base href="https://cdn.example.com/lib/">` and `<a href="script.js">` (resolves to `https://cdn.example.com/lib/script.js`) is NOT in scope when scope is `subpages` and base is `https://example.com/app/`. Same canonical scenario as the removed test, asserted against the new code paths.
+- [x] 5.5 Add a `describe("scope edge cases")` block:
+  - Start URL is always fetched even when its path doesn't match its own scope after redirect (depth-0 exemption).
+  - Warning fires at most once per scrape on multi-page crawl.
+  - Warning does not fire when there is no redirect or when the redirect is descendant-only.
+  - `scope: undefined` at the strategy layer behaves identically to `scope: "subpages"`.
+
+## 6. Validation
+
+- [x] 6.1 Run `npm run typecheck` and confirm no new errors.
+- [x] 6.2 Run `npm run lint` and confirm no new errors.
+- [x] 6.3 Run `npm run test:unit -- src/scraper/utils/scope.test.ts` and confirm all new unit tests pass.
+- [x] 6.4 Run `npm run test:unit -- src/scraper/strategies/WebScraperStrategy.test.ts` and confirm all rewritten and untouched tests pass.
+- [x] 6.5 Run the full unit test suite `npm run test:unit` and confirm no other tests regress.
+- [x] 6.6 Run `npx openspec validate fix-subpages-scope-after-redirect --strict` and confirm it passes.
+
+## 7. PR/commit hygiene
+
+- [x] 7.1 Reference issue #381 in the eventual commit/PR description.
+- [x] 7.2 Call out the four behavior changes explicitly in the PR description, matching the proposal's "BREAKING" list: (1) siblingwise depth-0 redirect now keeps user path + warns; (2) start URLs like `/v1.0`, `/foo.html`, `/changelog.md` now scope narrowly instead of accidentally crawling the whole hostname; (3) `subpages`/`hostname` scopes now distinguish ports; (4) `scope: undefined` at the strategy layer now defaults to `subpages` instead of unrestricted crawling.
+- [x] 7.3 No README or user-facing docs changes required — config shape is unchanged. The spec at [openspec/changes/fix-subpages-scope-after-redirect/specs/scraping-scope/spec.md](openspec/changes/fix-subpages-scope-after-redirect/specs/scraping-scope/spec.md) is the authoritative reference.

--- a/openspec/changes/fix-subpages-scope-after-redirect/tasks.md
+++ b/openspec/changes/fix-subpages-scope-after-redirect/tasks.md
@@ -53,6 +53,12 @@
   - Warning fires at most once per scrape on multi-page crawl.
   - Warning does not fire when there is no redirect or when the redirect is descendant-only.
   - `scope: undefined` at the strategy layer behaves identically to `scope: "subpages"`.
+- [x] 5.6 Add a `describe("hash-route scope interaction")` block covering the `preserveHashes` × scope contract (orthogonal to existing hash-preservation tests):
+  - Hash-routed siblings on the same pathname all pass subpages scope (issue #379 scenario).
+  - Hash route to a different pathname is still filtered by subpages scope.
+  - Descendant redirect with restored hash keeps hash routes in scope.
+  - Siblingwise redirect with hash drops the hash and warns.
+  - Hash routes are equivalent under hostname scope.
 
 ## 6. Validation
 

--- a/src/scraper/strategies/BaseScraperStrategy.test.ts
+++ b/src/scraper/strategies/BaseScraperStrategy.test.ts
@@ -766,6 +766,7 @@ describe("BaseScraperStrategy", () => {
         version: "1.0.0",
         maxPages: 5,
         maxDepth: 1,
+        scope: "hostname",
         includePatterns: ["docs/*"],
       };
       const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
@@ -814,6 +815,7 @@ describe("BaseScraperStrategy", () => {
         version: "1.0.0",
         maxPages: 5,
         maxDepth: 1,
+        scope: "hostname",
         includePatterns: ["/docs\\/intro.*/"],
       };
       const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
@@ -861,6 +863,7 @@ describe("BaseScraperStrategy", () => {
         version: "1.0.0",
         maxPages: 5,
         maxDepth: 1,
+        scope: "hostname",
         excludePatterns: ["docs/private/*"],
       };
       const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
@@ -908,6 +911,7 @@ describe("BaseScraperStrategy", () => {
         version: "1.0.0",
         maxPages: 5,
         maxDepth: 1,
+        scope: "hostname",
         excludePatterns: ["/private/"],
       };
       const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
@@ -955,6 +959,7 @@ describe("BaseScraperStrategy", () => {
         version: "1.0.0",
         maxPages: 5,
         maxDepth: 1,
+        scope: "hostname",
         includePatterns: ["docs/*"],
         excludePatterns: ["docs/private/*"],
       };

--- a/src/scraper/strategies/BaseScraperStrategy.ts
+++ b/src/scraper/strategies/BaseScraperStrategy.ts
@@ -101,14 +101,13 @@ export abstract class BaseScraperStrategy implements ScraperStrategy {
    * Scope is checked first, then patterns.
    */
   protected shouldProcessUrl(url: string, options: ScraperOptions): boolean {
-    if (options.scope) {
-      try {
-        const base = this.canonicalBaseUrl ?? new URL(options.url);
-        const target = new URL(url);
-        if (!isInScope(base, target, options.scope)) return false;
-      } catch {
-        return false;
-      }
+    const scope = options.scope ?? "subpages";
+    try {
+      const base = this.canonicalBaseUrl ?? new URL(options.url);
+      const target = new URL(url);
+      if (!isInScope(base, target, scope)) return false;
+    } catch {
+      return false;
     }
     return shouldIncludeUrl(url, options.includePatterns, options.excludePatterns);
   }

--- a/src/scraper/strategies/WebScraperStrategy.test.ts
+++ b/src/scraper/strategies/WebScraperStrategy.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProgressCallback } from "../../types";
 import { type AppConfig, loadConfig } from "../../utils/config";
+import { logger } from "../../utils/logger";
 import { FetchStatus } from "../fetcher/types";
 import type { ScrapeResult, ScraperOptions, ScraperProgressEvent } from "../types";
 import { ScrapeMode } from "../types"; // Import ScrapeMode
@@ -119,29 +120,455 @@ describe("WebScraperStrategy", () => {
   }, 10000);
 
   // --- Scope Tests ---
-  // These tests now rely on the actual pipeline running,
-  // verifying behavior by checking mockFetchFn calls and progressCallback results.
+  // Comprehensive coverage of the scraping-scope spec: each scope mode, depth-0 redirect
+  // shapes, port/trailing-dot/protocol edge cases, and the start-URL exemption.
 
-  it("should follow links based on scope=subpages", async () => {
-    const baseHtml = `
-      <html><head><title>Test Site</title></head><body>
-        <h1>Test Page</h1>
-        <a href="https://example.com/subpage1">Subpage 1</a>
-        <a href="https://example.com/subpage2/">Subpage 2</a>
-        <a href="https://otherdomain.com/page">External Link</a>
-        <a href="https://api.example.com/endpoint">Different Subdomain</a>
-        <a href="/relative-path">Relative Path</a>
-      </body></html>`;
+  /**
+   * Configure mockFetchFn to return a page at `startUrl` with the given anchor links.
+   * Optionally simulate a depth-0 redirect by setting `finalSource` to a different URL than the
+   * one fetched (matches how AutoDetectFetcher reports the post-redirect URL via `source`).
+   * Every fetch for an unrelated URL returns a generic page so the crawler can keep walking.
+   */
+  function mockPageWithLinks(
+    startUrl: string,
+    anchors: string[],
+    finalSource: string = startUrl,
+  ) {
+    const startHtml = `<html><head><title>Start</title></head><body>${anchors
+      .map((href) => `<a href="${href}">${href}</a>`)
+      .join("")}</body></html>`;
+    mockFetchFn.mockImplementation(async (url: string) => {
+      if (url === startUrl) {
+        return {
+          content: startHtml,
+          mimeType: "text/html",
+          source: finalSource,
+          status: FetchStatus.SUCCESS,
+        };
+      }
+      return {
+        content: `<html><head><title>${url}</title></head><body>${url}</body></html>`,
+        mimeType: "text/html",
+        source: url,
+        status: FetchStatus.SUCCESS,
+      };
+    });
+  }
+
+  describe("scope filtering", () => {
+    it("subpages: descendant in, sibling out, subdomain out, different host out", async () => {
+      options.url = "https://example.com/api/";
+      options.scope = "subpages";
+      options.maxDepth = 1;
+      mockPageWithLinks("https://example.com/api/", [
+        "https://example.com/api/intro",
+        "https://example.com/blog/post",
+        "https://api.example.com/v1",
+        "https://other.com/page",
+      ]);
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com/api/intro",
+        expect.anything(),
+      );
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://example.com/blog/post",
+        expect.anything(),
+      );
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://api.example.com/v1",
+        expect.anything(),
+      );
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://other.com/page",
+        expect.anything(),
+      );
+    });
+
+    it("subpages: /api/index.html start follows siblings under /api/", async () => {
+      options.url = "https://example.com/api/index.html";
+      options.scope = "subpages";
+      options.maxDepth = 1;
+      mockPageWithLinks("https://example.com/api/index.html", [
+        "https://example.com/api/intro",
+        "https://example.com/api/guides/deep",
+      ]);
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com/api/intro",
+        expect.anything(),
+      );
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com/api/guides/deep",
+        expect.anything(),
+      );
+    });
+
+    it("subpages: /api/index extensionless start follows siblings under /api/", async () => {
+      options.url = "https://example.com/api/index";
+      options.scope = "subpages";
+      options.maxDepth = 1;
+      mockPageWithLinks("https://example.com/api/index", [
+        "https://example.com/api/intro",
+      ]);
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com/api/intro",
+        expect.anything(),
+      );
+    });
+
+    it("subpages: /v1.0 start scopes narrowly to /v1.0/* (silent bug fixed)", async () => {
+      options.url = "https://example.com/v1.0";
+      options.scope = "subpages";
+      options.maxDepth = 1;
+      mockPageWithLinks("https://example.com/v1.0", [
+        "https://example.com/v1.0/intro",
+        "https://example.com/v2.0/intro",
+        "https://example.com/other/page",
+      ]);
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com/v1.0/intro",
+        expect.anything(),
+      );
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://example.com/v2.0/intro",
+        expect.anything(),
+      );
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://example.com/other/page",
+        expect.anything(),
+      );
+    });
+
+    it("subpages: /foo.html start scopes to itself only (silent bug fixed)", async () => {
+      options.url = "https://example.com/foo.html";
+      options.scope = "subpages";
+      options.maxDepth = 1;
+      mockPageWithLinks("https://example.com/foo.html", [
+        "https://example.com/other.html",
+        "https://example.com/some/page",
+      ]);
+      await strategy.scrape(options, vi.fn());
+
+      // Start URL itself is fetched (depth-0 exemption); other links are out of scope
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com/foo.html",
+        expect.anything(),
+      );
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://example.com/other.html",
+        expect.anything(),
+      );
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://example.com/some/page",
+        expect.anything(),
+      );
+    });
+
+    it("subpages: path comparison is case-sensitive", async () => {
+      options.url = "https://example.com/Api/";
+      options.scope = "subpages";
+      options.maxDepth = 1;
+      mockPageWithLinks("https://example.com/Api/", ["https://example.com/api/intro"]);
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://example.com/api/intro",
+        expect.anything(),
+      );
+    });
+
+    it("hostname: same host all paths followed; subdomain rejected", async () => {
+      options.url = "https://example.com/api";
+      options.scope = "hostname";
+      options.maxDepth = 1;
+      mockPageWithLinks("https://example.com/api", [
+        "https://example.com/blog/post",
+        "https://api.example.com/v1",
+      ]);
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com/blog/post",
+        expect.anything(),
+      );
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://api.example.com/v1",
+        expect.anything(),
+      );
+    });
+
+    it("hostname: different ports treated as different hosts", async () => {
+      options.url = "https://example.com:8443/api";
+      options.scope = "hostname";
+      options.maxDepth = 1;
+      mockPageWithLinks("https://example.com:8443/api", [
+        "https://example.com:9000/api/intro",
+        "https://example.com/api/intro",
+        "https://example.com:8443/api/intro",
+      ]);
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com:8443/api/intro",
+        expect.anything(),
+      );
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://example.com:9000/api/intro",
+        expect.anything(),
+      );
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://example.com/api/intro",
+        expect.anything(),
+      );
+    });
+
+    it("hostname: protocol mismatch rejected", async () => {
+      options.url = "https://example.com/api";
+      options.scope = "hostname";
+      options.maxDepth = 1;
+      mockPageWithLinks("https://example.com/api", ["http://example.com/api/intro"]);
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "http://example.com/api/intro",
+        expect.anything(),
+      );
+    });
+
+    it("domain: same primary domain across subdomains accepted; different primary domain rejected", async () => {
+      options.url = "https://docs.example.com/";
+      options.scope = "domain";
+      options.maxDepth = 1;
+      mockPageWithLinks("https://docs.example.com/", [
+        "https://api.example.com/v1",
+        "https://example.org/page",
+      ]);
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://api.example.com/v1",
+        expect.anything(),
+      );
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://example.org/page",
+        expect.anything(),
+      );
+    });
+
+    it("domain: GitHub Pages users are isolated", async () => {
+      options.url = "https://userA.github.io/proj/";
+      options.scope = "domain";
+      options.maxDepth = 1;
+      mockPageWithLinks("https://userA.github.io/proj/", [
+        "https://userB.github.io/other/",
+      ]);
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://userB.github.io/other/",
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("depth-0 redirect handling", () => {
+    it("hash-suffix redirect: child links under the unsuffixed path are in scope (issue #381)", async () => {
+      options.url = "https://example.com/foo";
+      options.scope = "subpages";
+      options.maxDepth = 1;
+      mockPageWithLinks(
+        "https://example.com/foo",
+        ["https://example.com/foo/child"],
+        "https://example.com/foo~abc",
+      );
+      const warnSpy = vi.spyOn(logger, "warn");
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com/foo/child",
+        expect.anything(),
+      );
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it("trailing-slash redirect: descendant adoption keeps children in scope", async () => {
+      options.url = "https://example.com/api";
+      options.scope = "subpages";
+      options.maxDepth = 1;
+      mockPageWithLinks(
+        "https://example.com/api",
+        ["https://example.com/api/intro"],
+        "https://example.com/api/",
+      );
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com/api/intro",
+        expect.anything(),
+      );
+    });
+
+    it("directory-index redirect: siblings under /api/ remain in scope", async () => {
+      options.url = "https://example.com/api";
+      options.scope = "subpages";
+      options.maxDepth = 1;
+      mockPageWithLinks(
+        "https://example.com/api",
+        ["https://example.com/api/intro"],
+        "https://example.com/api/index.html",
+      );
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com/api/intro",
+        expect.anything(),
+      );
+    });
+
+    it("deeper-descendant redirect: scope narrows to the deeper path", async () => {
+      options.url = "https://example.com/api";
+      options.scope = "subpages";
+      options.maxDepth = 1;
+      // Redirect path /api/v2/intro is treated as a directory (last segment isn't an index file).
+      // Descendants like /api/v2/intro/child are in scope; siblings under /api/ are not.
+      mockPageWithLinks(
+        "https://example.com/api",
+        ["https://example.com/api/v2/intro/child", "https://example.com/api/v1/intro"],
+        "https://example.com/api/v2/intro",
+      );
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com/api/v2/intro/child",
+        expect.anything(),
+      );
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://example.com/api/v1/intro",
+        expect.anything(),
+      );
+    });
+
+    it("site-reorg redirect (siblingwise): child under redirected path is NOT followed; warning logged", async () => {
+      options.url = "https://example.com/v1/api";
+      options.scope = "subpages";
+      options.maxDepth = 1;
+      mockPageWithLinks(
+        "https://example.com/v1/api",
+        ["https://example.com/v2/api/child"],
+        "https://example.com/v2/api",
+      );
+      const warnSpy = vi.spyOn(logger, "warn");
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://example.com/v2/api/child",
+        expect.anything(),
+      );
+      const siblingwiseWarn = warnSpy.mock.calls.find((c) =>
+        String(c[0]).includes("Depth-0 redirect changed path siblingwise"),
+      );
+      expect(siblingwiseWarn).toBeDefined();
+      warnSpy.mockRestore();
+    });
+
+    it("dead-URL redirect to homepage: scope does not expand to the whole host", async () => {
+      options.url = "https://example.com/removed";
+      options.scope = "subpages";
+      options.maxDepth = 1;
+      mockPageWithLinks(
+        "https://example.com/removed",
+        ["https://example.com/home/intro"],
+        "https://example.com/",
+      );
+      const warnSpy = vi.spyOn(logger, "warn");
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://example.com/home/intro",
+        expect.anything(),
+      );
+      const siblingwiseWarn = warnSpy.mock.calls.find((c) =>
+        String(c[0]).includes("Depth-0 redirect changed path siblingwise"),
+      );
+      expect(siblingwiseWarn).toBeDefined();
+      warnSpy.mockRestore();
+    });
+
+    it("protocol-upgrade redirect: child links on the new protocol are in scope", async () => {
+      options.url = "http://example.com/api";
+      options.scope = "subpages";
+      options.maxDepth = 1;
+      mockPageWithLinks(
+        "http://example.com/api",
+        ["https://example.com/api/child"],
+        "https://example.com/api",
+      );
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com/api/child",
+        expect.anything(),
+      );
+    });
+
+    it("apex→www redirect: child links on www are in scope", async () => {
+      options.url = "https://example.com/api";
+      options.scope = "subpages";
+      options.maxDepth = 1;
+      mockPageWithLinks(
+        "https://example.com/api",
+        ["https://www.example.com/api/child"],
+        "https://www.example.com/api",
+      );
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://www.example.com/api/child",
+        expect.anything(),
+      );
+    });
+
+    it("port-change redirect: child links on the new port are in scope", async () => {
+      options.url = "https://example.com/api";
+      options.scope = "subpages";
+      options.maxDepth = 1;
+      mockPageWithLinks(
+        "https://example.com/api",
+        ["https://example.com:8443/api/child"],
+        "https://example.com:8443/api",
+      );
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com:8443/api/child",
+        expect.anything(),
+      );
+    });
+  });
+
+  it("should not enqueue cross-origin links introduced via <base href> when scope=subpages", async () => {
+    const start = "https://example.com/app/index.html";
+    const cdnBase = "https://cdn.example.com/lib/";
+    const relLink = "script.js";
+    const resolved = `${cdnBase}${relLink}`;
 
     mockFetchFn.mockImplementation(async (url: string) => {
-      if (url === "https://example.com")
+      if (url === start) {
         return {
-          content: baseHtml,
+          content: `<html><head><base href="${cdnBase}"></head><body><a href="${relLink}">Script</a></body></html>`,
           mimeType: "text/html",
           source: url,
           status: FetchStatus.SUCCESS,
         };
-      // Return simple content for subpages, title reflects URL
+      }
       return {
         content: `<html><head><title>${url}</title></head><body>${url}</body></html>`,
         mimeType: "text/html",
@@ -150,145 +577,100 @@ describe("WebScraperStrategy", () => {
       };
     });
 
+    options.url = start;
     options.scope = "subpages";
-    options.maxDepth = 1; // Limit depth for simplicity
-    options.maxPages = 5; // Allow enough pages
-    const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
+    options.maxDepth = 1;
+    options.maxPages = 5;
 
-    await strategy.scrape(options, progressCallback);
+    await strategy.scrape(options, vi.fn());
 
-    // Verify fetcher calls
-    expect(mockFetchFn).toHaveBeenCalledWith("https://example.com", expect.anything());
-    expect(mockFetchFn).toHaveBeenCalledWith(
-      "https://example.com/subpage1",
-      expect.anything(),
-    );
-    expect(mockFetchFn).toHaveBeenCalledWith(
-      "https://example.com/subpage2/",
-      expect.anything(),
-    );
-    expect(mockFetchFn).toHaveBeenCalledWith(
-      "https://example.com/relative-path",
-      expect.anything(),
-    );
-    expect(mockFetchFn).not.toHaveBeenCalledWith(
-      "https://otherdomain.com/page",
-      expect.anything(),
-    );
-    expect(mockFetchFn).not.toHaveBeenCalledWith(
-      "https://api.example.com/endpoint",
-      expect.anything(),
-    );
+    expect(mockFetchFn).toHaveBeenCalledWith(start, expect.anything());
+    expect(mockFetchFn).not.toHaveBeenCalledWith(resolved, expect.anything());
+  });
 
-    // Verify documents via callback
-    const receivedDocs = progressCallback.mock.calls.map((call) => call[0].result);
-    expect(receivedDocs).toHaveLength(4);
-    expect(receivedDocs.some((doc) => doc?.title === "Test Site")).toBe(true);
-    expect(
-      receivedDocs.some((doc) => doc?.title === "https://example.com/subpage1"),
-    ).toBe(true);
-    expect(
-      receivedDocs.some((doc) => doc?.title === "https://example.com/subpage2/"),
-    ).toBe(true);
-    expect(
-      receivedDocs.some((doc) => doc?.title === "https://example.com/relative-path"),
-    ).toBe(true);
-  }, 10000);
+  describe("scope edge cases", () => {
+    it("start URL is always fetched even when its path doesn't match its own scope post-redirect", async () => {
+      options.url = "https://example.com/foo";
+      options.scope = "subpages";
+      options.maxDepth = 1;
+      mockPageWithLinks("https://example.com/foo", [], "https://example.com/foo~abc");
+      await strategy.scrape(options, vi.fn());
 
-  it("should follow links based on scope=hostname", async () => {
-    mockFetchFn.mockImplementation(async (url: string) => {
-      if (url === "https://example.com") {
-        return {
-          content:
-            '<html><head><title>Base</title></head><body><a href="/subpage">Sub</a><a href="https://api.example.com/ep">API</a><a href="https://other.com">Other</a></body></html>',
-          mimeType: "text/html",
-          source: url,
-          status: FetchStatus.SUCCESS,
-        };
-      }
-      return {
-        content: `<html><head><title>${url}</title></head><body>${url}</body></html>`,
-        mimeType: "text/html",
-        source: url,
-        status: FetchStatus.SUCCESS,
-      };
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com/foo",
+        expect.anything(),
+      );
     });
 
-    options.scope = "hostname";
-    options.maxDepth = 1;
-    const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
+    it("siblingwise warning fires at most once per scrape", async () => {
+      options.url = "https://example.com/foo";
+      options.scope = "subpages";
+      options.maxDepth = 2;
+      mockPageWithLinks(
+        "https://example.com/foo",
+        ["https://example.com/foo/child"],
+        "https://example.com/foo~abc",
+      );
+      const warnSpy = vi.spyOn(logger, "warn");
+      await strategy.scrape(options, vi.fn());
 
-    await strategy.scrape(options, progressCallback);
-
-    // Verify fetcher calls
-    expect(mockFetchFn).toHaveBeenCalledWith("https://example.com", expect.anything());
-    expect(mockFetchFn).toHaveBeenCalledWith(
-      "https://example.com/subpage",
-      expect.anything(),
-    );
-    expect(mockFetchFn).not.toHaveBeenCalledWith(
-      "https://api.example.com/ep",
-      expect.anything(),
-    );
-    expect(mockFetchFn).not.toHaveBeenCalledWith("https://other.com", expect.anything());
-
-    // Verify documents via callback
-    const receivedDocs = progressCallback.mock.calls.map((call) => call[0].result);
-    expect(receivedDocs).toHaveLength(2);
-    expect(receivedDocs.some((doc) => doc?.title === "Base")).toBe(true);
-    expect(receivedDocs.some((doc) => doc?.title === "https://example.com/subpage")).toBe(
-      true,
-    );
-  }, 10000);
-
-  it("should follow links based on scope=domain", async () => {
-    mockFetchFn.mockImplementation(async (url: string) => {
-      if (url === "https://example.com") {
-        return {
-          content:
-            '<html><head><title>Base</title></head><body><a href="/subpage">Sub</a><a href="https://api.example.com/ep">API</a><a href="https://other.com">Other</a></body></html>',
-          mimeType: "text/html",
-          source: url,
-          status: FetchStatus.SUCCESS,
-        };
-      }
-      return {
-        content: `<html><head><title>${url}</title></head><body>${url}</body></html>`,
-        mimeType: "text/html",
-        source: url,
-        status: FetchStatus.SUCCESS,
-      };
+      const siblingwiseWarns = warnSpy.mock.calls.filter((c) =>
+        String(c[0]).includes("Depth-0 redirect changed path siblingwise"),
+      );
+      expect(siblingwiseWarns.length).toBe(1);
+      warnSpy.mockRestore();
     });
 
-    options.scope = "domain";
-    options.maxDepth = 1;
-    const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
+    it("no warning when there is no redirect", async () => {
+      options.url = "https://example.com/api";
+      options.scope = "subpages";
+      options.maxDepth = 1;
+      mockPageWithLinks("https://example.com/api", []);
+      const warnSpy = vi.spyOn(logger, "warn");
+      await strategy.scrape(options, vi.fn());
 
-    await strategy.scrape(options, progressCallback);
+      const siblingwiseWarns = warnSpy.mock.calls.filter((c) =>
+        String(c[0]).includes("Depth-0 redirect changed path siblingwise"),
+      );
+      expect(siblingwiseWarns.length).toBe(0);
+      warnSpy.mockRestore();
+    });
 
-    // Verify fetcher calls
-    expect(mockFetchFn).toHaveBeenCalledWith("https://example.com", expect.anything());
-    expect(mockFetchFn).toHaveBeenCalledWith(
-      "https://example.com/subpage",
-      expect.anything(),
-    );
-    expect(mockFetchFn).toHaveBeenCalledWith(
-      "https://api.example.com/ep",
-      expect.anything(),
-    ); // Same domain
-    expect(mockFetchFn).not.toHaveBeenCalledWith("https://other.com", expect.anything());
+    it("no warning when the redirect is descendant-only (e.g. trailing slash)", async () => {
+      options.url = "https://example.com/api";
+      options.scope = "subpages";
+      options.maxDepth = 1;
+      mockPageWithLinks("https://example.com/api", [], "https://example.com/api/");
+      const warnSpy = vi.spyOn(logger, "warn");
+      await strategy.scrape(options, vi.fn());
 
-    // Verify documents via callback
-    const receivedDocs = progressCallback.mock.calls.map((call) => call[0].result);
-    expect(receivedDocs).toHaveLength(3);
-    expect(receivedDocs.some((doc) => doc?.title === "Base")).toBe(true);
-    expect(receivedDocs.some((doc) => doc?.title === "https://example.com/subpage")).toBe(
-      true,
-    );
-    expect(receivedDocs.some((doc) => doc?.title === "https://api.example.com/ep")).toBe(
-      true,
-    );
-  }, 10000);
+      const siblingwiseWarns = warnSpy.mock.calls.filter((c) =>
+        String(c[0]).includes("Depth-0 redirect changed path siblingwise"),
+      );
+      expect(siblingwiseWarns.length).toBe(0);
+      warnSpy.mockRestore();
+    });
+
+    it("scope: undefined behaves identically to scope: 'subpages'", async () => {
+      options.url = "https://example.com/api/";
+      options.scope = undefined;
+      options.maxDepth = 1;
+      mockPageWithLinks("https://example.com/api/", [
+        "https://example.com/api/intro",
+        "https://example.com/blog/post",
+      ]);
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com/api/intro",
+        expect.anything(),
+      );
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://example.com/blog/post",
+        expect.anything(),
+      );
+    });
+  });
 
   // --- Limit Tests ---
 
@@ -897,160 +1279,6 @@ describe("WebScraperStrategy", () => {
 
     expect(mockFetchFn).toHaveBeenCalledWith(original, expect.anything());
     expect(mockFetchFn).toHaveBeenCalledWith(expectedCanonicalFollow, expect.anything());
-  });
-
-  // Integration: relative resolution from index.html with subpages scope
-  it("should follow nested descendant from index.html (subpages scope) but not upward sibling", async () => {
-    const start = "https://example.com/api/index.html";
-    const nestedRel = "aiq/agent/index.html";
-    const upwardRel = "../shared/index.html";
-    const expectedNested = "https://example.com/api/aiq/agent/index.html";
-    const expectedUpward = "https://example.com/shared/index.html";
-
-    mockFetchFn.mockImplementation(async (url: string) => {
-      if (url === start) {
-        return {
-          content: `<html><body>
-            <a href="${nestedRel}">Nested</a>
-            <a href="${upwardRel}">UpOne</a>
-          </body></html>`,
-          mimeType: "text/html",
-          source: url,
-          status: FetchStatus.SUCCESS,
-        };
-      }
-      return {
-        content: `<html><head><title>${url}</title></head><body>${url}</body></html>`,
-        mimeType: "text/html",
-        source: url,
-        status: FetchStatus.SUCCESS,
-      };
-    });
-
-    options.url = start;
-    options.scope = "subpages";
-    options.maxDepth = 1;
-    options.maxPages = 5;
-
-    const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
-    await strategy.scrape(options, progressCallback);
-
-    expect(mockFetchFn).toHaveBeenCalledWith(start, expect.anything());
-    expect(mockFetchFn).toHaveBeenCalledWith(expectedNested, expect.anything());
-    expect(mockFetchFn).not.toHaveBeenCalledWith(expectedUpward, expect.anything());
-  });
-
-  // Integration: upward relative allowed with hostname scope
-  it("should follow upward relative link when scope=hostname", async () => {
-    const start = "https://example.com/api/index.html";
-    const nestedRel = "aiq/agent/index.html";
-    const upwardRel = "../shared/index.html";
-    const expectedNested = "https://example.com/api/aiq/agent/index.html";
-    const expectedUpward = "https://example.com/shared/index.html";
-
-    mockFetchFn.mockImplementation(async (url: string) => {
-      if (url === start) {
-        return {
-          content: `<html><body>
-            <a href="${nestedRel}">Nested</a>
-            <a href="${upwardRel}">UpOne</a>
-          </body></html>`,
-          mimeType: "text/html",
-          source: url,
-          status: FetchStatus.SUCCESS,
-        };
-      }
-      return {
-        content: `<html><head><title>${url}</title></head><body>${url}</body></html>`,
-        mimeType: "text/html",
-        source: url,
-        status: FetchStatus.SUCCESS,
-      };
-    });
-
-    options.url = start;
-    options.scope = "hostname";
-    options.maxDepth = 1;
-    options.maxPages = 10;
-
-    const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
-    await strategy.scrape(options, progressCallback);
-
-    expect(mockFetchFn).toHaveBeenCalledWith(start, expect.anything());
-    expect(mockFetchFn).toHaveBeenCalledWith(expectedNested, expect.anything());
-    expect(mockFetchFn).toHaveBeenCalledWith(expectedUpward, expect.anything());
-  });
-
-  // Integration: directory base parity
-  it("should treat directory base and index.html base equivalently for nested descendant", async () => {
-    const startDir = "https://example.com/api/";
-    const nestedRel = "aiq/agent/index.html";
-    const expectedNested = "https://example.com/api/aiq/agent/index.html";
-
-    mockFetchFn.mockImplementation(async (url: string) => {
-      if (url === startDir) {
-        return {
-          content: `<html><body><a href="${nestedRel}">Nested</a></body></html>`,
-          mimeType: "text/html",
-          source: url,
-          status: FetchStatus.SUCCESS,
-        };
-      }
-      return {
-        content: `<html><head><title>${url}</title></head><body>${url}</body></html>`,
-        mimeType: "text/html",
-        source: url,
-        status: FetchStatus.SUCCESS,
-      };
-    });
-
-    options.url = startDir;
-    options.scope = "subpages";
-    options.maxDepth = 1;
-    options.maxPages = 5;
-
-    const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
-    await strategy.scrape(options, progressCallback);
-
-    expect(mockFetchFn).toHaveBeenCalledWith(startDir, expect.anything());
-    expect(mockFetchFn).toHaveBeenCalledWith(expectedNested, expect.anything());
-  });
-
-  it("should not enqueue cross-origin links introduced via <base href> when scope=subpages", async () => {
-    const start = "https://example.com/app/index.html";
-    const cdnBase = "https://cdn.example.com/lib/";
-    const relLink = "script.js";
-    const resolved = `${cdnBase}${relLink}`;
-
-    mockFetchFn.mockImplementation(async (url: string) => {
-      if (url === start) {
-        return {
-          content: `<html><head><base href="${cdnBase}"></head><body><a href="${relLink}">Script</a></body></html>`,
-          mimeType: "text/html",
-          source: url,
-          status: FetchStatus.SUCCESS,
-        };
-      }
-      // Any unexpected fetches return generic content
-      return {
-        content: `<html><head><title>${url}</title></head><body>${url}</body></html>`,
-        mimeType: "text/html",
-        source: url,
-        status: FetchStatus.SUCCESS,
-      };
-    });
-
-    options.url = start;
-    options.scope = "subpages";
-    options.maxDepth = 1;
-    options.maxPages = 5;
-
-    const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
-    await strategy.scrape(options, progressCallback);
-
-    // Should fetch only the start page; the cross-origin (different hostname) base-derived link is filtered out
-    expect(mockFetchFn).toHaveBeenCalledWith(start, expect.anything());
-    expect(mockFetchFn).not.toHaveBeenCalledWith(resolved, expect.anything());
   });
 
   describe("cleanup", () => {

--- a/src/scraper/strategies/WebScraperStrategy.test.ts
+++ b/src/scraper/strategies/WebScraperStrategy.test.ts
@@ -686,6 +686,143 @@ describe("WebScraperStrategy", () => {
     expect(mockFetchFn).not.toHaveBeenCalledWith(resolved, expect.anything());
   });
 
+  describe("hash-route scope interaction", () => {
+    // Anchor tags use hash hrefs that resolve relative to the page URL. The link extractor
+    // resolves them to absolute URLs via the URL constructor, which preserves the hash. With
+    // preserveHashes=true, the URL normalizer keeps the hash so each route is a distinct queue
+    // entry. Scope filtering is pathname-only, so hash routes sharing a pathname all pass.
+
+    function mockPageWithHashLinks(
+      startUrl: string,
+      hashHrefs: string[],
+      finalSource: string = startUrl,
+    ) {
+      const startHtml = `<html><head><title>Start</title></head><body>${hashHrefs
+        .map((h) => `<a href="${h}">${h}</a>`)
+        .join("")}</body></html>`;
+      mockFetchFn.mockImplementation(async (url: string) => {
+        if (url === startUrl) {
+          return {
+            content: startHtml,
+            mimeType: "text/html",
+            source: finalSource,
+            status: FetchStatus.SUCCESS,
+          };
+        }
+        return {
+          content: `<html><head><title>${url}</title></head><body>${url}</body></html>`,
+          mimeType: "text/html",
+          source: url,
+          status: FetchStatus.SUCCESS,
+        };
+      });
+    }
+
+    it("hash-routed siblings on the same pathname all pass subpages scope (issue #379)", async () => {
+      options.url = "https://docs.example.com/";
+      options.scope = "subpages";
+      options.preserveHashes = true;
+      options.maxDepth = 1;
+      mockPageWithHashLinks("https://docs.example.com/", [
+        "#/Docs/welcome",
+        "#/Docs/api",
+        "#/Docs/config",
+      ]);
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://docs.example.com/#/Docs/welcome",
+        expect.anything(),
+      );
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://docs.example.com/#/Docs/api",
+        expect.anything(),
+      );
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://docs.example.com/#/Docs/config",
+        expect.anything(),
+      );
+    });
+
+    it("hash route to a different pathname is still filtered by subpages scope", async () => {
+      options.url = "https://example.com/foo/";
+      options.scope = "subpages";
+      options.preserveHashes = true;
+      options.maxDepth = 1;
+      mockPageWithHashLinks("https://example.com/foo/", [
+        "https://example.com/bar#/section",
+      ]);
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://example.com/bar#/section",
+        expect.anything(),
+      );
+    });
+
+    it("descendant redirect with restored hash keeps hash routes in scope", async () => {
+      options.url = "https://example.com/docs#/guide";
+      options.scope = "subpages";
+      options.preserveHashes = true;
+      options.maxDepth = 1;
+      // Mock returns `/docs/` as the source (server stripped the hash and added trailing slash).
+      // restorePreservedHash will re-attach `#/guide` since pre/post paths match modulo slash.
+      mockPageWithHashLinks(
+        "https://example.com/docs#/guide",
+        ["https://example.com/docs/#/api"],
+        "https://example.com/docs/",
+      );
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com/docs/#/api",
+        expect.anything(),
+      );
+    });
+
+    it("siblingwise redirect with hash drops the hash and warns", async () => {
+      options.url = "https://example.com/foo#/guide";
+      options.scope = "subpages";
+      options.preserveHashes = true;
+      options.maxDepth = 1;
+      mockPageWithHashLinks(
+        "https://example.com/foo#/guide",
+        ["https://example.com/bar#/api"],
+        "https://example.com/bar",
+      );
+      const warnSpy = vi.spyOn(logger, "warn");
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).not.toHaveBeenCalledWith(
+        "https://example.com/bar#/api",
+        expect.anything(),
+      );
+      const siblingwiseWarn = warnSpy.mock.calls.find((c) =>
+        String(c[0]).includes("Depth-0 redirect changed path siblingwise"),
+      );
+      expect(siblingwiseWarn).toBeDefined();
+      warnSpy.mockRestore();
+    });
+
+    it("hash routes are equivalent under hostname scope", async () => {
+      options.url = "https://example.com/";
+      options.scope = "hostname";
+      options.preserveHashes = true;
+      options.maxDepth = 1;
+      mockPageWithHashLinks("https://example.com/", ["#/a", "#/b"]);
+      await strategy.scrape(options, vi.fn());
+
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com/#/a",
+        expect.anything(),
+      );
+      expect(mockFetchFn).toHaveBeenCalledWith(
+        "https://example.com/#/b",
+        expect.anything(),
+      );
+    });
+  });
+
   describe("scope edge cases", () => {
     it("start URL is always fetched even when its path doesn't match its own scope post-redirect", async () => {
       options.url = "https://example.com/foo";

--- a/src/scraper/strategies/WebScraperStrategy.ts
+++ b/src/scraper/strategies/WebScraperStrategy.ts
@@ -14,6 +14,7 @@ import { FetchStatus, type RawContent } from "../fetcher/types";
 import { PipelineFactory } from "../pipelines/PipelineFactory";
 import type { ContentPipeline, PipelineResult } from "../pipelines/types";
 import type { QueueItem, ScraperOptions } from "../types";
+import { isPathDescendant } from "../utils/scope";
 import { BaseScraperStrategy, type ProcessItemResult } from "./BaseScraperStrategy";
 import { LocalFileStrategy } from "./LocalFileStrategy";
 
@@ -28,6 +29,7 @@ export class WebScraperStrategy extends BaseScraperStrategy {
   private readonly pipelines: ContentPipeline[];
   private readonly localFileStrategy: LocalFileStrategy;
   private tempFiles: string[] = [];
+  private siblingwiseRedirectWarned = false;
 
   constructor(config: AppConfig, options: WebScraperStrategyOptions = {}) {
     super(config, { urlNormalizerOptions: options.urlNormalizerOptions });
@@ -171,9 +173,31 @@ export class WebScraperStrategy extends BaseScraperStrategy {
         };
       }
 
-      // Update canonical base URL from the first page's final URL (after redirects)
+      // Update canonical base URL from the first page's final URL (after redirects).
+      // Protocol and host are always adopted from the redirected URL so cross-origin redirects
+      // (http→https, apex↔www, port changes) don't drop every discovered link via the host check.
+      // The path is adopted only when the redirected pathname is a descendant of the user-provided
+      // pathname; otherwise the user's path is kept as the scope anchor. This preserves user intent
+      // when a server appends a platform-specific suffix (e.g. Document360 /foo → /foo~hash) or
+      // redirects to a reorganized location (/v1 → /v2).
       if (item.depth === 0) {
-        this.canonicalBaseUrl = new URL(effectiveSource);
+        const final = new URL(effectiveSource);
+        const userPath = new URL(options.url).pathname;
+        if (isPathDescendant(userPath, final.pathname)) {
+          this.canonicalBaseUrl = final;
+        } else {
+          if (!this.siblingwiseRedirectWarned) {
+            logger.warn(
+              `⚠️  Depth-0 redirect changed path siblingwise. Scope anchor remains the user-provided path; ` +
+                `discovered links under the redirected path will not be in scope. ` +
+                `Requested: ${options.url} → Final: ${effectiveSource} → Scope anchor: ${userPath}. ` +
+                `If the redirected path is intended, resubmit with that URL.`,
+            );
+            this.siblingwiseRedirectWarned = true;
+          }
+          final.pathname = userPath;
+          this.canonicalBaseUrl = final;
+        }
       }
 
       const filteredLinks =

--- a/src/scraper/utils/scope.test.ts
+++ b/src/scraper/utils/scope.test.ts
@@ -1,93 +1,308 @@
 import { describe, expect, it } from "vitest";
-import { computeBaseDirectory, isInScope } from "./scope";
+import {
+  computeBaseDirectory,
+  isInScope,
+  isPathDescendant,
+  stripTrailingDot,
+} from "./scope";
 
 describe("computeBaseDirectory", () => {
+  it("returns '/' for empty pathname", () => {
+    expect(computeBaseDirectory("")).toBe("/");
+  });
+
+  it("returns '/' for root pathname", () => {
+    expect(computeBaseDirectory("/")).toBe("/");
+  });
+
   it("returns directory unchanged when pathname ends with slash", () => {
     expect(computeBaseDirectory("/api/")).toBe("/api/");
+    expect(computeBaseDirectory("/deep/nested/path/")).toBe("/deep/nested/path/");
   });
 
-  it("treats file-looking path as its parent directory", () => {
-    expect(computeBaseDirectory("/api/index.html")).toBe("/api/");
-    expect(computeBaseDirectory("/deep/path/file.md")).toBe("/deep/path/");
-  });
-
-  it("treats non-file last segment (no dot) as directory and appends slash", () => {
+  it("appends trailing slash for non-index last segment", () => {
     expect(computeBaseDirectory("/api")).toBe("/api/");
     expect(computeBaseDirectory("/api/v1")).toBe("/api/v1/");
   });
 
-  it("root path stays root", () => {
-    expect(computeBaseDirectory("/")).toBe("/");
+  it("treats /index.<ext> as directory index (uses parent directory)", () => {
+    expect(computeBaseDirectory("/api/index.html")).toBe("/api/");
+    expect(computeBaseDirectory("/api/index.htm")).toBe("/api/");
+    expect(computeBaseDirectory("/Index.HTML")).toBe("/");
+  });
+
+  it("matches index file case-insensitively", () => {
+    expect(computeBaseDirectory("/api/Index.HTML")).toBe("/api/");
+    expect(computeBaseDirectory("/api/INDEX.html")).toBe("/api/");
+  });
+
+  it("treats extensionless /index as directory index", () => {
+    expect(computeBaseDirectory("/api/index")).toBe("/api/");
+    expect(computeBaseDirectory("/api/Index")).toBe("/api/");
+  });
+
+  it("does not match index-like names that are not exactly 'index'", () => {
+    expect(computeBaseDirectory("/api/indexes")).toBe("/api/indexes/");
+    expect(computeBaseDirectory("/api/index2")).toBe("/api/index2/");
+    expect(computeBaseDirectory("/api/indexing")).toBe("/api/indexing/");
+  });
+
+  it("treats version-like paths as directories (the old dot-heuristic over-fire is fixed)", () => {
+    expect(computeBaseDirectory("/v1.0")).toBe("/v1.0/");
+    expect(computeBaseDirectory("/api/v2.0")).toBe("/api/v2.0/");
+    expect(computeBaseDirectory("/v2.1")).toBe("/v2.1/");
+  });
+
+  it("treats non-index file-like paths as directories (narrow scope, just themselves)", () => {
+    expect(computeBaseDirectory("/foo.html")).toBe("/foo.html/");
+    expect(computeBaseDirectory("/changelog.md")).toBe("/changelog.md/");
+    expect(computeBaseDirectory("/deep/path/file.md")).toBe("/deep/path/file.md/");
+  });
+});
+
+describe("isPathDescendant", () => {
+  it("returns true for equal paths", () => {
+    expect(isPathDescendant("/api", "/api")).toBe(true);
+    expect(isPathDescendant("/api/", "/api/")).toBe(true);
+  });
+
+  it("normalizes parent trailing slash when comparing", () => {
+    expect(isPathDescendant("/api", "/api/")).toBe(true);
+    expect(isPathDescendant("/api/", "/api")).toBe(true);
+  });
+
+  it("returns true when child is under parent directory", () => {
+    expect(isPathDescendant("/api", "/api/intro")).toBe(true);
+    expect(isPathDescendant("/api/", "/api/intro/deep")).toBe(true);
+    expect(isPathDescendant("/", "/anything")).toBe(true);
+  });
+
+  it("returns false for sibling paths sharing a prefix", () => {
+    expect(isPathDescendant("/api", "/apix")).toBe(false);
+    expect(isPathDescendant("/foo", "/foo~hash")).toBe(false);
+    expect(isPathDescendant("/foo", "/foobar")).toBe(false);
+  });
+
+  it("returns false for unrelated paths", () => {
+    expect(isPathDescendant("/api", "/blog")).toBe(false);
+    expect(isPathDescendant("/api/v1", "/api/v2")).toBe(false);
+  });
+
+  it("returns true with root as parent", () => {
+    expect(isPathDescendant("/", "/")).toBe(true);
+    expect(isPathDescendant("/", "/foo")).toBe(true);
+    expect(isPathDescendant("/", "/foo/bar")).toBe(true);
+  });
+
+  it("handles empty parent path", () => {
+    expect(isPathDescendant("", "/foo")).toBe(true);
+  });
+});
+
+describe("stripTrailingDot", () => {
+  it("returns hostname unchanged when no trailing dot", () => {
+    expect(stripTrailingDot("example.com")).toBe("example.com");
+    expect(stripTrailingDot("docs.example.com")).toBe("docs.example.com");
+  });
+
+  it("strips a single trailing dot", () => {
+    expect(stripTrailingDot("example.com.")).toBe("example.com");
+    expect(stripTrailingDot("docs.example.com.")).toBe("docs.example.com");
+  });
+
+  it("strips only the last dot, leaving inner dots intact", () => {
+    expect(stripTrailingDot("a.b.c.")).toBe("a.b.c");
+  });
+
+  it("handles empty string", () => {
+    expect(stripTrailingDot("")).toBe("");
+  });
+});
+
+describe("isInScope - protocol equality", () => {
+  it("rejects target with different protocol regardless of scope", () => {
+    const base = new URL("https://example.com/api/");
+    const target = new URL("http://example.com/api/intro");
+    expect(isInScope(base, target, "subpages")).toBe(false);
+    expect(isInScope(base, target, "hostname")).toBe(false);
+    expect(isInScope(base, target, "domain")).toBe(false);
   });
 });
 
 describe("isInScope - subpages", () => {
-  const baseFile = new URL("https://example.com/api/index.html");
   const baseDir = new URL("https://example.com/api/");
-  const nested = new URL("https://example.com/api/child/page.html");
-  const upward = new URL("https://example.com/shared/page.html");
+  const baseFile = new URL("https://example.com/api/index.html");
 
-  it("file base acts like its parent directory for descendants", () => {
-    expect(isInScope(baseFile, nested, "subpages")).toBe(true);
+  it("descendant path is in scope from directory base", () => {
+    expect(
+      isInScope(baseDir, new URL("https://example.com/api/guides/intro"), "subpages"),
+    ).toBe(true);
   });
 
-  it("directory base includes descendant", () => {
-    expect(isInScope(baseDir, nested, "subpages")).toBe(true);
+  it("sibling path is not in scope", () => {
+    expect(isInScope(baseDir, new URL("https://example.com/blog/post"), "subpages")).toBe(
+      false,
+    );
   });
 
-  it("file base excludes upward sibling", () => {
-    expect(isInScope(baseFile, upward, "subpages")).toBe(false);
+  it("file base acts like its parent directory (preserves index.html behavior)", () => {
+    expect(
+      isInScope(baseFile, new URL("https://example.com/api/child/page"), "subpages"),
+    ).toBe(true);
+    expect(
+      isInScope(baseFile, new URL("https://example.com/shared/page"), "subpages"),
+    ).toBe(false);
   });
 
-  it("non-file segment without slash acts as directory", () => {
+  it("path-only base (no trailing slash) acts as directory", () => {
     const base = new URL("https://example.com/api");
-    expect(isInScope(base, nested, "subpages")).toBe(true);
+    expect(isInScope(base, new URL("https://example.com/api/intro"), "subpages")).toBe(
+      true,
+    );
+  });
+
+  it("path comparison is case-sensitive", () => {
+    const base = new URL("https://example.com/Api/");
+    expect(isInScope(base, new URL("https://example.com/api/intro"), "subpages")).toBe(
+      false,
+    );
+  });
+
+  it("/v1.0 start URL scopes narrowly to /v1.0/ (silent bug fixed)", () => {
+    const base = new URL("https://example.com/v1.0");
+    expect(isInScope(base, new URL("https://example.com/v1.0/intro"), "subpages")).toBe(
+      true,
+    );
+    expect(isInScope(base, new URL("https://example.com/v2.0/intro"), "subpages")).toBe(
+      false,
+    );
+  });
+
+  it("/foo.html start URL scopes to itself only (silent bug fixed)", () => {
+    const base = new URL("https://example.com/foo.html");
+    // base directory becomes /foo.html/ — only descendants of that fictional path match
+    expect(isInScope(base, new URL("https://example.com/foo.html"), "subpages")).toBe(
+      false,
+    ); // /foo.html does not start with /foo.html/
+    expect(isInScope(base, new URL("https://example.com/other.html"), "subpages")).toBe(
+      false,
+    );
   });
 });
 
-describe("isInScope - hostname and domain", () => {
+describe("isInScope - hostname", () => {
+  const base = new URL("https://docs.example.com/api/");
+
+  it("same host all paths in scope", () => {
+    expect(
+      isInScope(base, new URL("https://docs.example.com/blog/post"), "hostname"),
+    ).toBe(true);
+  });
+
+  it("different subdomain rejected", () => {
+    expect(isInScope(base, new URL("https://api.example.com/v1"), "hostname")).toBe(
+      false,
+    );
+  });
+
+  it("different ports treated as different hosts", () => {
+    const baseWithPort = new URL("https://example.com:8443/api/");
+    expect(
+      isInScope(baseWithPort, new URL("https://example.com:9000/api/intro"), "hostname"),
+    ).toBe(false);
+    expect(
+      isInScope(baseWithPort, new URL("https://example.com/api/intro"), "hostname"),
+    ).toBe(false);
+  });
+
+  it("default port is normalized away", () => {
+    const baseNoPort = new URL("https://example.com/api/");
+    expect(
+      isInScope(baseNoPort, new URL("https://example.com:443/api/intro"), "hostname"),
+    ).toBe(true);
+  });
+
+  it("trailing dot on either hostname is normalized", () => {
+    const baseDot = new URL("https://example.com./api/");
+    expect(isInScope(baseDot, new URL("https://example.com/api/intro"), "hostname")).toBe(
+      true,
+    );
+    expect(
+      isInScope(
+        new URL("https://example.com/api/"),
+        new URL("https://example.com./api/intro"),
+        "hostname",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("isInScope - domain", () => {
   const base = new URL("https://docs.example.com/guide/");
-  const sameHost = new URL("https://docs.example.com/guide/intro");
-  const diffSub = new URL("https://api.example.com/endpoint");
-  const diffDomain = new URL("https://other.org/");
 
-  it("hostname scope restricts to exact hostname", () => {
-    expect(isInScope(base, sameHost, "hostname")).toBe(true);
-    expect(isInScope(base, diffSub, "hostname")).toBe(false);
+  it("different subdomain under same registrable domain is in scope", () => {
+    expect(isInScope(base, new URL("https://api.example.com/endpoint"), "domain")).toBe(
+      true,
+    );
   });
 
-  it("domain scope allows different subdomains under same registrable domain", () => {
-    expect(isInScope(base, diffSub, "domain")).toBe(true);
-    expect(isInScope(base, diffDomain, "domain")).toBe(false);
+  it("different primary domain rejected", () => {
+    expect(isInScope(base, new URL("https://other.org/page"), "domain")).toBe(false);
   });
 
-  it("domain scope handles complex TLDs correctly", () => {
+  it("handles complex TLDs (.co.uk)", () => {
     const baseCoUk = new URL("https://api.service.co.uk/docs");
-    const sameCoUk = new URL("https://www.service.co.uk/other");
-    const diffCoUk = new URL("https://different.co.uk/page");
-
-    expect(isInScope(baseCoUk, sameCoUk, "domain")).toBe(true);
-    expect(isInScope(baseCoUk, diffCoUk, "domain")).toBe(false);
+    expect(
+      isInScope(baseCoUk, new URL("https://www.service.co.uk/other"), "domain"),
+    ).toBe(true);
+    expect(isInScope(baseCoUk, new URL("https://different.co.uk/page"), "domain")).toBe(
+      false,
+    );
   });
 
-  it("domain scope handles GitHub Pages correctly", () => {
+  it("GitHub Pages users are isolated", () => {
     const baseGithub = new URL("https://user.github.io/repo");
-    const sameUser = new URL("https://user.github.io/other-repo");
-    const diffUser = new URL("https://otheruser.github.io/repo");
-
-    expect(isInScope(baseGithub, sameUser, "domain")).toBe(true);
-    expect(isInScope(baseGithub, diffUser, "domain")).toBe(false);
+    expect(
+      isInScope(baseGithub, new URL("https://user.github.io/other-repo"), "domain"),
+    ).toBe(true);
+    expect(
+      isInScope(baseGithub, new URL("https://otheruser.github.io/repo"), "domain"),
+    ).toBe(false);
   });
 
-  it("domain scope handles gov.uk domains correctly", () => {
-    // For .gov.uk, each service gets its own registrable domain
+  it("handles gov.uk service-level domains", () => {
     const baseGov = new URL("https://api.service.gov.uk/docs");
-    const sameGov = new URL("https://subdomain.api.service.gov.uk/assets"); // Same registrable domain
-    const diffGov = new URL("https://api.different.gov.uk/docs"); // Different registrable domain
-    const diffService = new URL("https://cdn.service.gov.uk/assets"); // Different service = different registrable domain
+    expect(
+      isInScope(
+        baseGov,
+        new URL("https://subdomain.api.service.gov.uk/assets"),
+        "domain",
+      ),
+    ).toBe(true);
+    expect(
+      isInScope(baseGov, new URL("https://api.different.gov.uk/docs"), "domain"),
+    ).toBe(false);
+    expect(
+      isInScope(baseGov, new URL("https://cdn.service.gov.uk/assets"), "domain"),
+    ).toBe(false);
+  });
 
-    expect(isInScope(baseGov, sameGov, "domain")).toBe(true);
-    expect(isInScope(baseGov, diffGov, "domain")).toBe(false);
-    expect(isInScope(baseGov, diffService, "domain")).toBe(false);
+  it("IPv4 hosts compare verbatim", () => {
+    const base = new URL("http://192.168.1.10/");
+    expect(isInScope(base, new URL("http://192.168.1.10/foo"), "domain")).toBe(true);
+    expect(isInScope(base, new URL("http://192.168.1.20/foo"), "domain")).toBe(false);
+  });
+
+  it("localhost compares verbatim and ignores port", () => {
+    const base = new URL("http://localhost:3000/");
+    expect(isInScope(base, new URL("http://localhost:4000/"), "domain")).toBe(true);
+    expect(isInScope(base, new URL("http://otherhost:3000/"), "domain")).toBe(false);
+  });
+
+  it("trailing dot on hostname is normalized for domain scope", () => {
+    const baseDot = new URL("https://docs.example.com./");
+    expect(isInScope(baseDot, new URL("https://api.example.com/v1"), "domain")).toBe(
+      true,
+    );
   });
 });

--- a/src/scraper/utils/scope.ts
+++ b/src/scraper/utils/scope.ts
@@ -2,29 +2,60 @@
 import type { URL } from "node:url";
 import { extractPrimaryDomain } from "../../utils/url";
 
+const INDEX_FILE_PATTERN = /^index(\.[a-z0-9]+)?$/i;
+
 /**
  * Compute the effective base directory for scope=subpages.
  * Rules:
- * - If path ends with '/', treat as directory (keep as-is)
- * - Else if last segment contains a dot, treat as file and use its parent directory
- * - Else treat the path as a directory name (append '/')
+ * - Empty path or "/" → "/"
+ * - Path ending with "/" → returned unchanged
+ * - Last segment matches /^index(\.[a-z0-9]+)?$/i (case-insensitive, extension optional)
+ *   → parent directory with trailing slash. Covers /api/index, /api/index.html, /api/Index.HTML, etc.
+ * - Otherwise → path with trailing slash appended (path is treated as a directory)
  */
 export function computeBaseDirectory(pathname: string): string {
-  if (pathname === "") return "/";
+  if (pathname === "" || pathname === "/") return "/";
   if (pathname.endsWith("/")) return pathname;
   const lastSegment = pathname.split("/").at(-1) || "";
-  const looksLikeFile = lastSegment.includes(".");
-  if (looksLikeFile) {
+  if (INDEX_FILE_PATTERN.test(lastSegment)) {
     return pathname.replace(/\/[^/]*$/, "/");
   }
   return `${pathname}/`;
 }
 
 /**
+ * Returns true when `childPath` is the same as `parentPath` or is a path-descendant of it.
+ * `parentPath` is normalized to end with "/" before comparison so directory semantics apply.
+ *
+ * Examples:
+ * - isPathDescendant("/api", "/api") → true (equal after normalization)
+ * - isPathDescendant("/api", "/api/") → true
+ * - isPathDescendant("/api", "/api/foo") → true
+ * - isPathDescendant("/api", "/api~hash") → false (siblingwise, not under /api/)
+ * - isPathDescendant("/api", "/blog") → false
+ */
+export function isPathDescendant(parentPath: string, childPath: string): boolean {
+  const normalizedParent = parentPath.endsWith("/") ? parentPath : `${parentPath}/`;
+  if (childPath === normalizedParent) return true;
+  if (`${childPath}/` === normalizedParent) return true; // child is parent without trailing slash
+  return childPath.startsWith(normalizedParent);
+}
+
+/**
+ * Strip a single trailing "." from a hostname. DNS names like "example.com." and "example.com"
+ * resolve identically; comparison code should treat them as equivalent.
+ */
+export function stripTrailingDot(hostname: string): string {
+  return hostname.endsWith(".") ? hostname.slice(0, -1) : hostname;
+}
+
+/**
  * Returns true if the targetUrl is in scope of the baseUrl for the given scope.
- * - "subpages": same hostname, and target path starts with the parent directory of the base path
- * - "hostname": same hostname
- * - "domain": same top-level domain (e.g. example.com)
+ * - "subpages": same host (incl. port) AND target path starts with the base directory of base path
+ * - "hostname": same host (incl. port)
+ * - "domain": same primary domain (registrable domain, port-agnostic)
+ *
+ * Protocol equality is required for all scopes. Hostname trailing-dot is normalized for all scopes.
  */
 export function isInScope(
   baseUrl: URL,
@@ -33,21 +64,35 @@ export function isInScope(
 ): boolean {
   if (baseUrl.protocol !== targetUrl.protocol) return false;
 
+  const baseHostNoDot = normalizeHost(baseUrl.host, baseUrl.hostname);
+  const targetHostNoDot = normalizeHost(targetUrl.host, targetUrl.hostname);
+
   switch (scope) {
     case "subpages": {
-      if (baseUrl.hostname !== targetUrl.hostname) return false;
+      if (baseHostNoDot !== targetHostNoDot) return false;
       const baseDir = computeBaseDirectory(baseUrl.pathname);
       return targetUrl.pathname.startsWith(baseDir);
     }
     case "hostname":
-      return baseUrl.hostname === targetUrl.hostname;
+      return baseHostNoDot === targetHostNoDot;
     case "domain": {
       return (
-        extractPrimaryDomain(baseUrl.hostname) ===
-        extractPrimaryDomain(targetUrl.hostname)
+        extractPrimaryDomain(stripTrailingDot(baseUrl.hostname)) ===
+        extractPrimaryDomain(stripTrailingDot(targetUrl.hostname))
       );
     }
     default:
       return false;
   }
+}
+
+/**
+ * Strip the trailing dot only from the hostname portion of a `host` string (which may include
+ * a port). Returns the host with the trailing dot removed from the hostname, port preserved.
+ */
+function normalizeHost(host: string, hostname: string): string {
+  const stripped = stripTrailingDot(hostname);
+  if (stripped === hostname) return host;
+  // Replace the leading hostname portion with the stripped version, preserving any ":port" suffix.
+  return host.replace(hostname, stripped);
 }


### PR DESCRIPTION
## Summary

Closes #381. Scraping `scope=subpages` filtered out every discovered link when the start URL responded with a path-changing redirect (e.g. Document360-backed help sites redirect `/foo` → `/foo~7400049439868183793`). The scraper unconditionally adopted the redirected URL as `canonicalBaseUrl`, so the computed base directory drifted away from what the user typed and every child link failed the prefix check.

This change keeps the protocol/host adoption from the original commit `6403325` (preserving http→https and apex↔www redirect handling) but adopts the path **only when the redirected pathname is a descendant of the user-provided pathname**. Siblingwise redirects keep the user's path as the scope anchor and emit a one-shot warning so users can see why discovery looks narrow and resubmit with the redirected URL if they intended the new path.

While auditing the scope code I found four related issues; all are fixed in the same change and the full scope contract is captured in a new `scraping-scope` OpenSpec capability so this doesn't regress silently again.

## What changed

- **Depth-0 redirect handling** ([WebScraperStrategy.ts](src/scraper/strategies/WebScraperStrategy.ts)): adopt protocol+host always; adopt path only when descendant; warn (once per scrape) when siblingwise.
- **`computeBaseDirectory` heuristic** ([scope.ts](src/scraper/utils/scope.ts)): tightened from "any dot in last segment ⇒ file" to `/^index(\.[a-z0-9]+)?$/i` only. Fixes silent over-broad-crawl on `/v1.0`, `/v2.1`, `/foo.html`, `/changelog.md` (these previously fell through to base `/` and scraped the whole hostname). Preserves the deliberate `/api/index.html` behavior and adds extensionless `/api/index` for clean-URL routers.
- **Host comparison**: `subpages`/`hostname` scopes now compare on `URL.host` (incl. port); `domain` continues to use primary-domain extraction (port-agnostic).
- **Hostname trailing dot**: stripped uniformly across all three scopes (`example.com.` ≡ `example.com`).
- **Strategy-layer scope default** ([BaseScraperStrategy.ts](src/scraper/strategies/BaseScraperStrategy.ts)): `shouldProcessUrl` defaults `scope` to `\"subpages\"` when undefined instead of skipping the check entirely. Eliminates the \"programmatic caller with omitted scope gets unrestricted crawl\" footgun.

## OpenSpec change

This work introduces a new `scraping-scope` capability spec (13 requirements, ~50 scenarios) under [openspec/changes/fix-subpages-scope-after-redirect/](openspec/changes/fix-subpages-scope-after-redirect/). The spec pins down every behavior touched here — scope mode semantics, depth-0 redirect rules, base-directory computation with worked examples, protocol/host/port/trailing-dot equality, the start-URL exemption, and filter ordering.

## Behavior changes (four)

These are intentional and surfaced explicitly. Users relying on any of these old behaviors will need to adjust:

1. **Siblingwise redirect**: previously silently followed the redirect into a different subtree (e.g. `/v1` → `/v2/` scraped 400 pages on `/v2/*`). Now scrapes the depth-0 page and logs a warning. Resubmit with the redirected URL if intended.
2. **Version-like / file-like start URLs** (`/v1.0`, `/foo.html`, `/changelog.md`, etc.): previously the dot heuristic over-fired and these accidentally crawled the whole hostname under `subpages` scope. Now they scope narrowly to themselves and their descendants. (Bug fix — old behavior was undocumented.)
3. **Ports**: `subpages` and `hostname` scopes now distinguish ports. `https://x:8443/api` and `https://x:9000/api` are different scopes.
4. **Undefined `scope` at the strategy layer**: previously bypassed filtering entirely. Now defaults to `subpages`. CLI/web/MCP entry points already defaulted to `subpages`, so end-user behavior is unchanged.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check .` — clean (0 errors, 0 warnings)
- [x] `npm run test:unit -- src/scraper/utils/scope.test.ts` — 42/42 pass (file rewritten from 93 → 313 lines with full spec coverage)
- [x] `npm run test:unit -- src/scraper/strategies/WebScraperStrategy.test.ts` — 54/54 pass (scope cluster rewritten as a comprehensive matrix: scope filtering, depth-0 redirect shapes, edge cases, `<base href>` cross-origin)
- [x] `npm run test:unit -- src/scraper/strategies/BaseScraperStrategy.test.ts` — 31/31 pass (pattern-filter tests updated to set `scope: \"hostname\"` so they exercise pattern filtering, not scope)
- [x] Full unit suite: 1509 pass; 74 pre-existing failures in DocumentStore/migrations/HierarchicalAssembly are unrelated to this change (verified by running against `main` with our changes stashed)
- [x] `npx openspec validate fix-subpages-scope-after-redirect --strict` — valid
- [ ] Manual verification against the reporter's URL once merged

## Notes for reviewers

- The redirect target's path is treated by the same `computeBaseDirectory` rule as a user-typed path — there's one mental model now (no scope-specific exceptions). The spec's \"Deeper-descendant redirect\" scenario calls this out explicitly.
- The siblingwise warning uses a per-instance `siblingwiseRedirectWarned` flag. Strategy instances are per-scrape (per `scraper-isolation`), so the flag resets naturally.
- Refresh mode is unaffected — `initialQueue` items pass through the same `shouldProcessUrl` path which now uses the corrected scope base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)