### PR TITLE
docs(openspec): propose html markdown alternate discovery

### DIFF
--- a/openspec/changes/discover-html-markdown-alternates/.openspec.yaml
+++ b/openspec/changes/discover-html-markdown-alternates/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-18

--- a/openspec/changes/discover-html-markdown-alternates/design.md
+++ b/openspec/changes/discover-html-markdown-alternates/design.md
@@ -1,0 +1,88 @@
+## Context
+
+The current web scraper fetches a URL, selects a content pipeline by MIME type, and sends HTML through `HtmlPipeline`. That pipeline can run Playwright for `scrapeMode=playwright` or `scrapeMode=auto`, then parses the resulting HTML with Cheerio, extracts links and metadata, sanitizes, normalizes, and converts to Markdown.
+
+The llms.txt branch already improves Markdown ingestion by probing `llms.txt`, trying implicit `.md` variants for llms.txt pages, and requesting `Accept: text/markdown`. HTML alternate links are complementary: a page can explicitly advertise a Markdown representation with standard markup such as `<link rel="alternate" type="text/markdown" href="page.md">`.
+
+The important placement constraint is performance. Alternate discovery must happen before expensive HTML processing. If the raw fetched HTML declares a usable Markdown alternate, the scraper should fetch and process that alternate instead of running Playwright or converting the original HTML.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Discover Markdown alternates from raw HTML before Playwright, sanitization, normalization, and HTML-to-Markdown conversion.
+- Treat a validated Markdown alternate as the content representation for the original HTML page.
+- Preserve the original page URL as the crawl/document identity unless the existing store semantics require using the final fetched alternate source.
+- Reuse existing fetcher, redirect handling, scope checks, custom follow-link policy, and outbound access policy.
+- Fall back to normal HTML processing on absent, invalid, blocked, unsupported, or failed alternates.
+
+**Non-Goals:**
+- Discover or process RSS/Atom feeds, PDF alternates, print views, translations, alternate stylesheets, or generic alternate HTML pages.
+- Add user-facing configuration.
+- Change `llms.txt` parsing or probe behavior.
+- Index both the original HTML page and the Markdown alternate as separate documents when the alternate is used as the representation of the page.
+
+## Decisions
+
+### Decision 1: Extract alternates in WebScraperStrategy before pipeline selection
+
+Alternate discovery SHALL happen in the web strategy after the initial fetch returns an HTML response and before selecting `HtmlPipeline`.
+
+**Rationale:** `HtmlPipeline` is intentionally a full HTML processing pipeline and may run Playwright first. If alternate discovery lives inside the existing standard middleware stack, it is too late to avoid the expensive work. Keeping it in the web strategy lets the scraper choose a Markdown response before invoking any HTML pipeline middleware.
+
+**Alternatives considered:**
+- Add a new `HtmlAlternateExtractorMiddleware` before existing HTML middleware: Rejected because middleware is only reached after `HtmlPipeline` selection and, in current ordering, after optional Playwright.
+- Add alternate extraction to `HtmlLinkExtractorMiddleware`: Rejected because it runs after metadata extraction and still cannot replace the fetched content before conversion.
+
+### Decision 2: Use a cheap raw-HTML parser, not browser rendering
+
+The implementation SHOULD parse the raw HTML response body directly with Cheerio or a small utility to inspect `<head>` links. It MUST NOT require Playwright execution to discover alternate links.
+
+**Rationale:** `<link rel="alternate">` is declarative metadata normally present in the document head. Running JavaScript to discover it would erase the primary benefit of this feature. Sites that inject alternates only after client-side rendering will fall back to normal HTML processing.
+
+### Decision 3: Only Markdown typed alternates are eligible
+
+The scraper SHALL consider only alternate links whose `rel` token list includes `alternate`, whose `href` resolves to HTTP(S), and whose `type` attribute is a known Markdown MIME type: `text/markdown`, `text/x-markdown`, `text/mdx`, or `text/x-gfm`.
+
+Links SHALL be ignored when `rel` also includes `stylesheet`, or when `type` indicates RSS, Atom, PDF, HTML, CSS, JavaScript, or any non-Markdown format.
+
+**Rationale:** The HTML `alternate` relationship is broad. It covers feeds, translations, print views, PDFs, stylesheets, and other reformulations. Restricting to explicit Markdown MIME types avoids crawling unrelated alternates and avoids duplicate HTML pages.
+
+**Alternative considered:** Infer Markdown from `.md` path when `type` is missing. Rejected initially because this broadens behavior beyond the standard signal and can misclassify ordinary links. The existing llms.txt `.md` preference already covers its specific convention.
+
+### Decision 4: Validate fetched alternate content before using it
+
+The `type` attribute is advisory. After fetching an alternate, the scraper SHALL use it only if the actual response status is success and the response MIME type is Markdown. The implementation MAY accept `text/plain` only if it applies the same conservative Markdown heuristic already used elsewhere, or if a future requirement explicitly allows it.
+
+If validation fails, the scraper SHALL fall back to the original HTML response and process it normally.
+
+**Rationale:** Servers can misconfigure `type`, redirects can land on HTML error pages, and stale alternates can return non-Markdown content. Response validation keeps the behavior safe and reversible.
+
+### Decision 5: Alternate URLs are representations, not independent crawl links
+
+When a Markdown alternate is accepted, it represents the original page for indexing. The scraper SHOULD avoid enqueueing or storing both the original HTML URL and the alternate URL as separate pages solely because of the alternate relation.
+
+Links extracted from the accepted Markdown content SHALL continue through normal link filtering and crawling.
+
+**Rationale:** Treating the alternate as just another link creates duplicate content and pollutes search results. The relationship says the resources are alternate representations of the same document, not two separate docs to index.
+
+### Decision 6: Preserve existing policy boundaries
+
+Alternate href resolution SHALL respect `<base href>` using the same cautious base handling as HTML link extraction where practical. Resolved alternate URLs SHALL pass existing scope checks, optional custom follow-link policy, and outbound access policy before use.
+
+**Rationale:** Alternate discovery must not become a bypass for subpage scope, include/exclude patterns, private-network blocking, host/CIDR allowlists, TLS policy, redirect validation, or caller-provided link restrictions.
+
+### Decision 7: Ordering with llms.txt Markdown URL preference
+
+For pages marked as discovered from llms.txt, the implicit `.md` variant preference remains the first attempt. If that attempt fails and the original URL fetch returns HTML, HTML Markdown alternate discovery MAY then run before normal HTML processing.
+
+For pages not discovered from llms.txt, the scraper fetches the original URL with Markdown-preferred `Accept`; if the server returns HTML, HTML Markdown alternate discovery runs before normal HTML processing.
+
+**Rationale:** The llms.txt change already defines a specific `.md` convention for llms-discovered pages. Explicit HTML alternates should complement, not replace, that behavior.
+
+## Risks / Trade-offs
+
+- **Extra HTTP request for pages with candidate alternates** -> Only fetch alternates when an explicit Markdown-typed alternate is present. Pages without candidates pay only cheap parsing cost.
+- **False positives from incorrect `type` attributes** -> Validate the actual response MIME type before using the alternate.
+- **Missed alternates injected by JavaScript** -> Accept this trade-off to avoid Playwright. Those pages continue through normal HTML processing.
+- **Ambiguous document source identity** -> Prefer indexing the alternate content as the original page representation to avoid duplicates; tests should pin the chosen store behavior.
+- **Interaction with `<base href>` edge cases** -> Reuse the existing cautious base resolution pattern from HTML link extraction where possible.

