### PR TITLE
Fix advertised server origin handling

### DIFF
--- a/docs/infrastructure/authentication.md
+++ b/docs/infrastructure/authentication.md
@@ -98,6 +98,7 @@ npx docs-mcp-server
   --auth-enabled
   --auth-issuer-url "https://auth.your-domain.com"
   --auth-audience "https://mcp.your-domain.com"
+  --public-origin "https://mcp.your-domain.com"
 ```
 
 ### Environment Variables
@@ -111,6 +112,8 @@ export DOCS_MCP_AUTH_AUDIENCE="https://mcp.your-domain.com"
 
 You can also set the same values in `docs-mcp.config.yaml` under `auth.enabled`, `auth.issuerUrl`, and `auth.audience`.
 
+For remote or reverse-proxy deployments, set `server.publicOrigin` (or pass `--public-origin`) to the externally reachable origin clients use. `--host` only controls the local bind interface; OAuth metadata and resource URLs use the public origin when configured.
+
 ### Configuration Options
 
 | Option      | CLI Flag            | Environment Variable       | Description                                             |
@@ -118,6 +121,7 @@ You can also set the same values in `docs-mcp.config.yaml` under `auth.enabled`,
 | Enable Auth | `--auth-enabled`    | `DOCS_MCP_AUTH_ENABLED`    | Enable OAuth2 token validation                          |
 | Issuer URL  | `--auth-issuer-url` | `DOCS_MCP_AUTH_ISSUER_URL` | OAuth2 discovery endpoint of your external provider     |
 | Audience    | `--auth-audience`   | `DOCS_MCP_AUTH_AUDIENCE`   | JWT audience claim (identifies this protected resource) |
+| Public Origin | `--public-origin` | `DOCS_MCP_SERVER_PUBLIC_ORIGIN` | Externally reachable server origin advertised in OAuth metadata |
 
 ## OAuth2 Setup
 

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -114,6 +114,7 @@ Common settings have dedicated CLI flags:
 
 ```bash
 docs-mcp-server --port 8080 --host 0.0.0.0
+docs-mcp-server --host 0.0.0.0 --public-origin https://docs.example.com
 docs-mcp-server --store-path /data/docs --read-only
 ```
 
@@ -165,7 +166,8 @@ Settings for the API and MCP servers.
 | Option | Default | Description |
 |:-------|:--------|:------------|
 | `protocol` | `auto` | Server protocol (`stdio`, `http`, or `auto`). |
-| `host` | `127.0.0.1` | Host interface to bind to. |
+| `host` | `127.0.0.1` | Host interface to bind to. Use `0.0.0.0` to listen on all IPv4 interfaces. |
+| `publicOrigin` | - | Externally reachable origin advertised to clients, such as `https://docs.example.com`. Set this when the bind host is not the URL clients should use. |
 | `heartbeatMs` | `30000` | MCP protocol heartbeat interval (ms). |
 | `ports.default` | `6280` | Default port for the main server. |
 | `ports.worker` | `8080` | Port for the background worker service. |

--- a/openspec/changes/correct-host-origin-urls/.openspec.yaml
+++ b/openspec/changes/correct-host-origin-urls/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-06

--- a/openspec/changes/correct-host-origin-urls/design.md
+++ b/openspec/changes/correct-host-origin-urls/design.md
@@ -1,0 +1,76 @@
+## Context
+
+`--host` currently reaches `appConfig.server.host` and is passed to Fastify's `listen` call, so the server binds to the requested interface. The startup banner, however, logs the address string returned by Fastify, which can normalize wildcard binds such as `0.0.0.0` to a loopback URL. Separately, auth metadata registration constructs its base URL from `http://localhost:${port}`, so auth-enabled deployments can advertise localhost endpoints even when the server is intentionally exposed on another host.
+
+The implementation already treats auth metadata origins as trusted configuration rather than request-derived values to avoid Host header spoofing. The new design keeps that security boundary while making the configured origin explicit.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Preserve `server.host` / `--host` as the bind-interface setting used by Fastify.
+- Display startup endpoint URLs that match the configured bind host when no public origin is configured.
+- Add a canonical public origin setting for externally advertised URLs, especially OAuth authorization-server and protected-resource metadata.
+- Ensure generated URLs are absolute, valid, and IPv6-safe.
+- Add regression coverage for bind-host display and auth metadata origin generation.
+
+**Non-Goals:**
+- Do not infer public origins from request `Host`, `Forwarded`, or `X-Forwarded-*` headers.
+- Do not change the MCP transport endpoints or introduce new auth flows.
+- Do not make `0.0.0.0` a recommended public client URL; it remains a bind address and only becomes the fallback display origin when no public origin is configured.
+- Do not change token audience validation semantics beyond using the canonical origin for generated OAuth resource and endpoint URLs.
+
+## Decisions
+
+### Decision: Separate bind host from public origin
+
+Add an optional `server.publicOrigin` configuration value. `server.host` continues to control binding. `server.publicOrigin`, when set, controls externally advertised absolute URLs.
+
+Alternatives considered:
+- Reuse `server.host` for all generated URLs. This fixes the issue report but fails for reverse-proxy and TLS deployments where the bind host differs from the client-facing origin.
+- Use `auth.audience` as the public origin. Audience identifies the expected token audience and may not be the same string as the HTTP origin or transport-specific resource URL.
+- Trust request headers. This would make metadata convenient behind proxies but conflicts with the existing security model and can reintroduce Host header spoofing risks.
+
+### Decision: Centralize URL origin formatting
+
+Introduce a shared helper for deriving URL-safe origins from either `server.publicOrigin` or `{ protocol: "http", host, port }`. The helper should bracket IPv6 literals, omit default ports only if an existing URL parser naturally does so, and normalize configured public origins by removing a trailing slash.
+
+Alternatives considered:
+- Format URLs inline at each call site. That risks repeating the same host/IPv6/port edge cases and recreating drift between logs and metadata.
+- Continue using Fastify's returned listen address. That describes what Fastify reports, not necessarily what operators configured or what clients should use.
+
+### Decision: Use public origin for auth metadata and startup URLs when present
+
+When `server.publicOrigin` is configured, startup diagnostics and OAuth metadata should use it. When it is absent, startup diagnostics use the bind-derived origin, and OAuth metadata falls back to the same bind-derived origin instead of hard-coded localhost.
+
+Alternatives considered:
+- Always display bind origin in startup logs and use public origin only in auth metadata. That makes it harder for operators to copy the correct MCP endpoint in proxy deployments.
+- Require public origin whenever auth is enabled. That is safer for production but would be a breaking change for local auth testing.
+
+### Decision: Warn for auth plus wildcard bind without public origin
+
+If auth is enabled, no public origin is configured, and the bind host is wildcard (`0.0.0.0`, `::`, or equivalent), emit a warning that the fallback origin is a bind address and may not be usable by remote clients.
+
+Alternatives considered:
+- Fail startup. This would prevent ambiguous production deployments but could break current local workflows.
+- Stay silent. That leaves a known footgun unaddressed after introducing the public-origin concept.
+
+## Risks / Trade-offs
+
+- [Risk] Operators may expect `--host 0.0.0.0` to be a public client URL. -> Mitigation: preserve the requested display behavior while documenting that `server.publicOrigin` is the correct external URL for clients.
+- [Risk] Adding a new config key increases CLI/config surface area. -> Mitigation: keep it optional, use existing config precedence patterns, and validate it as a simple absolute origin.
+- [Risk] Auth deployments behind proxies may still need HTTPS origins while the app listens over HTTP locally. -> Mitigation: `server.publicOrigin` accepts `https://...` even though the local bind uses HTTP.
+- [Risk] Changing generated OAuth metadata can affect existing auth setups that accidentally depended on localhost. -> Mitigation: fallback remains local/bind-derived when no public origin is set, and tests cover the new deterministic behavior.
+
+## Migration Plan
+
+1. Add `server.publicOrigin` to defaults, schema, env mappings, config CLI support, and relevant server commands.
+2. Add shared origin formatting helpers and replace direct uses of Fastify listen address / hard-coded auth base URL.
+3. Update startup logging and auth metadata registration to use the shared origin selection.
+4. Add unit coverage for configuration, origin formatting, startup logs, and auth metadata registration.
+5. Update deployment and authentication docs to explain bind host versus public origin, with a concise note in `docs/infrastructure/authentication.md` for auth-enabled remote or reverse-proxy deployments.
+
+Rollback is straightforward: unset `server.publicOrigin` to return to bind-derived URL generation, or revert the change if unexpected metadata behavior appears.
+
+## Open Questions
+
+- Resolved: `--public-origin` is available on long-running HTTP server commands only, matching where `--host` is useful and avoiding irrelevant flags on one-shot commands.

