### PR TITLE
fix(scraper): make regex include/exclude patterns work on full URLs

### DIFF
--- a/src/scraper/utils/patternMatcher.test.ts
+++ b/src/scraper/utils/patternMatcher.test.ts
@@ -451,6 +451,46 @@ describe("patternMatcher", () => {
         false,
       );
     });
+
+    it("should match regex patterns anchored on a full URL", () => {
+      // Regression test: previously the matcher prepended `/` to inputs that
+      // didn't start with one, which broke regex patterns anchored with
+      // `^https://` because the URL became `/https://...` before testing.
+      const pythonDocs = [
+        "/^https:\\/\\/docs\\.python\\.org\\/3\\/(library|reference|howto)\\//",
+      ];
+
+      expect(
+        shouldIncludeUrl("https://docs.python.org/3/library/functions.html", pythonDocs),
+      ).toBe(true);
+      expect(
+        shouldIncludeUrl(
+          "https://docs.python.org/3/reference/datamodel.html",
+          pythonDocs,
+        ),
+      ).toBe(true);
+      expect(
+        shouldIncludeUrl("https://docs.python.org/3/howto/regex.html", pythonDocs),
+      ).toBe(true);
+
+      // Other sections on the same host should not match.
+      expect(
+        shouldIncludeUrl("https://docs.python.org/3/tutorial/index.html", pythonDocs),
+      ).toBe(false);
+      // Other hosts should not match.
+      expect(shouldIncludeUrl("https://example.com/3/library/foo.html", pythonDocs)).toBe(
+        false,
+      );
+    });
+
+    it("should support multi-host regex include patterns", () => {
+      // A single regex can allow specific subdomains while excluding others.
+      const patterns = ["/^https:\\/\\/(docs|api)\\.example\\.com\\/v\\d+\\//"];
+
+      expect(shouldIncludeUrl("https://docs.example.com/v1/guide", patterns)).toBe(true);
+      expect(shouldIncludeUrl("https://api.example.com/v2/ref", patterns)).toBe(true);
+      expect(shouldIncludeUrl("https://blog.example.com/v1/post", patterns)).toBe(false);
+    });
   });
 
   describe("full URL vs pathname pattern matching", () => {

--- a/src/scraper/utils/patternMatcher.ts
+++ b/src/scraper/utils/patternMatcher.ts
@@ -37,13 +37,22 @@ export function patternToRegExp(pattern: string): RegExp {
 }
 
 /**
+ * Matches an absolute URL with a scheme (e.g. `https://`, `file://`).
+ * Used to avoid prepending a `/` to inputs that are already full URLs.
+ */
+const URL_WITH_PROTOCOL_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+/**
  * Checks if a given path matches any pattern in the list.
  * For globs, uses minimatch. For regex, uses RegExp.
  */
 export function matchesAnyPattern(path: string, patterns?: string[]): boolean {
   if (!patterns || patterns.length === 0) return false;
-  // Always match from a leading slash for path-based globs
-  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  // Always match from a leading slash for path-based globs, but leave full
+  // URLs (with scheme) untouched so anchored regex patterns like `^https://`
+  // still match.
+  const isFullUrl = URL_WITH_PROTOCOL_RE.test(path);
+  const normalizedPath = isFullUrl || path.startsWith("/") ? path : `/${path}`;
   return patterns.some((pattern) => {
     if (isRegexPattern(pattern)) {
       return patternToRegExp(pattern).test(normalizedPath);


### PR DESCRIPTION
## Summary

- `matchesAnyPattern` unconditionally prepended `/` to inputs that didn't start with one, so a full URL like `https://example.com/foo` became `/https://example.com/foo` before being tested. This broke any regex pattern anchored with `^https://...` — it could never match, and a crawl with such an include pattern would only index the seed page.
- Reported case: indexing `https://docs.python.org/3/` with include pattern `/^https:\/\/docs\.python\.org\/3\/(library|reference|howto)\//` only indexed a single page.

## Fix

Skip the leading-slash prepend when the input already has a URL scheme (matched by `/^[a-z][a-z0-9+.-]*:\/\//i`). Path-only inputs continue to be normalized as before. The glob branch in `matchesAnyPattern` already stripped the leading slash back off, so its behavior is unchanged.

This keeps the documented "patterns match against both full URL and pathname" contract intact and unlocks regex patterns that anchor on a scheme/host — including patterns that allow specific subdomains, e.g. `/^https:\/\/(docs|api)\.example\.com\/v\d+\//`.

## Test plan

- [x] New regression tests in `patternMatcher.test.ts` cover the Python-docs case and a multi-subdomain alternation pattern.
- [x] `npx vitest run src/scraper/utils/patternMatcher.test.ts` — 36 passed.
- [x] `npx vitest run src/scraper` — 648 passed (no regressions).
- [x] `npm run typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)