--- a/openspec/changes/discover-html-markdown-alternates/proposal.md
+++ b/openspec/changes/discover-html-markdown-alternates/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Some documentation sites advertise clean Markdown versions of HTML pages with standard HTML alternate links, such as `<link rel="alternate" type="text/markdown" href="page.md">`. The scraper should prefer those explicitly declared Markdown representations early enough to avoid expensive HTML processing, including Playwright rendering, when a trusted Markdown alternate is available.
+
+## What Changes
+
+- Add discovery for Markdown alternate representations declared by HTML `<link rel="alternate">` elements.
+- Prefer a validated Markdown alternate over HTML-to-Markdown conversion for the same page.
+- Run alternate discovery before expensive HTML processing steps such as Playwright, sanitization, normalization, and HTML-to-Markdown conversion.
+- Preserve graceful fallback: if no acceptable alternate is declared, fetchable, or validated as Markdown, process the original HTML normally.
+- Reuse existing scope checks, caller-provided follow-link policy, fetcher path, and outbound access policy for alternate URLs.
+- Avoid indexing both the HTML page and its Markdown alternate as separate duplicate documents when the alternate is used as the representation of the original page.
+
+## Capabilities
+
+### New Capabilities
+
+- `html-markdown-alternates`: Discovers and uses explicitly advertised Markdown alternate representations for HTML pages before expensive HTML processing.
+
+### Modified Capabilities
+
+<!-- None. -->
+
+## Impact
+
+- Affected code:
+  - `src/scraper/strategies/WebScraperStrategy.ts` or adjacent web scrape orchestration for early alternate selection.
+  - `src/scraper/middleware/` or `src/scraper/utils/` for extracting Markdown alternate links from raw HTML.
+  - `src/scraper/pipelines/HtmlPipeline.ts` only if a small pre-render parsing stage is introduced there; the preferred design should avoid running the full HTML pipeline before alternate selection.
+  - `src/scraper/fetcher/` only if additional response metadata or fetch behavior is needed.
+  - Tests covering alternate extraction, early fallback behavior, scope/access-policy enforcement, and duplicate avoidance.
+- No new user-facing configuration is required.
+- No database schema changes are required.