--- a/openspec/changes/correct-host-origin-urls/proposal.md
+++ b/openspec/changes/correct-host-origin-urls/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Startup endpoint URLs and OAuth discovery metadata can disagree with the host/origin that operators intend clients to use. This causes confusion for ordinary `--host` usage and can break auth-enabled remote deployments when metadata advertises `localhost`.
+
+## What Changes
+
+- Generate human-facing startup endpoint URLs from the configured bind host and selected service port instead of relying on Fastify's normalized listen address.
+- Introduce an explicit public server origin for externally advertised URLs, so auth metadata can use a client-reachable origin instead of a bind address.
+- Use one shared origin-building path for startup display and server-generated endpoint metadata, including IPv6-safe URL formatting.
+- Preserve existing bind behavior: `--host` continues to control the network interface the server listens on.
+- Document and validate the difference between bind host values such as `0.0.0.0` and externally reachable public origins.
+
+## Capabilities
+
+### New Capabilities
+- `server-origin-urls`: Defines how the server derives and uses bind-host, display, and public origins for generated endpoint URLs and metadata.
+
+### Modified Capabilities
+- `cli-output`: Startup diagnostics must display endpoint URLs that reflect configured host/origin behavior.
+- `configuration`: Server configuration must expose and validate the public origin used for externally advertised URLs.
+
+## Impact
+
+- Affected code: `src/app/AppServer.ts`, configuration schema/loading in `src/utils/config.ts`, CLI option/env mappings, and auth metadata registration.
+- Affected tests: AppServer startup logging, auth metadata route registration, configuration precedence/validation, and relevant CLI/E2E coverage.
+- Affected docs: server configuration docs and auth/deployment guidance explaining bind host versus public origin.
+- No dependency changes expected.

--- a/openspec/changes/correct-host-origin-urls/specs/cli-output/spec.md
+++ b/openspec/changes/correct-host-origin-urls/specs/cli-output/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Display canonical startup endpoint URLs
+Long-running server commands SHALL display startup endpoint URLs using the canonical origin selected for generated server URLs.
+
+#### Scenario: Startup output reflects configured bind host
+- **WHEN** the default server starts with `--host 0.0.0.0 --port 6280`
+- **AND** no public origin is configured
+- **THEN** the startup diagnostics MUST display the web interface URL as `http://0.0.0.0:6280`
+- **AND** the startup diagnostics MUST display MCP endpoint URLs under `http://0.0.0.0:6280`
+- **AND** the startup diagnostics MUST NOT display `http://127.0.0.1:6280` or `http://localhost:6280`
+
+#### Scenario: Startup output prefers public origin
+- **WHEN** the server starts with `--host 0.0.0.0`
+- **AND** `server.publicOrigin` is configured as `https://docs.example.com`
+- **THEN** the startup diagnostics MUST display web and MCP endpoint URLs under `https://docs.example.com`
+
+#### Scenario: Startup output remains logger-controlled
+- **WHEN** startup endpoint URLs are emitted
+- **THEN** they MUST be emitted through the shared logger
+- **AND** existing quiet and verbose logging controls MUST continue to apply

--- a/openspec/changes/correct-host-origin-urls/specs/configuration/spec.md
+++ b/openspec/changes/correct-host-origin-urls/specs/configuration/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Server Public Origin Configuration
+The configuration system SHALL expose an optional `server.publicOrigin` setting that defines the absolute HTTP(S) origin used for externally advertised server URLs.
+
+#### Scenario: Public origin absent by default
+- **WHEN** no public origin is configured
+- **THEN** the loaded configuration MUST leave `server.publicOrigin` unset
+- **AND** generated URLs MUST use the bind-derived origin fallback
+
+#### Scenario: Public origin from config file
+- **WHEN** a configuration file sets `server.publicOrigin` to `https://docs.example.com`
+- **THEN** the loaded configuration MUST set `server.publicOrigin` to `https://docs.example.com`
+
+#### Scenario: Public origin from environment variable
+- **WHEN** the environment variable `DOCS_MCP_SERVER_PUBLIC_ORIGIN` is set to `https://docs.example.com`
+- **THEN** the loaded configuration MUST set `server.publicOrigin` to `https://docs.example.com`
+
+#### Scenario: Public origin from CLI flag
+- **WHEN** a long-running server command is invoked with `--public-origin https://docs.example.com`
+- **THEN** the loaded configuration MUST set `server.publicOrigin` to `https://docs.example.com`
+- **AND** the CLI value MUST take precedence over environment and config file values
+
+#### Scenario: Public origin must be an origin
+- **WHEN** `server.publicOrigin` is configured with a path, query string, fragment, or unsupported protocol
+- **THEN** configuration loading MUST reject the value with a clear validation error
+
+#### Scenario: Trailing slash is normalized
+- **WHEN** `server.publicOrigin` is configured as `https://docs.example.com/`
+- **THEN** the loaded configuration or URL-generation path MUST use `https://docs.example.com` as the canonical origin

--- a/openspec/changes/correct-host-origin-urls/specs/server-origin-urls/spec.md
+++ b/openspec/changes/correct-host-origin-urls/specs/server-origin-urls/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Distinguish bind host from advertised origin
+The server SHALL treat the configured bind host as the network interface used for listening and SHALL treat the configured public origin as the canonical origin for externally advertised absolute URLs when that public origin is present.
+
+#### Scenario: Bind host controls listener
+- **WHEN** the server starts with `server.host` set to `0.0.0.0`
+- **THEN** the HTTP listener MUST bind with host `0.0.0.0`
+- **AND** the bind host MUST NOT be replaced by `localhost` or `127.0.0.1` before calling the HTTP server listen API
+
+#### Scenario: Public origin controls advertised URLs
+- **WHEN** `server.publicOrigin` is set to `https://docs.example.com`
+- **THEN** generated externally advertised endpoint URLs MUST use `https://docs.example.com`
+- **AND** the generated externally advertised endpoint URLs MUST NOT use the bind host unless the public origin is absent
+
+#### Scenario: Bind-derived origin fallback
+- **WHEN** `server.publicOrigin` is not set
+- **AND** the server binds to host `0.0.0.0` on port `6280`
+- **THEN** generated fallback endpoint URLs MUST use `http://0.0.0.0:6280`
+- **AND** they MUST NOT fall back to hard-coded `localhost` or `127.0.0.1`
+
+#### Scenario: IPv6 bind host formatting
+- **WHEN** `server.publicOrigin` is not set
+- **AND** the server binds to IPv6 host `::` on port `6280`
+- **THEN** generated fallback endpoint URLs MUST use bracketed IPv6 host formatting such as `http://[::]:6280`
+
+### Requirement: Generate OAuth metadata from the canonical origin
+When authentication is enabled, OAuth authorization-server metadata, protected-resource metadata, advertised MCP transport URLs, and proxied OAuth resource parameters SHALL be generated from the canonical server origin.
+
+#### Scenario: OAuth metadata uses public origin
+- **WHEN** authentication is enabled
+- **AND** `server.publicOrigin` is set to `https://docs.example.com`
+- **THEN** `/.well-known/oauth-authorization-server` MUST advertise OAuth endpoints under `https://docs.example.com`
+- **AND** `/.well-known/oauth-protected-resource` MUST advertise MCP transport endpoints under `https://docs.example.com`
+
+#### Scenario: OAuth metadata falls back to bind origin
+- **WHEN** authentication is enabled
+- **AND** `server.publicOrigin` is not set
+- **AND** the server binds to host `0.0.0.0` on port `6280`
+- **THEN** OAuth metadata MUST use `http://0.0.0.0:6280` as its fallback origin
+- **AND** OAuth metadata MUST NOT use hard-coded `http://localhost:6280`
+
+#### Scenario: OAuth resource parameter uses canonical origin
+- **WHEN** authentication is enabled
+- **AND** an OAuth authorization or token request is proxied upstream
+- **THEN** the forced OAuth `resource` parameter MUST be derived from the canonical server origin
+- **AND** it MUST remain consistent with the protected-resource metadata resource URL
+
+#### Scenario: Metadata does not trust request host
+- **WHEN** a request for OAuth metadata includes a spoofed `Host` header
+- **THEN** generated OAuth metadata MUST continue to use the configured canonical origin
+- **AND** it MUST NOT use the spoofed request host
+
+### Requirement: Warn on ambiguous auth wildcard origins
+The server SHALL warn operators when auth metadata must fall back to a wildcard bind origin that is unlikely to be directly usable by remote OAuth clients.
+
+#### Scenario: Auth enabled with wildcard bind and no public origin
+- **WHEN** authentication is enabled
+- **AND** `server.publicOrigin` is not set
+- **AND** `server.host` is a wildcard bind address such as `0.0.0.0` or `::`
+- **THEN** startup diagnostics MUST include a warning that a public origin should be configured for remote clients
+
+#### Scenario: Auth enabled with public origin suppresses warning
+- **WHEN** authentication is enabled
+- **AND** `server.publicOrigin` is set
+- **THEN** startup diagnostics MUST NOT emit the wildcard bind-origin warning

--- a/openspec/changes/correct-host-origin-urls/tasks.md
+++ b/openspec/changes/correct-host-origin-urls/tasks.md
@@ -1,0 +1,31 @@
+## 1. Configuration
+
+- [x] 1.1 Add optional `server.publicOrigin` to the default config shape, Zod schema, typed `AppConfig`, and config serialization path.
+- [x] 1.2 Add environment and CLI override support for `server.publicOrigin`, including `DOCS_MCP_SERVER_PUBLIC_ORIGIN` and `--public-origin` on long-running server commands.
+- [x] 1.3 Validate `server.publicOrigin` as an absolute `http` or `https` origin with no path, query, or fragment, and normalize a trailing slash.
+- [x] 1.4 Add configuration tests for default absence, config-file loading, environment override, CLI precedence, invalid values, and trailing-slash normalization.
+
+## 2. Origin Derivation
+
+- [x] 2.1 Add a shared helper that derives a canonical origin from `server.publicOrigin` when present or from bind `host` plus selected `port` otherwise.
+- [x] 2.2 Ensure the helper formats IPv4, hostnames, and IPv6 literals into valid URL origins.
+- [x] 2.3 Add unit tests for public-origin preference, bind-derived fallback, wildcard bind hosts, and IPv6 bracket formatting.
+
+## 3. Server Integration
+
+- [x] 3.1 Update `AppServer.start()` and startup logging to use the canonical origin instead of Fastify's returned listen address for displayed endpoint URLs.
+- [x] 3.2 Update OAuth route registration to pass the canonical origin into `ProxyAuthManager.registerRoutes()` instead of hard-coded `http://localhost:<port>`.
+- [x] 3.3 Emit a warning when auth is enabled, no public origin is configured, and the bind host is a wildcard address.
+- [x] 3.4 Preserve existing Fastify binding behavior so `server.host` continues to be passed unchanged to `listen()`.
+
+## 4. Documentation
+
+- [x] 4.1 Update configuration documentation to describe `server.host` as the bind interface and `server.publicOrigin` as the externally advertised origin.
+- [x] 4.2 Update `docs/infrastructure/authentication.md` to briefly mention `server.publicOrigin` / `--public-origin` for auth-enabled remote or reverse-proxy deployments.
+
+## 5. Validation
+
+- [x] 5.1 Add AppServer tests proving startup URLs show `0.0.0.0` when `--host 0.0.0.0` is used without a public origin.
+- [x] 5.2 Add AppServer or auth tests proving OAuth metadata and forced OAuth resource values use `server.publicOrigin` when configured.
+- [x] 5.3 Add tests proving OAuth metadata falls back to the bind-derived origin and never hard-codes localhost.
+- [x] 5.4 Run targeted tests for config, AppServer, auth metadata, and any updated CLI command parsing.