--- a/openspec/changes/discover-html-markdown-alternates/specs/html-markdown-alternates/spec.md
+++ b/openspec/changes/discover-html-markdown-alternates/specs/html-markdown-alternates/spec.md
@@ -1,0 +1,112 @@
+## ADDED Requirements
+
+### Requirement: Early Markdown alternate discovery
+
+The web scraper SHALL inspect successful HTML responses for Markdown alternate links before running Playwright, HTML sanitization, HTML normalization, or HTML-to-Markdown conversion. The inspection SHALL operate on the raw fetched HTML response and SHALL NOT require JavaScript execution. If no eligible Markdown alternate is found, the scraper SHALL continue with the existing HTML processing pipeline.
+
+#### Scenario: Markdown alternate avoids Playwright
+- **WHEN** a web scrape fetches an HTML page while `scrapeMode` is `playwright` or `auto`
+- **AND** the raw HTML contains an eligible Markdown alternate link
+- **AND** the alternate fetch succeeds and validates as Markdown
+- **THEN** the system SHALL process the Markdown alternate content through the Markdown pipeline
+- **AND** the system SHALL NOT run Playwright for the original HTML page
+- **AND** the system SHALL NOT run HTML-to-Markdown conversion for the original HTML page
+
+#### Scenario: No eligible alternate uses existing HTML pipeline
+- **WHEN** a web scrape fetches an HTML page
+- **AND** the raw HTML does not contain an eligible Markdown alternate link
+- **THEN** the system SHALL process the original HTML response through the existing HTML pipeline
+
+### Requirement: Eligible alternate link selection
+
+The scraper SHALL consider only `<link>` elements whose `rel` token list contains `alternate`, whose `href` resolves to an HTTP(S) URL, and whose `type` attribute is a known Markdown MIME type: `text/markdown`, `text/x-markdown`, `text/mdx`, or `text/x-gfm`. The scraper SHALL ignore alternate links with missing or non-Markdown `type` values, including RSS, Atom, PDF, HTML, CSS, JavaScript, and generic binary formats. The scraper SHALL ignore links whose `rel` token list also contains `stylesheet`.
+
+#### Scenario: Markdown alternate selected
+- **WHEN** raw HTML contains `<link rel="alternate" type="text/markdown" href="guide.md">`
+- **THEN** the system SHALL treat `guide.md` as an eligible Markdown alternate candidate after resolving it against the page URL
+
+#### Scenario: Alternate stylesheet ignored
+- **WHEN** raw HTML contains `<link rel="alternate stylesheet" href="contrast.css" title="High contrast">`
+- **THEN** the system SHALL NOT treat the link as a Markdown alternate candidate
+
+#### Scenario: Feed alternate ignored
+- **WHEN** raw HTML contains `<link rel="alternate" type="application/atom+xml" href="feed.xml">`
+- **THEN** the system SHALL NOT treat the link as a Markdown alternate candidate
+
+#### Scenario: Untyped alternate ignored
+- **WHEN** raw HTML contains `<link rel="alternate" href="guide.md">`
+- **THEN** the system SHALL NOT treat the link as a Markdown alternate candidate
+
+### Requirement: Markdown alternate validation and fallback
+
+The scraper SHALL fetch eligible Markdown alternate candidates with the existing fetcher path and SHALL use an alternate only when the fetch succeeds and the actual response MIME type is Markdown. The scraper SHALL treat the alternate link's `type` attribute as advisory and SHALL validate the fetched response MIME type before replacing the original HTML response. If the alternate fetch fails, is blocked, returns a non-success status, redirects to a disallowed URL, or returns a non-Markdown MIME type, the scraper SHALL fall back to processing the original HTML response normally.
+
+#### Scenario: Valid alternate replaces original HTML processing
+- **WHEN** an HTML page declares an eligible Markdown alternate
+- **AND** fetching the alternate returns success with `Content-Type: text/markdown`
+- **THEN** the system SHALL process the alternate response as Markdown content
+- **AND** the system SHALL skip normal HTML processing for the original HTML response
+
+#### Scenario: Misconfigured alternate falls back to HTML
+- **WHEN** an HTML page declares an eligible Markdown alternate
+- **AND** fetching the alternate returns success with `Content-Type: text/html`
+- **THEN** the system SHALL reject the alternate response
+- **AND** the system SHALL process the original HTML response normally
+
+#### Scenario: Missing alternate falls back to HTML
+- **WHEN** an HTML page declares an eligible Markdown alternate
+- **AND** fetching the alternate returns not found or another non-success status
+- **THEN** the system SHALL process the original HTML response normally
+
+### Requirement: Policy enforcement for alternate URLs
+
+The scraper SHALL resolve Markdown alternate `href` values against the effective HTML document URL, using the document `<base href>` when it is valid according to the same cautious base-resolution rules used for HTML link extraction. Resolved alternate URLs SHALL pass existing scope checks, include/exclude pattern checks, optional custom follow-link policy, and outbound access policy before use. The scraper SHALL NOT fetch or process an alternate URL that is out of scope, blocked by include/exclude patterns, rejected by a custom follow-link policy, blocked by network security policy, or resolved to a non-HTTP(S) scheme.
+
+#### Scenario: Relative alternate resolved against page URL
+- **WHEN** the fetched HTML page source is `https://docs.example.com/docs/guide.html`
+- **AND** raw HTML contains `<link rel="alternate" type="text/markdown" href="guide.md">`
+- **THEN** the system SHALL resolve the alternate candidate to `https://docs.example.com/docs/guide.md`
+
+#### Scenario: Out-of-scope alternate ignored
+- **WHEN** the user scrapes `https://docs.example.com/docs/guide.html` with default subpages scope
+- **AND** raw HTML contains `<link rel="alternate" type="text/markdown" href="https://docs.example.com/blog/guide.md">`
+- **THEN** the system SHALL NOT fetch the alternate URL
+- **AND** the system SHALL process the original HTML response normally
+
+#### Scenario: Access-policy blocked alternate ignored
+- **WHEN** raw HTML contains an eligible Markdown alternate URL
+- **AND** the outbound access policy blocks the alternate URL or one of its redirects
+- **THEN** the system SHALL NOT bypass the configured access policy
+- **AND** the system SHALL process the original HTML response normally
+
+### Requirement: Alternate representation avoids duplicate indexing
+
+When a Markdown alternate is accepted, the scraper SHALL treat the alternate as the content representation of the original HTML page rather than as an additional independent crawl target. The scraper SHALL avoid indexing both the original HTML page and the accepted Markdown alternate as separate documents solely because of the alternate relationship. Links extracted from the accepted Markdown content SHALL continue through normal link filtering and crawling.
+
+#### Scenario: Accepted alternate indexes one document
+- **WHEN** an HTML page declares an eligible Markdown alternate
+- **AND** the alternate is fetched and accepted
+- **THEN** the system SHALL store one processed document for the page representation
+- **AND** the system SHALL NOT also store the original HTML conversion as a second duplicate document
+
+#### Scenario: Markdown alternate links continue crawling
+- **WHEN** an accepted Markdown alternate contains links to additional in-scope documentation pages
+- **THEN** the system SHALL extract those links through the Markdown pipeline
+- **AND** the system SHALL apply the normal crawl filtering rules before queueing them
+
+### Requirement: Ordering with llms.txt Markdown preference
+
+For queue items discovered from llms.txt, the scraper SHALL preserve the existing implicit `.md` variant preference before using HTML Markdown alternate discovery. If the implicit `.md` variant fails and the original URL response is HTML, the scraper SHALL then apply HTML Markdown alternate discovery before normal HTML processing. For queue items not discovered from llms.txt, the scraper SHALL fetch the original URL with the existing Markdown-preferred `Accept` behavior and apply HTML Markdown alternate discovery only when the response is HTML.
+
+#### Scenario: llms.txt .md variant wins before HTML alternate
+- **WHEN** a queue item is marked as discovered from llms.txt
+- **AND** the implicit `.md` variant fetch succeeds and validates as Markdown
+- **THEN** the system SHALL process the implicit `.md` variant
+- **AND** the system SHALL NOT fetch the original HTML page solely to inspect its alternate links
+
+#### Scenario: llms.txt fallback can use HTML alternate
+- **WHEN** a queue item is marked as discovered from llms.txt
+- **AND** the implicit `.md` variant fetch fails
+- **AND** the original URL response is HTML with an eligible Markdown alternate
+- **AND** the alternate fetch succeeds and validates as Markdown
+- **THEN** the system SHALL process the declared Markdown alternate before normal HTML processing

--- a/openspec/changes/discover-html-markdown-alternates/tasks.md
+++ b/openspec/changes/discover-html-markdown-alternates/tasks.md
@@ -1,0 +1,34 @@
+## 1. Alternate Extraction Utility
+
+- [ ] 1.1 Add a focused HTML Markdown alternate extractor that parses raw HTML without Playwright and returns resolved candidate URLs for `<link rel="alternate">` elements with Markdown MIME `type` values.
+- [ ] 1.2 Reuse or mirror the existing cautious `<base href>` resolution behavior from HTML link extraction for resolving alternate `href` values.
+- [ ] 1.3 Add unit tests for eligible Markdown alternates, multiple `rel` tokens, relative URLs, `<base href>`, alternate stylesheets, feeds, PDFs, HTML alternates, missing `type`, invalid `href`, and non-HTTP(S) URLs.
+
+## 2. Early Web Scraper Integration
+
+- [ ] 2.1 Integrate alternate discovery in `WebScraperStrategy` after a successful HTML fetch and before selecting/running `HtmlPipeline`.
+- [ ] 2.2 Fetch eligible alternate candidates with the existing fetcher path and existing request options so redirects, caller headers, cancellation, and outbound access policy continue to apply.
+- [ ] 2.3 Validate alternate responses by actual status and MIME type before replacing the original HTML response with the Markdown response.
+- [ ] 2.4 Fall back to the original HTML response on missing candidates, policy rejection, fetch errors, non-success status, redirects to blocked targets, or non-Markdown response MIME types.
+- [ ] 2.5 Ensure accepted alternates skip Playwright, HTML sanitization, HTML normalization, and HTML-to-Markdown conversion for the original HTML page.
+
+## 3. Scope, Deduplication, and Ordering
+
+- [ ] 3.1 Apply existing scope checks, include/exclude pattern checks, and optional custom follow-link policy before fetching a resolved alternate URL.
+- [ ] 3.2 Treat an accepted alternate as the representation of the original page and avoid enqueueing or indexing both resources solely because of the alternate relationship.
+- [ ] 3.3 Preserve existing llms.txt ordering: implicit `.md` variant first for `fromLlmsTxt` pages, then original HTML alternate discovery only if the implicit variant fails and the original response is HTML.
+- [ ] 3.4 Preserve existing Markdown content negotiation behavior for all web requests.
+
+## 4. Integration Tests
+
+- [ ] 4.1 Add web scraper tests proving a valid Markdown alternate is processed through the Markdown pipeline and Playwright/HTML conversion are skipped.
+- [ ] 4.2 Add fallback tests for no alternate, unsupported alternate types, failed alternate fetch, non-Markdown alternate response, out-of-scope alternate, custom follow-link rejection, and access-policy rejection.
+- [ ] 4.3 Add tests proving accepted alternates do not create duplicate indexed documents and that links from accepted Markdown content continue normal crawl filtering.
+- [ ] 4.4 Add tests for ordering with llms.txt `.md` preference success and fallback to HTML alternate discovery.
+
+## 5. Documentation and Validation
+
+- [ ] 5.1 Update README or architecture documentation if the early alternate discovery path materially changes the documented Markdown-optimized web scraping behavior.
+- [ ] 5.2 Run `npm run lint` and `npm run typecheck`.
+- [ ] 5.3 Run targeted scraper tests, including `src/scraper/strategies/WebScraperStrategy.test.ts` and any new alternate extractor tests.
+- [ ] 5.4 Run broader tests if changes touch shared pipeline or fetcher behavior.


### PR DESCRIPTION
## Summary
- add an OpenSpec change for discovering Markdown alternates from HTML rel=alternate links
- specify early raw-HTML discovery before Playwright and HTML conversion
- define validation, policy, deduplication, and llms.txt ordering requirements

## Validation
- npx openspec validate "discover-html-markdown-alternates" --strict