--- a/src/app/AppServer.test.ts
+++ b/src/app/AppServer.test.ts
@@ -4,7 +4,7 @@
  */
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EventBusService } from "../events";
 import type { IPipeline } from "../pipeline/trpc/interfaces";
 import type { DocumentManagementService } from "../store/DocumentManagementService";
@@ -104,6 +104,10 @@ describe("AppServer Behavior Tests", () => {
     mockWorkerService.stopWorkerService.mockResolvedValue(undefined);
     mockProxyAuthManager.initialize.mockResolvedValue(undefined);
     mockProxyAuthManager.registerRoutes.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   describe("Configuration Validation", () => {

--- a/src/app/AppServer.test.ts
+++ b/src/app/AppServer.test.ts
@@ -9,6 +9,7 @@ import { EventBusService } from "../events";
 import type { IPipeline } from "../pipeline/trpc/interfaces";
 import type { DocumentManagementService } from "../store/DocumentManagementService";
 import { type AppConfig, loadConfig } from "../utils/config";
+import { logger } from "../utils/logger";
 import { AppServer } from "./AppServer";
 import type { AppServerConfig } from "./AppServerConfig";
 
@@ -18,6 +19,7 @@ const mockFastify = vi.hoisted(() => ({
   listen: vi.fn(),
   close: vi.fn(),
   setErrorHandler: vi.fn(), // Add missing mock method
+  addHook: vi.fn(),
   server: {
     on: vi.fn(), // Mock HTTP server for WebSocket upgrade handling
     closeAllConnections: vi.fn(), // Mock for forcing connection closure
@@ -43,6 +45,11 @@ const mockWorkerService = vi.hoisted(() => ({
   stopWorkerService: vi.fn(),
 }));
 
+const mockProxyAuthManager = vi.hoisted(() => ({
+  initialize: vi.fn(),
+  registerRoutes: vi.fn(),
+}));
+
 // Apply mocks using hoisted values
 vi.mock("fastify", () => ({
   default: vi.fn(() => mockFastify),
@@ -52,6 +59,9 @@ vi.mock("../services/mcpService", () => mockMcpService);
 vi.mock("../services/trpcService", () => mockTrpcService);
 vi.mock("../services/webService", () => mockWebService);
 vi.mock("../services/workerService", () => mockWorkerService);
+vi.mock("../auth", () => ({
+  ProxyAuthManager: vi.fn(() => mockProxyAuthManager),
+}));
 vi.mock("../utils/paths", () => ({
   getProjectRoot: vi.fn(() => "/mock/project/root"),
 }));
@@ -85,12 +95,15 @@ describe("AppServer Behavior Tests", () => {
     mockFastify.register.mockResolvedValue(undefined);
     mockFastify.listen.mockResolvedValue("http://localhost:3000");
     mockFastify.close.mockResolvedValue(undefined);
+    mockFastify.addHook.mockReturnValue(undefined);
     mockMcpService.registerMcpService.mockResolvedValue(mockMcpServer as McpServer);
     mockMcpService.cleanupMcpService.mockResolvedValue(undefined);
     mockTrpcService.registerTrpcService.mockResolvedValue(undefined);
     mockWebService.registerWebService.mockResolvedValue(undefined);
     mockWorkerService.registerWorkerService.mockResolvedValue(undefined);
     mockWorkerService.stopWorkerService.mockResolvedValue(undefined);
+    mockProxyAuthManager.initialize.mockResolvedValue(undefined);
+    mockProxyAuthManager.registerRoutes.mockReturnValue(undefined);
   });
 
   describe("Configuration Validation", () => {
@@ -428,6 +441,195 @@ describe("AppServer Behavior Tests", () => {
         host: "0.0.0.0",
       });
       expect(fastifyInstance).toBe(mockFastify);
+    });
+
+    it("should log startup URLs using configured bind host instead of listen address", async () => {
+      const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => undefined);
+      const config: AppServerConfig = {
+        enableWebInterface: true,
+        enableMcpServer: true,
+        enableApiServer: true,
+        enableWorker: true,
+        port: 6280,
+        showLogo: false,
+      };
+      const appConfigWithHost: AppConfig = JSON.parse(JSON.stringify(appConfig));
+      appConfigWithHost.server.host = "0.0.0.0";
+      mockFastify.listen.mockResolvedValue("http://127.0.0.1:6280");
+
+      const server = new AppServer(
+        mockDocService as DocumentManagementService,
+        mockPipeline as IPipeline,
+        eventBus,
+        config,
+        appConfigWithHost,
+      );
+
+      await server.start();
+
+      expect(infoSpy).toHaveBeenCalledWith(
+        "🚀 Grounded Docs available at http://0.0.0.0:6280",
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "MCP endpoints: http://0.0.0.0:6280/mcp, http://0.0.0.0:6280/sse",
+        ),
+      );
+      expect(infoSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("http://127.0.0.1:6280"),
+      );
+    });
+
+    it("should prefer public origin in startup URLs", async () => {
+      const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => undefined);
+      const config: AppServerConfig = {
+        enableWebInterface: true,
+        enableMcpServer: true,
+        enableApiServer: true,
+        enableWorker: true,
+        port: 6280,
+        showLogo: false,
+      };
+      const appConfigWithPublicOrigin: AppConfig = JSON.parse(JSON.stringify(appConfig));
+      appConfigWithPublicOrigin.server.host = "0.0.0.0";
+      appConfigWithPublicOrigin.server.publicOrigin = "https://docs.example.com";
+
+      const server = new AppServer(
+        mockDocService as DocumentManagementService,
+        mockPipeline as IPipeline,
+        eventBus,
+        config,
+        appConfigWithPublicOrigin,
+      );
+
+      await server.start();
+
+      expect(infoSpy).toHaveBeenCalledWith(
+        "🚀 Grounded Docs available at https://docs.example.com",
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "MCP endpoints: https://docs.example.com/mcp, https://docs.example.com/sse",
+        ),
+      );
+    });
+
+    it("should register OAuth metadata with public origin when configured", async () => {
+      const config: AppServerConfig = {
+        enableWebInterface: false,
+        enableMcpServer: true,
+        enableApiServer: false,
+        enableWorker: true,
+        port: 6280,
+        showLogo: false,
+      };
+      const appConfigWithAuth: AppConfig = JSON.parse(JSON.stringify(appConfig));
+      appConfigWithAuth.auth.enabled = true;
+      appConfigWithAuth.auth.issuerUrl = "https://auth.example.com";
+      appConfigWithAuth.auth.audience = "https://docs.example.com";
+      appConfigWithAuth.server.host = "0.0.0.0";
+      appConfigWithAuth.server.publicOrigin = "https://docs.example.com";
+
+      const server = new AppServer(
+        mockDocService as DocumentManagementService,
+        mockPipeline as IPipeline,
+        eventBus,
+        config,
+        appConfigWithAuth,
+      );
+
+      await server.start();
+
+      expect(mockProxyAuthManager.registerRoutes).toHaveBeenCalledWith(
+        mockFastify,
+        new URL("https://docs.example.com"),
+      );
+    });
+
+    it("should register OAuth metadata with bind-derived origin when public origin is absent", async () => {
+      const config: AppServerConfig = {
+        enableWebInterface: false,
+        enableMcpServer: true,
+        enableApiServer: false,
+        enableWorker: true,
+        port: 6280,
+        showLogo: false,
+      };
+      const appConfigWithAuth: AppConfig = JSON.parse(JSON.stringify(appConfig));
+      appConfigWithAuth.auth.enabled = true;
+      appConfigWithAuth.auth.issuerUrl = "https://auth.example.com";
+      appConfigWithAuth.auth.audience = "https://docs.example.com";
+      appConfigWithAuth.server.host = "0.0.0.0";
+
+      const server = new AppServer(
+        mockDocService as DocumentManagementService,
+        mockPipeline as IPipeline,
+        eventBus,
+        config,
+        appConfigWithAuth,
+      );
+
+      await server.start();
+
+      expect(mockProxyAuthManager.registerRoutes).toHaveBeenCalledWith(
+        mockFastify,
+        new URL("http://0.0.0.0:6280"),
+      );
+    });
+
+    it("should warn when auth uses wildcard bind without public origin", async () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+      const config: AppServerConfig = {
+        enableWebInterface: false,
+        enableMcpServer: true,
+        enableApiServer: false,
+        enableWorker: true,
+        port: 6280,
+        showLogo: false,
+      };
+      const appConfigWithAuth: AppConfig = JSON.parse(JSON.stringify(appConfig));
+      appConfigWithAuth.auth.enabled = true;
+      appConfigWithAuth.auth.issuerUrl = "https://auth.example.com";
+      appConfigWithAuth.auth.audience = "https://docs.example.com";
+      appConfigWithAuth.server.host = "::";
+
+      const server = new AppServer(
+        mockDocService as DocumentManagementService,
+        mockPipeline as IPipeline,
+        eventBus,
+        config,
+        appConfigWithAuth,
+      );
+
+      await server.start();
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("public origin"));
+    });
+
+    it("should not warn for wildcard bind when auth is disabled", async () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+      const config: AppServerConfig = {
+        enableWebInterface: false,
+        enableMcpServer: false,
+        enableApiServer: true,
+        enableWorker: false,
+        port: 6280,
+        showLogo: false,
+      };
+      const appConfigWithHost: AppConfig = JSON.parse(JSON.stringify(appConfig));
+      appConfigWithHost.server.host = "0.0.0.0";
+
+      const server = new AppServer(
+        mockDocService as DocumentManagementService,
+        mockPipeline as IPipeline,
+        eventBus,
+        config,
+        appConfigWithHost,
+      );
+
+      await server.start();
+
+      expect(warnSpy).not.toHaveBeenCalled();
     });
 
     it("should successfully start server with all services enabled", async () => {

--- a/src/app/AppServer.ts
+++ b/src/app/AppServer.ts
@@ -24,6 +24,7 @@ import { printBanner } from "../utils/banner";
 import type { AppConfig } from "../utils/config";
 import { logger } from "../utils/logger";
 import { getProjectRoot } from "../utils/paths";
+import { getCanonicalServerOrigin, isWildcardBindHost } from "../utils/serverOrigin";
 import type { AppServerConfig } from "./AppServerConfig";
 
 /**
@@ -129,7 +130,7 @@ export class AppServer {
     await this.setupServer();
 
     try {
-      const address = await this.server.listen({
+      await this.server.listen({
         port: this.serverConfig.port,
         host: this.appConfig.server.host,
       });
@@ -145,7 +146,7 @@ export class AppServer {
         this.remoteEventProxy.connect();
       }
 
-      this.logStartupInfo(address);
+      this.logStartupInfo(this.getCanonicalOrigin());
       return this.server;
     } catch (error) {
       logger.error(`❌ Failed to start AppServer: ${error}`);
@@ -504,10 +505,23 @@ export class AppServer {
     }
 
     // ProxyAuthManager handles all OAuth2 endpoints automatically
-    const baseUrl = new URL(`http://localhost:${this.serverConfig.port}`);
+    const baseUrl = new URL(this.getCanonicalOrigin());
     this.authManager.registerRoutes(this.server, baseUrl);
 
+    if (
+      !this.appConfig.server.publicOrigin &&
+      isWildcardBindHost(this.appConfig.server.host)
+    ) {
+      logger.warn(
+        "⚠️  Authentication is enabled with a wildcard bind host and no public origin. Configure server.publicOrigin or --public-origin for remote OAuth clients.",
+      );
+    }
+
     logger.debug("OAuth2 proxy endpoints registered");
+  }
+
+  private getCanonicalOrigin(): string {
+    return getCanonicalServerOrigin(this.appConfig, this.serverConfig.port);
   }
 
   /**

--- a/src/auth/ProxyAuthManager.test.ts
+++ b/src/auth/ProxyAuthManager.test.ts
@@ -482,6 +482,37 @@ describe("ProxyAuthManager", () => {
     });
   });
 
+  describe("authorization-server metadata", () => {
+    beforeEach(async () => {
+      authManager = new ProxyAuthManager(validAuthConfig);
+      await authManager.initialize();
+      authManager.registerRoutes(mockServer, new URL("https://docs.example.com"));
+    });
+
+    it("should advertise OAuth endpoints from the trusted base URL", async () => {
+      const handler = getHandler(
+        mockServer,
+        "get",
+        "/.well-known/oauth-authorization-server",
+      );
+      const reply = createMockReply();
+
+      await handler(
+        { protocol: "https", headers: { host: "attacker.example.com" } },
+        reply,
+      );
+
+      expect(reply.body.issuer).toBe("https://docs.example.com");
+      expect(reply.body.authorization_endpoint).toBe(
+        "https://docs.example.com/oauth/authorize",
+      );
+      expect(reply.body.token_endpoint).toBe("https://docs.example.com/oauth/token");
+      expect(reply.body.registration_endpoint).toBe(
+        "https://docs.example.com/oauth/register",
+      );
+    });
+  });
+
   describe("authentication context creation", () => {
     describe("when auth is disabled", () => {
       beforeEach(() => {

--- a/src/auth/ProxyAuthManager.ts
+++ b/src/auth/ProxyAuthManager.ts
@@ -83,6 +83,7 @@ export class ProxyAuthManager {
     userinfoUrl?: string;
   } | null = null;
   private jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
+  private resourceOrigin: string | null = null;
 
   constructor(private config: AuthConfig) {}
 
@@ -159,6 +160,8 @@ export class ProxyAuthManager {
     if (!this.proxyProvider) {
       throw new Error("Proxy provider not initialized");
     }
+
+    this.resourceOrigin = baseUrl.origin;
 
     // OAuth2 Authorization Server Metadata (RFC 8414)
     server.get("/.well-known/oauth-authorization-server", async (_request, reply) => {
@@ -432,13 +435,14 @@ export class ProxyAuthManager {
    * Get supported resource URLs for this MCP server instance.
    * This enables self-discovering resource validation per MCP Authorization spec.
    */
-  private getSupportedResources(request: FastifyRequest): string[] {
-    const baseUrl = `${request.protocol}://${request.headers.host}`;
-
+  private getSupportedResources(): string[] {
+    if (!this.resourceOrigin) {
+      return [];
+    }
     return [
-      `${baseUrl}/sse`, // SSE transport
-      `${baseUrl}/mcp`, // Streaming HTTP transport
-      `${baseUrl}`, // Server root
+      `${this.resourceOrigin}/sse`, // SSE transport
+      `${this.resourceOrigin}/mcp`, // Streaming HTTP transport
+      this.resourceOrigin, // Server root
     ];
   }
 
@@ -510,7 +514,7 @@ export class ProxyAuthManager {
 
         // Optional: Resource validation if MCP Authorization spec requires it
         if (request) {
-          const supportedResources = this.getSupportedResources(request);
+          const supportedResources = this.getSupportedResources();
           logger.debug(`Supported resources: ${JSON.stringify(supportedResources)}`);
           // For now, we allow access if the token is valid - binary authentication
         }

--- a/src/cli/commands/default.ts
+++ b/src/cli/commands/default.ts
@@ -47,6 +47,12 @@ export function createDefaultAction(cli: Argv) {
             type: "string",
             description: "Host to bind the server to",
           })
+          .option("public-origin", {
+            type: "string",
+            description:
+              "Public origin advertised to clients (e.g., https://docs.example.com)",
+            alias: "publicOrigin",
+          })
           .option("embedding-model", {
             type: "string",
             description:

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -47,6 +47,12 @@ export function createMcpCommand(cli: Argv) {
             type: "string",
             description: "Host to bind the MCP server to",
           })
+          .option("public-origin", {
+            type: "string",
+            description:
+              "Public origin advertised to clients (e.g., https://docs.example.com)",
+            alias: "publicOrigin",
+          })
           .option("embedding-model", {
             type: "string",
             description:

--- a/src/cli/commands/web.ts
+++ b/src/cli/commands/web.ts
@@ -33,6 +33,12 @@ export function createWebCommand(cli: Argv) {
           type: "string",
           description: "Host to bind the web interface to",
         })
+        .option("public-origin", {
+          type: "string",
+          description:
+            "Public origin advertised to clients (e.g., https://docs.example.com)",
+          alias: "publicOrigin",
+        })
         .option("embedding-model", {
           type: "string",
           description:

--- a/src/cli/commands/worker.ts
+++ b/src/cli/commands/worker.ts
@@ -33,6 +33,12 @@ export function createWorkerCommand(cli: Argv) {
           type: "string",
           description: "Host to bind the worker API to",
         })
+        .option("public-origin", {
+          type: "string",
+          description:
+            "Public origin advertised to clients (e.g., https://docs.example.com)",
+          alias: "publicOrigin",
+        })
         .option("embedding-model", {
           type: "string",
           description:

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -42,6 +42,7 @@ describe("Configuration Loading", () => {
     delete process.env.DOCS_MCP_READ_ONLY;
     delete process.env.DOCS_MCP_STORE_PATH;
     delete process.env.DOCS_MCP_AUTH_ENABLED;
+    delete process.env.DOCS_MCP_SERVER_PUBLIC_ORIGIN;
 
     // Redefine system paths to point to our temp dir for testing
     // Note: We can't easily re-mock env-paths per test because imports are cached.
@@ -109,6 +110,7 @@ describe("Configuration Loading", () => {
       const config = loadConfig({}, {}); // No args -> Default System Path
 
       expect(config.server.host).toBe("127.0.0.1");
+      expect(config.server.publicOrigin).toBeUndefined();
       // loadConfig should not throw even when the default system config path
       // is unwritable; it should fall back to in-memory defaults.
     });
@@ -167,6 +169,56 @@ describe("Configuration Loading", () => {
       const config = loadConfig({ host: "cli-host" }, { configPath });
 
       expect(config.server.host).toBe("cli-host");
+    });
+
+    it("loads and normalizes server.publicOrigin from config file", () => {
+      const configPath = path.join(tmpDir, "public-origin.yaml");
+      fs.writeFileSync(
+        configPath,
+        "server:\n  publicOrigin: https://docs.example.com/\n",
+      );
+
+      const config = loadConfig({}, { configPath });
+
+      expect(config.server.publicOrigin).toBe("https://docs.example.com");
+    });
+
+    it("applies server.publicOrigin precedence from CLI over env and config file", () => {
+      const configPath = path.join(tmpDir, "public-origin-priority.yaml");
+      fs.writeFileSync(configPath, "server:\n  publicOrigin: https://file.example.com\n");
+      process.env.DOCS_MCP_SERVER_PUBLIC_ORIGIN = "https://env.example.com";
+
+      const config = loadConfig(
+        { publicOrigin: "https://cli.example.com" },
+        { configPath },
+      );
+
+      expect(config.server.publicOrigin).toBe("https://cli.example.com");
+    });
+
+    it("treats empty server.publicOrigin env var as absent", () => {
+      process.env.DOCS_MCP_SERVER_PUBLIC_ORIGIN = "";
+
+      const config = loadConfig(
+        {},
+        { configPath: path.join(tmpDir, "empty-origin.yaml") },
+      );
+
+      expect(config.server.publicOrigin).toBeUndefined();
+    });
+
+    it.each([
+      "ftp://docs.example.com",
+      "https://docs.example.com/path",
+      "https://docs.example.com?x=1",
+      "https://docs.example.com#fragment",
+    ])("rejects invalid server.publicOrigin %s", (publicOrigin) => {
+      expect(() =>
+        loadConfig(
+          { publicOrigin },
+          { configPath: path.join(tmpDir, "invalid-public-origin.yaml") },
+        ),
+      ).toThrow("server.publicOrigin");
     });
   });
 
@@ -275,6 +327,7 @@ describe("Config CLI Helpers", () => {
       expect(isValidConfigPath("scraper.maxPages")).toBe(true);
       expect(isValidConfigPath("scraper.document.maxSize")).toBe(true);
       expect(isValidConfigPath("app.telemetryEnabled")).toBe(true);
+      expect(isValidConfigPath("server.publicOrigin")).toBe(true);
     });
 
     it("returns false for invalid paths", () => {

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -333,6 +333,8 @@ describe("Config CLI Helpers", () => {
     it("returns false for invalid paths", () => {
       expect(isValidConfigPath("invalid.path")).toBe(false);
       expect(isValidConfigPath("scraper.nonexistent")).toBe(false);
+      expect(isValidConfigPath("toString")).toBe(false);
+      expect(isValidConfigPath("server.toString")).toBe(false);
     });
   });
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -5,6 +5,7 @@ import yaml from "yaml";
 import { z } from "zod";
 import { normalizeEnvValue } from "./env";
 import { logger } from "./logger";
+import { normalizePublicOrigin } from "./serverOrigin";
 
 const envStringArray = z
   .union([z.array(z.string()), z.string()])
@@ -42,6 +43,26 @@ const envBoolean = z
   })
   .pipe(z.boolean());
 
+const publicOriginSchema = z
+  .preprocess((value) => {
+    if (typeof value !== "string") {
+      return value;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }, z.string().optional())
+  .transform((value, ctx) => {
+    try {
+      return normalizePublicOrigin(value);
+    } catch (error) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      return z.NEVER;
+    }
+  });
+
 // --- Default Global Configuration ---
 
 export const DEFAULT_CONFIG = {
@@ -54,6 +75,7 @@ export const DEFAULT_CONFIG = {
   server: {
     protocol: "auto",
     host: "127.0.0.1",
+    publicOrigin: undefined as string | undefined,
     ports: {
       default: 6280,
       worker: 8080,
@@ -156,6 +178,7 @@ export const AppConfigSchema = z.object({
     .object({
       protocol: z.string().default(DEFAULT_CONFIG.server.protocol),
       host: z.string().default(DEFAULT_CONFIG.server.host),
+      publicOrigin: publicOriginSchema.optional(),
       ports: z
         .object({
           default: z.coerce.number().int().default(DEFAULT_CONFIG.server.ports.default),
@@ -166,7 +189,12 @@ export const AppConfigSchema = z.object({
         .default(DEFAULT_CONFIG.server.ports),
       heartbeatMs: z.coerce.number().int().default(DEFAULT_CONFIG.server.heartbeatMs),
     })
-    .default(DEFAULT_CONFIG.server),
+    .default({
+      protocol: DEFAULT_CONFIG.server.protocol,
+      host: DEFAULT_CONFIG.server.host,
+      ports: DEFAULT_CONFIG.server.ports,
+      heartbeatMs: DEFAULT_CONFIG.server.heartbeatMs,
+    }),
   auth: z
     .object({
       enabled: envBoolean.default(DEFAULT_CONFIG.auth.enabled),
@@ -411,6 +439,11 @@ const configMappings: ConfigMapping[] = [
   },
   { path: ["server", "host"], env: ["DOCS_MCP_HOST", "HOST"], cli: "host" },
   {
+    path: ["server", "publicOrigin"],
+    env: ["DOCS_MCP_SERVER_PUBLIC_ORIGIN"],
+    cli: "publicOrigin",
+  },
+  {
     path: ["app", "embeddingModel"],
     env: ["DOCS_MCP_EMBEDDING_MODEL"],
     cli: "embeddingModel",
@@ -495,6 +528,12 @@ export function loadConfig(
   const parseResult = AppConfigSchema.safeParse(mergedInput);
   if (parseResult.success) {
     return parseResult.data;
+  }
+
+  if (hasParseIssueAtPath(parseResult.error, ["server", "publicOrigin"])) {
+    throw new Error(
+      `Invalid configuration for server.publicOrigin: ${parseResult.error.message}`,
+    );
   }
 
   // The file on disk is structurally wrong (e.g., array fields saved as
@@ -678,6 +717,21 @@ function getAtPath(obj: ConfigObject, pathArr: string[]): unknown {
   return current;
 }
 
+function hasPath(obj: ConfigObject, pathArr: string[]): boolean {
+  let current: unknown = obj;
+  for (const key of pathArr) {
+    if (typeof current !== "object" || current === null || !(key in current)) {
+      return false;
+    }
+    current = (current as ConfigObject)[key];
+  }
+  return true;
+}
+
+function hasParseIssueAtPath(error: z.ZodError, pathArr: string[]): boolean {
+  return error.issues.some((issue) => issue.path.join(".") === pathArr.join("."));
+}
+
 function deepMerge(target: unknown, source: unknown): unknown {
   if (typeof target !== "object" || target === null) return source;
   if (typeof source !== "object" || source === null) return target;
@@ -719,7 +773,7 @@ function deepMerge(target: unknown, source: unknown): unknown {
  */
 export function isValidConfigPath(path: string): boolean {
   const pathArr = path.split(".");
-  return getAtPath(DEFAULT_CONFIG as ConfigObject, pathArr) !== undefined;
+  return hasPath(DEFAULT_CONFIG as ConfigObject, pathArr);
 }
 
 /**

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -720,7 +720,7 @@ function getAtPath(obj: ConfigObject, pathArr: string[]): unknown {
 function hasPath(obj: ConfigObject, pathArr: string[]): boolean {
   let current: unknown = obj;
   for (const key of pathArr) {
-    if (typeof current !== "object" || current === null || !(key in current)) {
+    if (typeof current !== "object" || current === null || !Object.hasOwn(current, key)) {
       return false;
     }
     current = (current as ConfigObject)[key];

--- a/src/utils/serverOrigin.test.ts
+++ b/src/utils/serverOrigin.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { AppConfig } from "./config";
+import {
+  buildBindOrigin,
+  getCanonicalServerOrigin,
+  isWildcardBindHost,
+  normalizePublicOrigin,
+} from "./serverOrigin";
+
+describe("server origin helpers", () => {
+  it("normalizes absent and empty public origins", () => {
+    expect(normalizePublicOrigin(undefined)).toBeUndefined();
+    expect(normalizePublicOrigin("")).toBeUndefined();
+    expect(normalizePublicOrigin("   ")).toBeUndefined();
+  });
+
+  it("normalizes public origins and preserves non-default ports", () => {
+    expect(normalizePublicOrigin("https://docs.example.com/")).toBe(
+      "https://docs.example.com",
+    );
+    expect(normalizePublicOrigin("https://docs.example.com:8443")).toBe(
+      "https://docs.example.com:8443",
+    );
+  });
+
+  it.each([
+    "ftp://docs.example.com",
+    "https://docs.example.com/path",
+    "https://docs.example.com?x=1",
+    "https://docs.example.com#fragment",
+    "not a url",
+  ])("rejects invalid public origin %s", (origin) => {
+    expect(() => normalizePublicOrigin(origin)).toThrow();
+  });
+
+  it("builds bind-derived origins for hostnames and IPv4 addresses", () => {
+    expect(buildBindOrigin("localhost", 6280)).toBe("http://localhost:6280");
+    expect(buildBindOrigin("0.0.0.0", 6280)).toBe("http://0.0.0.0:6280");
+  });
+
+  it("builds bind-derived origins for IPv6 addresses", () => {
+    expect(buildBindOrigin("::", 6280)).toBe("http://[::]:6280");
+    expect(buildBindOrigin("[::1]", 6280)).toBe("http://[::1]:6280");
+  });
+
+  it("prefers public origin over bind-derived origin", () => {
+    const config = {
+      server: {
+        host: "0.0.0.0",
+        publicOrigin: "https://docs.example.com",
+      },
+    } as AppConfig;
+
+    expect(getCanonicalServerOrigin(config, 6280)).toBe("https://docs.example.com");
+  });
+
+  it("falls back to bind-derived origin when public origin is absent", () => {
+    const config = {
+      server: {
+        host: "0.0.0.0",
+      },
+    } as AppConfig;
+
+    expect(getCanonicalServerOrigin(config, 6280)).toBe("http://0.0.0.0:6280");
+  });
+
+  it("detects wildcard bind hosts", () => {
+    expect(isWildcardBindHost("0.0.0.0")).toBe(true);
+    expect(isWildcardBindHost("::")).toBe(true);
+    expect(isWildcardBindHost("[::]")).toBe(true);
+    expect(isWildcardBindHost("::0")).toBe(true);
+    expect(isWildcardBindHost("127.0.0.1")).toBe(false);
+    expect(isWildcardBindHost("localhost")).toBe(false);
+  });
+});

--- a/src/utils/serverOrigin.test.ts
+++ b/src/utils/serverOrigin.test.ts
@@ -28,6 +28,8 @@ describe("server origin helpers", () => {
     "https://docs.example.com/path",
     "https://docs.example.com?x=1",
     "https://docs.example.com#fragment",
+    "https://user@docs.example.com",
+    "https://user:pass@docs.example.com",
     "not a url",
   ])("rejects invalid public origin %s", (origin) => {
     expect(() => normalizePublicOrigin(origin)).toThrow();

--- a/src/utils/serverOrigin.ts
+++ b/src/utils/serverOrigin.ts
@@ -25,6 +25,10 @@ export function normalizePublicOrigin(origin: string | undefined): string | unde
     throw new Error("server.publicOrigin must use the http or https protocol.");
   }
 
+  if (parsed.username || parsed.password) {
+    throw new Error("server.publicOrigin must not include credentials.");
+  }
+
   if (parsed.pathname !== "/" || parsed.search || parsed.hash) {
     throw new Error(
       "server.publicOrigin must not include a path, query string, or fragment.",

--- a/src/utils/serverOrigin.ts
+++ b/src/utils/serverOrigin.ts
@@ -1,0 +1,83 @@
+import type { AppConfig } from "./config";
+
+/**
+ * Normalize a configured public origin into a canonical URL origin.
+ *
+ * Empty strings are treated as absent so container environments can leave the
+ * variable declared but unset.
+ */
+export function normalizePublicOrigin(origin: string | undefined): string | undefined {
+  const trimmed = origin?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(
+      "server.publicOrigin must be an absolute HTTP(S) origin without path, query, or fragment.",
+    );
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("server.publicOrigin must use the http or https protocol.");
+  }
+
+  if (parsed.pathname !== "/" || parsed.search || parsed.hash) {
+    throw new Error(
+      "server.publicOrigin must not include a path, query string, or fragment.",
+    );
+  }
+
+  return parsed.origin;
+}
+
+/**
+ * Build an HTTP origin from the local bind host and port.
+ *
+ * The server itself listens over HTTP; deployments that terminate TLS should
+ * configure server.publicOrigin to advertise an HTTPS origin.
+ */
+export function buildBindOrigin(host: string, port: number): string {
+  const formattedHost = formatHostForUrl(host);
+  return new URL(`http://${formattedHost}:${port}`).origin;
+}
+
+/**
+ * Resolve the canonical origin used for generated endpoint URLs.
+ */
+export function getCanonicalServerOrigin(config: AppConfig, port: number): string {
+  return (
+    normalizePublicOrigin(config.server.publicOrigin) ??
+    buildBindOrigin(config.server.host, port)
+  );
+}
+
+/**
+ * Return true when a host value represents a wildcard bind address.
+ */
+export function isWildcardBindHost(host: string): boolean {
+  const normalized = stripIpv6Brackets(host.trim().toLowerCase());
+  return (
+    normalized === "0.0.0.0" ||
+    normalized === "::" ||
+    normalized === "::0" ||
+    normalized === "0:0:0:0:0:0:0:0" ||
+    normalized === "0000:0000:0000:0000:0000:0000:0000:0000"
+  );
+}
+
+function formatHostForUrl(host: string): string {
+  const trimmed = host.trim();
+  const unbracketed = stripIpv6Brackets(trimmed);
+  if (unbracketed.includes(":")) {
+    return `[${unbracketed}]`;
+  }
+  return trimmed;
+}
+
+function stripIpv6Brackets(host: string): string {
+  return host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+}


### PR DESCRIPTION
Remote deployments that bind to wildcard or non-local interfaces need a separate advertised origin so client-facing URLs and OAuth metadata do not accidentally point at localhost.

## Summary

- Add `server.publicOrigin`, `DOCS_MCP_SERVER_PUBLIC_ORIGIN`, and `--public-origin` for long-running server commands.
- Derive startup URLs and OAuth metadata/resource URLs from the configured public origin, or from the bind host and selected port when no public origin is configured.
- Preserve existing Fastify bind behavior for `server.host` and warn when auth is enabled on a wildcard bind without a public origin.
- Document the new option in configuration and authentication docs.
- Add coverage for config parsing, canonical origin generation, startup URL display, and OAuth metadata/resource behavior.

Fixes #427

## Validation

- `npm run typecheck`
- `npx vitest run src/utils/config.test.ts src/utils/serverOrigin.test.ts src/app/AppServer.test.ts src/auth/ProxyAuthManager.test.ts`
- `npm run build`
- `npm run lint`