### PR TITLE
Fix embedding dimension resolution for custom models

### DIFF
--- a/docs/guides/embedding-models.md
+++ b/docs/guides/embedding-models.md
@@ -145,4 +145,4 @@ When you change the embedding model or vector dimension after initial setup, exi
 
 ### Vector Dimension Override
 
-The vector dimension defaults to the model's native dimension (e.g., 1536 for `text-embedding-3-small`). You can override it with `embeddings.vectorDimension` in the config file or `DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION` as an environment variable. The value must be a positive integer (minimum 1).
+The vector dimension defaults to the model's native dimension (e.g., 1536 for `text-embedding-3-small`). For unknown OpenAI-compatible models, the server detects the native dimension with a startup probe and uses that detected size. You can override it with `embeddings.vectorDimension` in the config file or `DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION` as an environment variable. The value must be a positive integer (minimum 1).

--- a/docs/guides/embedding-models.md
+++ b/docs/guides/embedding-models.md
@@ -145,4 +145,4 @@ When you change the embedding model or vector dimension after initial setup, exi
 
 ### Vector Dimension Override
 
-The vector dimension defaults to the model's native dimension (e.g., 1536 for `text-embedding-3-small`). For unknown OpenAI-compatible models, the server detects the native dimension with a startup probe and uses that detected size. You can override it with `embeddings.vectorDimension` in the config file or `DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION` as an environment variable. The value must be a positive integer (minimum 1).
+The vector dimension defaults to the model's native dimension (e.g., 1536 for `text-embedding-3-small`). For unknown OpenAI-compatible models, the server detects the native dimension with a startup probe on first successful initialization, stores that detected size in database metadata, and reuses it on later startups for the same model without probing again. You can override it with `embeddings.vectorDimension` in the config file or `DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION` as an environment variable. The value must be a positive integer (minimum 1).

--- a/openspec/changes/handle-variable-embedding-dimensions/.openspec.yaml
+++ b/openspec/changes/handle-variable-embedding-dimensions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-06

--- a/openspec/changes/handle-variable-embedding-dimensions/design.md
+++ b/openspec/changes/handle-variable-embedding-dimensions/design.md
@@ -1,0 +1,55 @@
+## Context
+
+The store currently has several dimension concepts that can diverge: configured `embeddings.vectorDimension`, known model dimensions, detected model dimensions, SQLite `documents_vec` DDL, and persisted metadata. Fixed-output models are well served by known dimensions, but OpenAI-compatible providers can expose aliases, custom models, or Matryoshka/resizable models whose actual output dimension depends on provider configuration.
+
+Choosing the largest supported dimension for resizable models is safe for compatibility but expensive. Vectors are stored as float arrays, so storage and index work scale roughly linearly with dimension count. For example, an 8192d vector uses about 8x the raw float storage of a 1024d vector before SQLite/index overhead.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Use the provider's actual output dimension by default for unknown or variable-dimension models.
+- Preserve explicit `embeddings.vectorDimension` as an opt-in override.
+- Keep stable known-dimension lookup for common fixed-output models.
+- Ensure vector table DDL, metadata, change detection, padding, and validation use one resolved effective dimension.
+- Avoid hardcoding one arbitrary dimension for models that advertise multiple valid outputs.
+
+**Non-Goals:**
+- Adding provider-specific APIs to request alternate dimensions.
+- Automatically selecting the largest or best-performing dimension for variable-dimension models.
+- Backfilling or re-embedding existing documents after a dimension change.
+- Changing embedding model selection or credentials behavior.
+
+## Decisions
+
+1. **Resolve one effective dimension before vector table creation**
+   - The store resolves an effective dimension before metadata comparison, `documents_vec` creation, prepared statements, and embedding metadata persistence.
+   - Rationale: all persistence and validation surfaces must agree on a single dimension.
+   - Alternative considered: allow `initializeEmbeddings()` to detect dimensions after table creation. Rejected because the table can already be created with the wrong dimension.
+
+2. **Runtime detection is the default for unknown and variable-dimension models**
+   - Unknown models and known variable-dimension models perform a startup probe by embedding `"test"` and measuring the returned vector length.
+   - Rationale: OpenAI-compatible providers are the authority on their actual output shape, especially when a model supports multiple dimensions.
+   - Alternative considered: hardcode the largest advertised dimension. Rejected because it wastes storage and can still mismatch providers configured to return smaller vectors.
+
+3. **Known-dimension lookup remains for stable fixed-output models**
+   - Stable models such as OpenAI, Vertex, Bedrock, Cohere, Voyage, and fixed Hugging Face models can use lookup dimensions without probing.
+   - Rationale: avoids unnecessary startup API calls for models with unambiguous output dimensions.
+   - Alternative considered: always probe all models. Rejected because it adds startup latency and can fail when credentials or network are temporarily unavailable.
+
+4. **Explicit vector dimension overrides win**
+   - If the user explicitly sets `embeddings.vectorDimension` through config, env, or CLI, the store uses that value and validates the model output against it.
+   - Rationale: users may intentionally select a provider-specific reduced dimension or pad smaller vectors for an existing database.
+   - Alternative considered: ignore user overrides for auto-detected models. Rejected because it removes an existing control surface.
+
+5. **Resizable model entries bypass known-dimension lookup**
+   - Models known to advertise multiple valid dimensions are treated as runtime-detected even if a historical value exists in the table.
+   - Rationale: the list cannot represent all valid dimensions with one number.
+   - Alternative considered: store arrays/ranges in the known dimensions map. Rejected for now because the vector table still needs one concrete runtime dimension and the probe already supplies it.
+
+## Risks / Trade-offs
+
+- **Startup probe can fail for unknown or variable-dimension models** -> Surface the same initialization error path used for other embedding startup failures; fixed known models avoid probing.
+- **Auto-detected dimension changes when provider configuration changes** -> Metadata comparison detects the resolved dimension change before reusing old vectors.
+- **Explicit override smaller than non-MRL output would truncate incorrectly** -> Raise `DimensionError` unless the embedding wrapper explicitly allows MRL truncation.
+- **Large provider output can increase storage unexpectedly** -> Log the resolved dimension and document explicit overrides for users who want smaller provider-configured outputs.
+- **Known variable-dimension model registry can become stale** -> Unknown models still probe; add aliases to the runtime-detected set when a known model advertises multiple dimensions.

--- a/openspec/changes/handle-variable-embedding-dimensions/design.md
+++ b/openspec/changes/handle-variable-embedding-dimensions/design.md
@@ -4,10 +4,13 @@ The store currently has several dimension concepts that can diverge: configured 
 
 Choosing the largest supported dimension for resizable models is safe for compatibility but expensive. Vectors are stored as float arrays, so storage and index work scale roughly linearly with dimension count. For example, an 8192d vector uses about 8x the raw float storage of a 1024d vector before SQLite/index overhead.
 
+Startup probes are also not free. Providers can bill for embedding calls, so an unknown or variable-dimension model should not require a paid probe every time the server boots after the database already has matching embedding metadata.
+
 ## Goals / Non-Goals
 
 **Goals:**
 - Use the provider's actual output dimension by default for unknown or variable-dimension models.
+- Persist the first detected dimension and reuse it on later startups for the same model.
 - Preserve explicit `embeddings.vectorDimension` as an opt-in override.
 - Keep stable known-dimension lookup for common fixed-output models.
 - Ensure vector table DDL, metadata, change detection, padding, and validation use one resolved effective dimension.
@@ -18,6 +21,7 @@ Choosing the largest supported dimension for resizable models is safe for compat
 - Automatically selecting the largest or best-performing dimension for variable-dimension models.
 - Backfilling or re-embedding existing documents after a dimension change.
 - Changing embedding model selection or credentials behavior.
+- Detecting provider-side dimension drift proactively on every startup after metadata is established.
 
 ## Decisions
 
@@ -26,9 +30,11 @@ Choosing the largest supported dimension for resizable models is safe for compat
    - Rationale: all persistence and validation surfaces must agree on a single dimension.
    - Alternative considered: allow `initializeEmbeddings()` to detect dimensions after table creation. Rejected because the table can already be created with the wrong dimension.
 
-2. **Runtime detection is the default for unknown and variable-dimension models**
-   - Unknown models and known variable-dimension models perform a startup probe by embedding `"test"` and measuring the returned vector length.
-   - Rationale: OpenAI-compatible providers are the authority on their actual output shape, especially when a model supports multiple dimensions.
+2. **Runtime detection establishes a stored dimension lock**
+   - Unknown models and known variable-dimension models perform a startup probe by embedding `"test"` only when there is no stored metadata for the same configured model and no explicit dimension override.
+   - The detected dimension is persisted as `embedding_dimension` and reused on later startups while `embedding_model` still matches.
+   - Rationale: OpenAI-compatible providers are the authority on their actual first-run output shape, but repeated probe requests cost users money and can trigger accidental model-change flows when providers drift without a config change.
+   - Alternative considered: probe on every startup and compare to stored metadata. Rejected because it charges users on every boot and treats provider-side drift as an automatic startup-time model change.
    - Alternative considered: hardcode the largest advertised dimension. Rejected because it wastes storage and can still mismatch providers configured to return smaller vectors.
 
 3. **Known-dimension lookup remains for stable fixed-output models**
@@ -46,10 +52,15 @@ Choosing the largest supported dimension for resizable models is safe for compat
    - Rationale: the list cannot represent all valid dimensions with one number.
    - Alternative considered: store arrays/ranges in the known dimensions map. Rejected for now because the vector table still needs one concrete runtime dimension and the probe already supplies it.
 
+6. **Stored dimensions win over auto-probing until the user changes configuration**
+   - If metadata contains the same `embedding_model` as the current configuration and no explicit dimension override has changed, the store uses the stored `embedding_dimension` as the effective database dimension without calling the provider.
+   - Rationale: the database's vector table and stored embeddings are already tied to that dimension; preserving it avoids paid startup calls and avoids accidental invalidation.
+   - Alternative considered: always prefer the current provider output over stored metadata. Rejected because this gives the provider, rather than the user, control over when existing embeddings become incompatible.
+
 ## Risks / Trade-offs
 
-- **Startup probe can fail for unknown or variable-dimension models** -> Surface the same initialization error path used for other embedding startup failures; fixed known models avoid probing.
-- **Auto-detected dimension changes when provider configuration changes** -> Metadata comparison detects the resolved dimension change before reusing old vectors.
+- **First-run startup probe can fail for unknown or variable-dimension models** -> Surface the same initialization error path used for other embedding startup failures; fixed known models and matching stored metadata avoid probing.
+- **Provider output dimension changes after metadata is locked** -> Startup continues using the locked database dimension; subsequent embedding generation is validated against that dimension and users can intentionally change model or dimension config to trigger the existing model-change flow.
 - **Explicit override smaller than non-MRL output would truncate incorrectly** -> Raise `DimensionError` unless the embedding wrapper explicitly allows MRL truncation.
 - **Large provider output can increase storage unexpectedly** -> Log the resolved dimension and document explicit overrides for users who want smaller provider-configured outputs.
 - **Known variable-dimension model registry can become stale** -> Unknown models still probe; add aliases to the runtime-detected set when a known model advertises multiple dimensions.

--- a/openspec/changes/handle-variable-embedding-dimensions/proposal.md
+++ b/openspec/changes/handle-variable-embedding-dimensions/proposal.md
@@ -6,17 +6,18 @@ Embedding providers increasingly expose OpenAI-compatible endpoints for custom, 
 
 - Resolve the effective vector dimension before vector table creation, model-change checks, and metadata persistence.
 - Treat `embeddings.vectorDimension` as an explicit override when provided by user configuration, environment variables, or CLI arguments.
-- Auto-detect the provider's actual output dimension for unknown models and known variable-dimension models.
+- Auto-detect the provider's actual output dimension for unknown models and known variable-dimension models only when no matching stored dimension exists.
+- Treat the persisted `embedding_model` + `embedding_dimension` metadata as a lock so repeated startups do not make paid probe requests for the same model.
 - Keep known-dimension lookup for stable fixed-output models to avoid unnecessary startup API calls.
 - Avoid choosing the largest supported dimension for variable-dimension models by default, because vector storage and index cost grow with dimension width.
-- Preserve explicit user overrides for deployments that intentionally pad or select a provider-specific dimension.
+- Preserve explicit user overrides for deployments that intentionally pad or select a provider-specific dimension, with model or explicit dimension changes continuing through the existing model-change safety flow.
 
 ## Capabilities
 
 ### New Capabilities
 
 ### Modified Capabilities
-- `embedding-resolution`: Dimension resolution must distinguish fixed known dimensions, runtime-detected dimensions, and explicit overrides.
+- `embedding-resolution`: Dimension resolution must distinguish fixed known dimensions, locked stored dimensions, runtime-detected dimensions, and explicit overrides.
 - `embedding-generation`: Vector normalization and table sizing must use the resolved effective dimension, not an unconditional configured default.
 - `embedding-model-change-safety`: Model change detection and metadata must compare and persist the resolved effective dimension.
 
@@ -24,5 +25,5 @@ Embedding providers increasingly expose OpenAI-compatible endpoints for custom, 
 
 - Affects embedding startup in `DocumentStore`, known-dimension lookup in `EmbeddingConfig`, and config source tracking for explicit dimension overrides.
 - Affects SQLite `documents_vec` table creation and embedding metadata values.
-- Adds regression coverage for unknown OpenAI-compatible models, variable-dimension models, and explicit dimension overrides.
+- Adds regression coverage for unknown OpenAI-compatible models, variable-dimension models, stored-dimension reuse, and explicit dimension overrides.
 - No dependency changes and no breaking configuration changes.

--- a/openspec/changes/handle-variable-embedding-dimensions/proposal.md
+++ b/openspec/changes/handle-variable-embedding-dimensions/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Embedding providers increasingly expose OpenAI-compatible endpoints for custom, aliased, and variable-dimension models. A fixed default dimension or stale known-model entry can create vector tables that do not match the provider's actual output, corrupting semantic search or wasting storage.
+
+## What Changes
+
+- Resolve the effective vector dimension before vector table creation, model-change checks, and metadata persistence.
+- Treat `embeddings.vectorDimension` as an explicit override when provided by user configuration, environment variables, or CLI arguments.
+- Auto-detect the provider's actual output dimension for unknown models and known variable-dimension models.
+- Keep known-dimension lookup for stable fixed-output models to avoid unnecessary startup API calls.
+- Avoid choosing the largest supported dimension for variable-dimension models by default, because vector storage and index cost grow with dimension width.
+- Preserve explicit user overrides for deployments that intentionally pad or select a provider-specific dimension.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+- `embedding-resolution`: Dimension resolution must distinguish fixed known dimensions, runtime-detected dimensions, and explicit overrides.
+- `embedding-generation`: Vector normalization and table sizing must use the resolved effective dimension, not an unconditional configured default.
+- `embedding-model-change-safety`: Model change detection and metadata must compare and persist the resolved effective dimension.
+
+## Impact
+
+- Affects embedding startup in `DocumentStore`, known-dimension lookup in `EmbeddingConfig`, and config source tracking for explicit dimension overrides.
+- Affects SQLite `documents_vec` table creation and embedding metadata values.
+- Adds regression coverage for unknown OpenAI-compatible models, variable-dimension models, and explicit dimension overrides.
+- No dependency changes and no breaking configuration changes.

--- a/openspec/changes/handle-variable-embedding-dimensions/specs/embedding-generation/spec.md
+++ b/openspec/changes/handle-variable-embedding-dimensions/specs/embedding-generation/spec.md
@@ -1,0 +1,61 @@
+## MODIFIED Requirements
+
+### Requirement: Vector Dimension Normalization
+The system SHALL normalize every embedding vector to the resolved effective database dimension before insertion into the vector table. The resolved effective dimension SHALL be determined before vector table creation from, in priority order:
+1. An explicit `embeddings.vectorDimension` value supplied by user configuration, environment variables, or CLI arguments.
+2. A known fixed-output model dimension.
+3. Runtime detection from a test embedding for unknown or variable-dimension models.
+
+If an embedding vector is shorter than the resolved effective dimension, the system SHALL pad it with zeros. If an embedding vector is longer than the resolved effective dimension, the system SHALL only truncate when the embedding provider explicitly allows Matryoshka/resizable truncation. Otherwise, the system SHALL reject the vector with a dimension error.
+
+**Default dimension:** 1536 when no embedding model is configured or when an explicit default-only configuration is needed for FTS-only operation.
+
+#### Scenario: Padding smaller vectors
+- **WHEN** the resolved effective dimension is 1536
+- **AND** an embedding API returns a 1024-dimensional vector
+- **THEN** the system SHALL pad the vector with 512 zeros
+- **AND** insert a 1536-dimensional vector into `documents_vec`
+
+#### Scenario: Rejecting oversized non-MRL vectors
+- **WHEN** the resolved effective dimension is 768
+- **AND** an embedding API returns a 1536-dimensional vector
+- **AND** the embedding wrapper does not allow Matryoshka/resizable truncation
+- **THEN** the system SHALL reject the vector with `DimensionError`
+- **AND** the system SHALL NOT silently truncate the vector
+
+#### Scenario: Runtime-detected unknown model dimension
+- **WHEN** the configured model is unknown
+- **AND** no explicit `embeddings.vectorDimension` is configured
+- **AND** the provider returns a 1024-dimensional vector for the startup probe
+- **THEN** the system SHALL create `documents_vec` for 1024-dimensional vectors
+- **AND** generated embeddings SHALL be normalized to 1024 dimensions
+
+#### Scenario: Explicit override remains authoritative
+- **WHEN** the configured model is unknown
+- **AND** `embeddings.vectorDimension` is explicitly configured as 768
+- **THEN** the system SHALL create `documents_vec` for 768-dimensional vectors
+- **AND** generated embeddings SHALL be validated and normalized against 768 dimensions
+
+### Requirement: Dimension Detection
+The system SHALL determine the effective embedding dimension during initialization when embeddings are enabled. The system SHALL skip runtime probing for known fixed-output models unless an explicit dimension override is configured. The system SHALL perform runtime probing for unknown models and known variable-dimension models when no explicit dimension override is configured.
+
+Runtime probing SHALL use the configured embedding provider to generate an embedding for the string `"test"` and measure the returned vector length. The system SHALL use the detected length consistently for vector table sizing, normalization, metadata persistence, and model-change checks during that session.
+
+#### Scenario: Known fixed-output model avoids probing
+- **WHEN** the configured model is `openai:text-embedding-3-small`
+- **AND** `embeddings.vectorDimension` is not explicitly configured
+- **THEN** the effective dimension SHALL be 1536
+- **AND** the system SHALL NOT make a startup probe request
+
+#### Scenario: Variable-dimension model is probed
+- **WHEN** the configured model is `openai:NovaSearch/stella_en_400M_v5`
+- **AND** `embeddings.vectorDimension` is not explicitly configured
+- **AND** the provider returns a 4096-dimensional vector for `"test"`
+- **THEN** the effective dimension SHALL be 4096
+- **AND** the vector table SHALL be created for 4096-dimensional vectors
+
+#### Scenario: Explicit override skips auto dimension selection
+- **WHEN** the configured model is `openai:NovaSearch/stella_en_400M_v5`
+- **AND** `embeddings.vectorDimension` is explicitly configured as 1024
+- **THEN** the effective dimension SHALL be 1024
+- **AND** generated embeddings SHALL be validated against 1024 dimensions

--- a/openspec/changes/handle-variable-embedding-dimensions/specs/embedding-generation/spec.md
+++ b/openspec/changes/handle-variable-embedding-dimensions/specs/embedding-generation/spec.md
@@ -3,8 +3,9 @@
 ### Requirement: Vector Dimension Normalization
 The system SHALL normalize every embedding vector to the resolved effective database dimension before insertion into the vector table. The resolved effective dimension SHALL be determined before vector table creation from, in priority order:
 1. An explicit `embeddings.vectorDimension` value supplied by user configuration, environment variables, or CLI arguments.
-2. A known fixed-output model dimension.
-3. Runtime detection from a test embedding for unknown or variable-dimension models.
+2. A stored `embedding_dimension` when stored `embedding_model` matches the current configured model.
+3. A known fixed-output model dimension.
+4. Runtime detection from a test embedding for unknown or variable-dimension models that do not have matching stored metadata.
 
 If an embedding vector is shorter than the resolved effective dimension, the system SHALL pad it with zeros. If an embedding vector is longer than the resolved effective dimension, the system SHALL only truncate when the embedding provider explicitly allows Matryoshka/resizable truncation. Otherwise, the system SHALL reject the vector with a dimension error.
 
@@ -37,9 +38,9 @@ If an embedding vector is shorter than the resolved effective dimension, the sys
 - **AND** generated embeddings SHALL be validated and normalized against 768 dimensions
 
 ### Requirement: Dimension Detection
-The system SHALL determine the effective embedding dimension during initialization when embeddings are enabled. The system SHALL skip runtime probing for known fixed-output models unless an explicit dimension override is configured. The system SHALL perform runtime probing for unknown models and known variable-dimension models when no explicit dimension override is configured.
+The system SHALL determine the effective embedding dimension during initialization when embeddings are enabled. The system SHALL skip runtime probing for known fixed-output models unless an explicit dimension override is configured. The system SHALL also skip runtime probing for unknown and variable-dimension models when stored metadata contains the same `embedding_model` as the current configuration and a stored `embedding_dimension`.
 
-Runtime probing SHALL use the configured embedding provider to generate an embedding for the string `"test"` and measure the returned vector length. The system SHALL use the detected length consistently for vector table sizing, normalization, metadata persistence, and model-change checks during that session.
+Runtime probing SHALL use the configured embedding provider to generate an embedding for the string `"test"` and measure the returned vector length only when no matching stored dimension exists and no explicit dimension override is configured. The system SHALL use the detected or stored length consistently for vector table sizing, normalization, metadata persistence, and model-change checks during that session.
 
 #### Scenario: Known fixed-output model avoids probing
 - **WHEN** the configured model is `openai:text-embedding-3-small`
@@ -50,9 +51,26 @@ Runtime probing SHALL use the configured embedding provider to generate an embed
 #### Scenario: Variable-dimension model is probed
 - **WHEN** the configured model is `openai:NovaSearch/stella_en_400M_v5`
 - **AND** `embeddings.vectorDimension` is not explicitly configured
+- **AND** no stored metadata exists for that model
 - **AND** the provider returns a 4096-dimensional vector for `"test"`
 - **THEN** the effective dimension SHALL be 4096
 - **AND** the vector table SHALL be created for 4096-dimensional vectors
+
+#### Scenario: Variable-dimension model reuses locked dimension
+- **WHEN** the configured model is `openai:NovaSearch/stella_en_400M_v5`
+- **AND** `embeddings.vectorDimension` is not explicitly configured
+- **AND** stored metadata contains `embedding_model = "openai:NovaSearch/stella_en_400M_v5"`
+- **AND** stored metadata contains `embedding_dimension = "4096"`
+- **THEN** the effective dimension SHALL be 4096
+- **AND** the system SHALL NOT make a startup probe request
+
+#### Scenario: Unknown model reuses locked dimension
+- **WHEN** the configured model is `openai:custom-embedding-v1`
+- **AND** `embeddings.vectorDimension` is not explicitly configured
+- **AND** stored metadata contains `embedding_model = "openai:custom-embedding-v1"`
+- **AND** stored metadata contains `embedding_dimension = "1024"`
+- **THEN** the effective dimension SHALL be 1024
+- **AND** the system SHALL NOT make a startup probe request
 
 #### Scenario: Explicit override skips auto dimension selection
 - **WHEN** the configured model is `openai:NovaSearch/stella_en_400M_v5`

--- a/openspec/changes/handle-variable-embedding-dimensions/specs/embedding-model-change-safety/spec.md
+++ b/openspec/changes/handle-variable-embedding-dimensions/specs/embedding-model-change-safety/spec.md
@@ -3,7 +3,7 @@
 ### Requirement: Embedding Metadata Persistence
 The system SHALL persist embedding model metadata to the SQLite `metadata` table after successful embedding initialization. The metadata SHALL include the configured model specification and the resolved effective vector dimension used by the database. The system SHALL update this metadata atomically with successful initialization, not during partial or failed initialization.
 
-The persisted dimension SHALL be the same dimension used for `documents_vec` table creation and vector normalization. For known fixed-output models this is the known dimension unless explicitly overridden. For unknown or variable-dimension models this is the runtime-detected provider output dimension unless explicitly overridden.
+The persisted dimension SHALL be the same dimension used for `documents_vec` table creation and vector normalization. For known fixed-output models this is the known dimension unless explicitly overridden. For unknown or variable-dimension models this is the runtime-detected provider output dimension on first successful initialization unless explicitly overridden. On later startups with the same model and no explicit dimension change, the persisted dimension SHALL be reused as the locked database dimension without probing the provider.
 
 #### Scenario: Persist fixed known model metadata
 - **WHEN** embeddings initialize successfully with `openai:text-embedding-3-small`
@@ -23,9 +23,9 @@ The persisted dimension SHALL be the same dimension used for `documents_vec` tab
 - **AND** the system SHALL NOT write new embedding metadata
 
 ### Requirement: Model Change Detection
-The system SHALL compare the stored embedding model metadata against the current configured model specification and current resolved effective vector dimension during startup. The comparison SHALL happen after database migrations and after resolving the current effective dimension, but before vector table creation, vector table mutation, prepared statement initialization, or vector search use.
+The system SHALL compare the stored embedding model metadata against the current configured model specification and any explicit vector dimension override during startup. The comparison SHALL happen after database migrations but before vector table creation, vector table mutation, prepared statement initialization, provider startup probing, or vector search use.
 
-If the stored model specification or stored dimension differs from the current values, the system SHALL throw `EmbeddingModelChangedError`. The error SHALL include the stored model, current model, stored dimension, and current resolved dimension.
+If the stored model specification differs from the current configured model, or if an explicitly configured vector dimension differs from the stored dimension, the system SHALL throw `EmbeddingModelChangedError`. The error SHALL include the stored model, current model, stored dimension, and current resolved dimension. If the stored model specification matches and no explicit dimension override changed, the system SHALL use the stored dimension as the current resolved dimension and SHALL NOT probe the provider during startup.
 
 #### Scenario: Model name change is detected
 - **WHEN** stored metadata contains `embedding_model = "openai:text-embedding-3-small"`
@@ -37,7 +37,7 @@ If the stored model specification or stored dimension differs from the current v
 - **WHEN** stored metadata contains `embedding_model = "openai:custom-embedding-model"`
 - **AND** stored metadata contains `embedding_dimension = "1024"`
 - **AND** current configuration uses `openai:custom-embedding-model`
-- **AND** runtime detection resolves the current dimension to 768
+- **AND** `embeddings.vectorDimension` is explicitly configured as 768
 - **THEN** the system SHALL throw `EmbeddingModelChangedError`
 - **AND** the error SHALL include stored dimension 1024 and current dimension 768
 
@@ -45,8 +45,8 @@ If the stored model specification or stored dimension differs from the current v
 - **WHEN** stored metadata contains `embedding_model = "openai:NovaSearch/stella_en_400M_v5"`
 - **AND** stored metadata contains `embedding_dimension = "6144"`
 - **AND** current configuration uses `openai:NovaSearch/stella_en_400M_v5`
-- **AND** runtime detection resolves the current dimension to 6144
 - **THEN** startup SHALL proceed without model-change confirmation
+- **AND** the system SHALL NOT probe the provider during startup
 
 ### Requirement: Runtime-Configurable Vector Table
 The system SHALL create the SQLite vector table with the current resolved effective vector dimension. The table DDL SHALL use `float[N]` where `N` is the resolved effective dimension. The system SHALL create the table only after the effective dimension has been resolved and model-change safety checks have passed.
@@ -62,6 +62,13 @@ If the resolved effective dimension changes relative to stored embedding metadat
 - **WHEN** the configured model is `openai:custom-embedding-model`
 - **AND** the provider returns a 1024-dimensional startup probe
 - **THEN** the system SHALL create `documents_vec` with `embedding float[1024]`
+
+#### Scenario: Create vector table with locked stored dimension
+- **WHEN** the configured model is `openai:custom-embedding-model`
+- **AND** stored metadata contains `embedding_model = "openai:custom-embedding-model"`
+- **AND** stored metadata contains `embedding_dimension = "1024"`
+- **THEN** the system SHALL create `documents_vec` with `embedding float[1024]`
+- **AND** the system SHALL NOT make a provider probe request during startup
 
 #### Scenario: Create vector table with explicit override dimension
 - **WHEN** `embeddings.vectorDimension` is explicitly configured as 768

--- a/openspec/changes/handle-variable-embedding-dimensions/specs/embedding-model-change-safety/spec.md
+++ b/openspec/changes/handle-variable-embedding-dimensions/specs/embedding-model-change-safety/spec.md
@@ -1,0 +1,68 @@
+## MODIFIED Requirements
+
+### Requirement: Embedding Metadata Persistence
+The system SHALL persist embedding model metadata to the SQLite `metadata` table after successful embedding initialization. The metadata SHALL include the configured model specification and the resolved effective vector dimension used by the database. The system SHALL update this metadata atomically with successful initialization, not during partial or failed initialization.
+
+The persisted dimension SHALL be the same dimension used for `documents_vec` table creation and vector normalization. For known fixed-output models this is the known dimension unless explicitly overridden. For unknown or variable-dimension models this is the runtime-detected provider output dimension unless explicitly overridden.
+
+#### Scenario: Persist fixed known model metadata
+- **WHEN** embeddings initialize successfully with `openai:text-embedding-3-small`
+- **AND** no explicit dimension override is configured
+- **THEN** the system SHALL persist `embedding_model = "openai:text-embedding-3-small"`
+- **AND** the system SHALL persist `embedding_dimension = "1536"`
+
+#### Scenario: Persist runtime-detected model metadata
+- **WHEN** embeddings initialize successfully with `openai:custom-embedding-model`
+- **AND** the provider returns a 1024-dimensional startup probe
+- **THEN** the system SHALL persist `embedding_model = "openai:custom-embedding-model"`
+- **AND** the system SHALL persist `embedding_dimension = "1024"`
+
+#### Scenario: Do not persist metadata on initialization failure
+- **WHEN** embedding initialization fails before completion
+- **THEN** the system SHALL NOT overwrite existing embedding metadata
+- **AND** the system SHALL NOT write new embedding metadata
+
+### Requirement: Model Change Detection
+The system SHALL compare the stored embedding model metadata against the current configured model specification and current resolved effective vector dimension during startup. The comparison SHALL happen after database migrations and after resolving the current effective dimension, but before vector table creation, vector table mutation, prepared statement initialization, or vector search use.
+
+If the stored model specification or stored dimension differs from the current values, the system SHALL throw `EmbeddingModelChangedError`. The error SHALL include the stored model, current model, stored dimension, and current resolved dimension.
+
+#### Scenario: Model name change is detected
+- **WHEN** stored metadata contains `embedding_model = "openai:text-embedding-3-small"`
+- **AND** current configuration uses `gemini:embedding-001`
+- **THEN** the system SHALL throw `EmbeddingModelChangedError`
+- **AND** the error SHALL include both model names
+
+#### Scenario: Resolved dimension change is detected
+- **WHEN** stored metadata contains `embedding_model = "openai:custom-embedding-model"`
+- **AND** stored metadata contains `embedding_dimension = "1024"`
+- **AND** current configuration uses `openai:custom-embedding-model`
+- **AND** runtime detection resolves the current dimension to 768
+- **THEN** the system SHALL throw `EmbeddingModelChangedError`
+- **AND** the error SHALL include stored dimension 1024 and current dimension 768
+
+#### Scenario: Same resolved model and dimension proceeds
+- **WHEN** stored metadata contains `embedding_model = "openai:NovaSearch/stella_en_400M_v5"`
+- **AND** stored metadata contains `embedding_dimension = "6144"`
+- **AND** current configuration uses `openai:NovaSearch/stella_en_400M_v5`
+- **AND** runtime detection resolves the current dimension to 6144
+- **THEN** startup SHALL proceed without model-change confirmation
+
+### Requirement: Runtime-Configurable Vector Table
+The system SHALL create the SQLite vector table with the current resolved effective vector dimension. The table DDL SHALL use `float[N]` where `N` is the resolved effective dimension. The system SHALL create the table only after the effective dimension has been resolved and model-change safety checks have passed.
+
+If the resolved effective dimension changes relative to stored embedding metadata, the system SHALL refuse to reuse the existing vector table until the user confirms reindexing or reset behavior through the existing model-change flow.
+
+#### Scenario: Create vector table with known fixed dimension
+- **WHEN** the configured model is `openai:text-embedding-3-small`
+- **AND** no explicit dimension override is configured
+- **THEN** the system SHALL create `documents_vec` with `embedding float[1536]`
+
+#### Scenario: Create vector table with runtime-detected dimension
+- **WHEN** the configured model is `openai:custom-embedding-model`
+- **AND** the provider returns a 1024-dimensional startup probe
+- **THEN** the system SHALL create `documents_vec` with `embedding float[1024]`
+
+#### Scenario: Create vector table with explicit override dimension
+- **WHEN** `embeddings.vectorDimension` is explicitly configured as 768
+- **THEN** the system SHALL create `documents_vec` with `embedding float[768]`

--- a/openspec/changes/handle-variable-embedding-dimensions/specs/embedding-resolution/spec.md
+++ b/openspec/changes/handle-variable-embedding-dimensions/specs/embedding-resolution/spec.md
@@ -1,0 +1,77 @@
+## MODIFIED Requirements
+
+### Requirement: Known Dimensions Lookup
+The system SHALL maintain a lookup table mapping well-known fixed-output embedding model names to their vector dimensions. The lookup SHALL be case-insensitive and SHALL support common provider aliases when they unambiguously identify the same fixed-output model. When a model is found in the lookup table and is not marked as runtime-detected, the system SHALL use the known dimensions directly without making an API call.
+
+The system SHALL treat known variable-dimension models as runtime-detected models rather than forcing a single table value. Variable-dimension models include models that advertise multiple valid output dimensions, such as Matryoshka/resizable models with selectable projection heads. For these models, the system SHALL generate a test embedding using the string `"test"` to detect the model's actual provider output dimensions.
+
+When a model is not found in the lookup table, the system SHALL generate a test embedding using the string `"test"` to detect the model's output dimensions. This detection SHALL have a configurable timeout (default 30 seconds, `embeddings.initTimeoutMs`). The detected dimensions SHALL be cached for the duration of the session.
+
+**Code reference:** `src/store/embeddings/EmbeddingConfig.ts:70-260`, `src/store/DocumentStore.ts:508-537`
+
+#### Scenario: Well-known fixed-output model dimensions
+- **WHEN** the embedding model is `text-embedding-3-small`
+- **THEN** the system SHALL resolve the dimensions to 1536 without making any API call
+
+#### Scenario: Known variable-dimension model triggers runtime detection
+- **WHEN** the embedding model is `openai:NovaSearch/stella_en_400M_v5`
+- **AND** the provider returns a 6144-dimensional vector for the test input
+- **THEN** the system SHALL detect 6144 as the model's effective dimension
+- **AND** the system SHALL NOT use a hardcoded known-dimension table value for that model
+
+#### Scenario: Unknown model dimension detection
+- **WHEN** the embedding model is not in the known dimensions lookup table
+- **THEN** the system SHALL generate a test embedding of `"test"` to detect the output dimensions
+- **AND** the system SHALL cache the detected dimensions for the session
+
+#### Scenario: Dimension detection timeout
+- **WHEN** the embedding model is not in the known dimensions lookup table
+- **AND** the test embedding request exceeds the initialization timeout
+- **THEN** the system SHALL fail embedding initialization
+- **AND** the system SHALL fall back to FTS-only mode
+
+### Requirement: Embedding Identity Persistence
+After successful embedding initialization, the system SHALL persist the resolved embedding model identity to the database `metadata` table. This enables detection of model changes on subsequent startups. The persisted values SHALL be the model specification string as provided in configuration (e.g., `openai:text-embedding-3-small` or `gemini:embedding-001`) and the resolved effective vector dimension.
+
+The persistence SHALL occur as the final step of `initializeEmbeddings()`, after dimension detection and validation have succeeded. If embedding initialization fails or is skipped (FTS-only mode), no metadata SHALL be written.
+
+#### Scenario: Model identity persisted after successful init
+- **WHEN** the embedding model `gemini:embedding-001` initializes successfully with resolved dimension 768
+- **THEN** the system SHALL store `embedding_model = "gemini:embedding-001"` in the `metadata` table
+- **AND** the system SHALL store `embedding_dimension = "768"` in the `metadata` table
+
+#### Scenario: Auto-detected dimension persisted after successful init
+- **WHEN** the embedding model `openai:custom-embedding-v1` returns a 1024-dimensional test embedding
+- **THEN** the system SHALL store `embedding_model = "openai:custom-embedding-v1"` in the `metadata` table
+- **AND** the system SHALL store `embedding_dimension = "1024"` in the `metadata` table
+
+#### Scenario: Model identity not persisted on init failure
+- **WHEN** the embedding model fails to initialize (e.g., network timeout)
+- **THEN** no embedding metadata SHALL be written to the `metadata` table
+- **AND** any previously stored metadata SHALL remain unchanged
+
+### Requirement: Startup Model Mismatch Detection
+During initialization, after migrations are applied and after resolving the current effective vector dimension, the system SHALL read the stored `embedding_model` and `embedding_dimension` from the `metadata` table and compare them against the current model specification and resolved effective dimension. If either value differs, the system SHALL throw a structured `EmbeddingModelChangedError` before proceeding with vector table creation or prepared statement initialization.
+
+This check SHALL occur only when both conditions are true:
+1. The `metadata` table contains an `embedding_model` key (not a first-run scenario)
+2. The current configuration specifies an embedding model (not FTS-only mode)
+
+#### Scenario: Mismatch detected before vec table creation
+- **WHEN** the stored model is `openai:text-embedding-3-small` (1536d)
+- **AND** the configured model is `gemini:embedding-001` (resolved 768d)
+- **THEN** the system SHALL throw `EmbeddingModelChangedError` before creating/modifying the `documents_vec` table
+- **AND** the vector table SHALL remain in its previous state until the change is confirmed or rejected
+
+#### Scenario: Auto-detected dimension matches metadata
+- **WHEN** the stored model is `openai:custom-embedding-v1`
+- **AND** the stored dimension is `"1024"`
+- **AND** the current provider test embedding resolves to 1024 dimensions
+- **THEN** startup SHALL proceed normally without any prompt or error
+
+#### Scenario: FTS-only mode skips mismatch check
+- **WHEN** the configured embedding model is empty or credentials are missing
+- **AND** the stored model is `openai:text-embedding-3-small`
+- **THEN** the system SHALL NOT throw an error
+- **AND** the system SHALL proceed in FTS-only mode
+- **AND** the stored metadata SHALL remain unchanged

--- a/openspec/changes/handle-variable-embedding-dimensions/specs/embedding-resolution/spec.md
+++ b/openspec/changes/handle-variable-embedding-dimensions/specs/embedding-resolution/spec.md
@@ -3,9 +3,9 @@
 ### Requirement: Known Dimensions Lookup
 The system SHALL maintain a lookup table mapping well-known fixed-output embedding model names to their vector dimensions. The lookup SHALL be case-insensitive and SHALL support common provider aliases when they unambiguously identify the same fixed-output model. When a model is found in the lookup table and is not marked as runtime-detected, the system SHALL use the known dimensions directly without making an API call.
 
-The system SHALL treat known variable-dimension models as runtime-detected models rather than forcing a single table value. Variable-dimension models include models that advertise multiple valid output dimensions, such as Matryoshka/resizable models with selectable projection heads. For these models, the system SHALL generate a test embedding using the string `"test"` to detect the model's actual provider output dimensions.
+The system SHALL treat known variable-dimension models as runtime-detected models rather than forcing a single table value. Variable-dimension models include models that advertise multiple valid output dimensions, such as Matryoshka/resizable models with selectable projection heads.
 
-When a model is not found in the lookup table, the system SHALL generate a test embedding using the string `"test"` to detect the model's output dimensions. This detection SHALL have a configurable timeout (default 30 seconds, `embeddings.initTimeoutMs`). The detected dimensions SHALL be cached for the duration of the session.
+When a model is not found in the lookup table or is marked as variable-dimension, the system SHALL first check persisted embedding metadata. If the stored `embedding_model` exactly matches the current configured model and the stored `embedding_dimension` is present, the system SHALL use the stored dimension without making a provider probe request. If no matching stored dimension exists, the system SHALL generate a test embedding using the string `"test"` to detect the model's output dimensions. This detection SHALL have a configurable timeout (default 30 seconds, `embeddings.initTimeoutMs`). The detected dimensions SHALL be cached for the duration of the session and persisted after successful embedding initialization.
 
 **Code reference:** `src/store/embeddings/EmbeddingConfig.ts:70-260`, `src/store/DocumentStore.ts:508-537`
 
@@ -15,17 +15,35 @@ When a model is not found in the lookup table, the system SHALL generate a test 
 
 #### Scenario: Known variable-dimension model triggers runtime detection
 - **WHEN** the embedding model is `openai:NovaSearch/stella_en_400M_v5`
+- **AND** no stored embedding metadata exists for that model
 - **AND** the provider returns a 6144-dimensional vector for the test input
 - **THEN** the system SHALL detect 6144 as the model's effective dimension
 - **AND** the system SHALL NOT use a hardcoded known-dimension table value for that model
 
+#### Scenario: Known variable-dimension model reuses stored dimension
+- **WHEN** the embedding model is `openai:NovaSearch/stella_en_400M_v5`
+- **AND** stored metadata contains `embedding_model = "openai:NovaSearch/stella_en_400M_v5"`
+- **AND** stored metadata contains `embedding_dimension = "6144"`
+- **THEN** the system SHALL resolve the effective dimension to 6144
+- **AND** the system SHALL NOT generate a test embedding during startup
+
 #### Scenario: Unknown model dimension detection
 - **WHEN** the embedding model is not in the known dimensions lookup table
+- **AND** no stored embedding metadata exists for that model
 - **THEN** the system SHALL generate a test embedding of `"test"` to detect the output dimensions
 - **AND** the system SHALL cache the detected dimensions for the session
+- **AND** the system SHALL persist the detected dimensions after successful initialization
+
+#### Scenario: Unknown model reuses stored dimension
+- **WHEN** the embedding model is `openai:custom-embedding-v1`
+- **AND** stored metadata contains `embedding_model = "openai:custom-embedding-v1"`
+- **AND** stored metadata contains `embedding_dimension = "1024"`
+- **THEN** the system SHALL resolve the effective dimension to 1024
+- **AND** the system SHALL NOT generate a test embedding during startup
 
 #### Scenario: Dimension detection timeout
 - **WHEN** the embedding model is not in the known dimensions lookup table
+- **AND** no stored embedding metadata exists for that model
 - **AND** the test embedding request exceeds the initialization timeout
 - **THEN** the system SHALL fail embedding initialization
 - **AND** the system SHALL fall back to FTS-only mode
@@ -51,7 +69,7 @@ The persistence SHALL occur as the final step of `initializeEmbeddings()`, after
 - **AND** any previously stored metadata SHALL remain unchanged
 
 ### Requirement: Startup Model Mismatch Detection
-During initialization, after migrations are applied and after resolving the current effective vector dimension, the system SHALL read the stored `embedding_model` and `embedding_dimension` from the `metadata` table and compare them against the current model specification and resolved effective dimension. If either value differs, the system SHALL throw a structured `EmbeddingModelChangedError` before proceeding with vector table creation or prepared statement initialization.
+During initialization, after migrations are applied, the system SHALL read the stored `embedding_model` and `embedding_dimension` from the `metadata` table. If the stored model matches the current model and no explicit vector dimension override changed, the system SHALL treat the stored dimension as the current resolved effective dimension without probing the provider. If the current model specification or explicitly configured dimension differs from stored metadata, the system SHALL throw a structured `EmbeddingModelChangedError` before proceeding with vector table creation or prepared statement initialization.
 
 This check SHALL occur only when both conditions are true:
 1. The `metadata` table contains an `embedding_model` key (not a first-run scenario)
@@ -66,8 +84,9 @@ This check SHALL occur only when both conditions are true:
 #### Scenario: Auto-detected dimension matches metadata
 - **WHEN** the stored model is `openai:custom-embedding-v1`
 - **AND** the stored dimension is `"1024"`
-- **AND** the current provider test embedding resolves to 1024 dimensions
+- **AND** the current configured model is `openai:custom-embedding-v1`
 - **THEN** startup SHALL proceed normally without any prompt or error
+- **AND** the system SHALL NOT generate a test embedding during startup
 
 #### Scenario: FTS-only mode skips mismatch check
 - **WHEN** the configured embedding model is empty or credentials are missing

--- a/openspec/changes/handle-variable-embedding-dimensions/tasks.md
+++ b/openspec/changes/handle-variable-embedding-dimensions/tasks.md
@@ -29,7 +29,7 @@
 
 ## 5. Stored Dimension Lock
 
-- [ ] 5.1 Reuse stored `embedding_dimension` without provider probing when stored `embedding_model` matches the current configured model and no explicit vector dimension override changed.
-- [ ] 5.2 Probe unknown and variable-dimension models only on first successful initialization or after an intentional model/dimension change.
-- [ ] 5.3 Update regression tests to prove matching stored metadata skips the startup probe for unknown and variable-dimension models.
-- [ ] 5.4 Update documentation to explain that detected dimensions are locked in database metadata until the user changes model or vector dimension configuration.
+- [x] 5.1 Reuse stored `embedding_dimension` without provider probing when stored `embedding_model` matches the current configured model and no explicit vector dimension override changed.
+- [x] 5.2 Probe unknown and variable-dimension models only on first successful initialization or after an intentional model/dimension change.
+- [x] 5.3 Update regression tests to prove matching stored metadata skips the startup probe for unknown and variable-dimension models.
+- [x] 5.4 Update documentation to explain that detected dimensions are locked in database metadata until the user changes model or vector dimension configuration.

--- a/openspec/changes/handle-variable-embedding-dimensions/tasks.md
+++ b/openspec/changes/handle-variable-embedding-dimensions/tasks.md
@@ -26,3 +26,10 @@
 - [x] 4.2 Document runtime dimension probing and explicit override behavior in the embedding model guide.
 - [x] 4.3 Add regression tests for unknown models, explicit overrides, non-MRL truncation rejection, and variable-dimension model probing.
 - [x] 4.4 Run targeted tests, typecheck, lint, and build verification.
+
+## 5. Stored Dimension Lock
+
+- [ ] 5.1 Reuse stored `embedding_dimension` without provider probing when stored `embedding_model` matches the current configured model and no explicit vector dimension override changed.
+- [ ] 5.2 Probe unknown and variable-dimension models only on first successful initialization or after an intentional model/dimension change.
+- [ ] 5.3 Update regression tests to prove matching stored metadata skips the startup probe for unknown and variable-dimension models.
+- [ ] 5.4 Update documentation to explain that detected dimensions are locked in database metadata until the user changes model or vector dimension configuration.

--- a/openspec/changes/handle-variable-embedding-dimensions/tasks.md
+++ b/openspec/changes/handle-variable-embedding-dimensions/tasks.md
@@ -1,0 +1,28 @@
+## 1. Dimension Resolution
+
+- [x] 1.1 Track whether `embeddings.vectorDimension` was explicitly supplied by user config, environment variables, or CLI arguments.
+- [x] 1.2 Update known-dimension lookup to distinguish fixed-output known models from known variable-dimension models.
+- [x] 1.3 Add aliases for current fixed-output provider model names that unambiguously resolve to known dimensions.
+- [x] 1.4 Add a runtime-detected model set for known variable-dimension models such as Stella/Jasper entries.
+
+## 2. Store Initialization
+
+- [x] 2.1 Resolve the effective database dimension before vector table creation, metadata comparison, and statement preparation.
+- [x] 2.2 Use known fixed dimensions without startup probing when no explicit override is configured.
+- [x] 2.3 Probe unknown and variable-dimension models with a test embedding when no explicit override is configured.
+- [x] 2.4 Persist the resolved effective dimension in embedding metadata after successful initialization.
+
+## 3. Vector Validation
+
+- [x] 3.1 Create `documents_vec` with the resolved effective dimension.
+- [x] 3.2 Normalize generated embeddings against the resolved effective dimension.
+- [x] 3.3 Preserve zero-padding for vectors smaller than the resolved dimension.
+- [x] 3.4 Reject oversized non-MRL vectors instead of silently truncating them.
+- [x] 3.5 Preserve explicit vector dimension overrides as authoritative opt-in behavior.
+
+## 4. Safety and Documentation
+
+- [x] 4.1 Compare stored embedding metadata against the current resolved effective dimension during model-change checks.
+- [x] 4.2 Document runtime dimension probing and explicit override behavior in the embedding model guide.
+- [x] 4.3 Add regression tests for unknown models, explicit overrides, non-MRL truncation rejection, and variable-dimension model probing.
+- [x] 4.4 Run targeted tests, typecheck, lint, and build verification.

--- a/src/store/DocumentStore.test.ts
+++ b/src/store/DocumentStore.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ScrapeResult } from "../scraper/types";
 import type { Chunk } from "../splitter/types";
-import { loadConfig } from "../utils/config";
+import { loadConfig, markVectorDimensionSource } from "../utils/config";
 import { DocumentStore } from "./DocumentStore";
 import { EmbeddingConfig } from "./embeddings/EmbeddingConfig";
-import { EmbeddingModelChangedError } from "./errors";
+import { DimensionError, EmbeddingModelChangedError } from "./errors";
 import { VersionStatus } from "./types";
+
+const mockEmbeddingDimension = vi.hoisted(() => ({ value: 1536 }));
 
 // Mock only the embedding service to generate deterministic embeddings for testing
 // This allows us to test ranking logic while using real SQLite database
@@ -20,7 +22,7 @@ vi.mock("./embeddings/EmbeddingFactory", async () => {
       embedQuery: vi.fn(async (text: string) => {
         // Generate deterministic embeddings based on text content for consistent testing
         const words = text.toLowerCase().split(/\s+/);
-        const embedding = new Array(1536).fill(0);
+        const embedding = new Array(mockEmbeddingDimension.value).fill(0);
 
         // Create meaningful semantic relationships for testing
         words.forEach((word, wordIndex) => {
@@ -31,7 +33,7 @@ vi.mock("./embeddings/EmbeddingFactory", async () => {
           const baseIndex = (wordHash % 100) * 15; // Distribute across embedding dimensions
 
           for (let i = 0; i < 15; i++) {
-            const index = (baseIndex + i) % 1536;
+            const index = (baseIndex + i) % mockEmbeddingDimension.value;
             embedding[index] += 1.0 / (wordIndex + 1); // Earlier words get higher weight
           }
         });
@@ -44,7 +46,7 @@ vi.mock("./embeddings/EmbeddingFactory", async () => {
         // Generate embeddings for each text using the same logic as embedQuery
         return texts.map((text) => {
           const words = text.toLowerCase().split(/\s+/);
-          const embedding = new Array(1536).fill(0);
+          const embedding = new Array(mockEmbeddingDimension.value).fill(0);
 
           words.forEach((word, wordIndex) => {
             const wordHash = Array.from(word).reduce(
@@ -54,7 +56,7 @@ vi.mock("./embeddings/EmbeddingFactory", async () => {
             const baseIndex = (wordHash % 100) * 15;
 
             for (let i = 0; i < 15; i++) {
-              const index = (baseIndex + i) % 1536;
+              const index = (baseIndex + i) % mockEmbeddingDimension.value;
               embedding[index] += 1.0 / (wordIndex + 1);
             }
           });
@@ -113,6 +115,7 @@ describe("DocumentStore - With Embeddings", () => {
   let store: DocumentStore;
 
   beforeEach(async () => {
+    mockEmbeddingDimension.value = 1536;
     // Create explicit embedding configuration for tests
     const embeddingConfig = EmbeddingConfig.parseEmbeddingConfig(
       "openai:text-embedding-3-small",
@@ -464,6 +467,7 @@ describe("DocumentStore - With Embeddings", () => {
     let mockEmbedDocuments: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
+      mockEmbeddingDimension.value = 1536;
       // Get reference to the mocked embedDocuments function if embeddings are enabled
       // @ts-expect-error Accessing private property for testing
       if (store.embeddings?.embedDocuments) {
@@ -1618,6 +1622,7 @@ describe("DocumentStore - Embedding Model Change Safety", () => {
   let originalApiKey: string | undefined;
 
   beforeEach(() => {
+    mockEmbeddingDimension.value = 1536;
     // Set dummy API key so areCredentialsAvailable("openai") returns true
     // and initializeEmbeddings() proceeds (the actual API call is mocked)
     originalApiKey = process.env.OPENAI_API_KEY;
@@ -1653,6 +1658,7 @@ describe("DocumentStore - Embedding Model Change Safety", () => {
     }
     if (dimension !== undefined) {
       cfg.embeddings.vectorDimension = dimension;
+      markVectorDimensionSource(cfg, true);
     }
     const s = new DocumentStore(":memory:", cfg);
     await s.initialize();
@@ -1725,6 +1731,15 @@ describe("DocumentStore - Embedding Model Change Safety", () => {
       store = await createStore("openai:text-embedding-3-small");
 
       // Metadata was persisted by initializeEmbeddings — check should pass
+      expect(() => store.checkEmbeddingModelChange()).not.toThrow();
+    });
+
+    it("should not throw after restarting with an auto-detected unknown model dimension", async () => {
+      mockEmbeddingDimension.value = 1024;
+      store = await createStore("openai:custom-1024-model");
+
+      // Metadata was persisted with the resolved dimension, not the default config value.
+      expect(store.getEmbeddingMetadata().dimension).toBe("1024");
       expect(() => store.checkEmbeddingModelChange()).not.toThrow();
     });
 
@@ -1855,6 +1870,65 @@ describe("DocumentStore - Embedding Model Change Safety", () => {
         .prepare("SELECT COUNT(*) as cnt FROM documents_vec")
         .get() as { cnt: number };
       expect(count.cnt).toBe(0);
+    });
+
+    it("should create table with auto-detected dimensions for unknown OpenAI-compatible models", async () => {
+      mockEmbeddingDimension.value = 1024;
+      store = await createStore("openai:custom-1024-model");
+
+      // @ts-expect-error Accessing private property for testing
+      const ddl = store.db
+        .prepare(
+          "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'documents_vec'",
+        )
+        .get() as { sql: string };
+      expect(ddl.sql).toContain("1024");
+
+      const metadata = store.getEmbeddingMetadata();
+      expect(metadata.model).toBe("openai:custom-1024-model");
+      expect(metadata.dimension).toBe("1024");
+    });
+
+    it("should auto-detect dimensions for variable-dimension known models", async () => {
+      mockEmbeddingDimension.value = 6144;
+      store = await createStore("openai:NovaSearch/stella_en_400M_v5");
+
+      // @ts-expect-error Accessing private property for testing
+      const ddl = store.db
+        .prepare(
+          "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'documents_vec'",
+        )
+        .get() as { sql: string };
+      expect(ddl.sql).toContain("6144");
+
+      const metadata = store.getEmbeddingMetadata();
+      expect(metadata.model).toBe("openai:NovaSearch/stella_en_400M_v5");
+      expect(metadata.dimension).toBe("6144");
+    });
+
+    it("should respect explicit vector dimension overrides for unknown models", async () => {
+      mockEmbeddingDimension.value = 1024;
+      store = await createStore("openai:custom-1024-model", 1536);
+
+      // @ts-expect-error Accessing private property for testing
+      const ddl = store.db
+        .prepare(
+          "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'documents_vec'",
+        )
+        .get() as { sql: string };
+      expect(ddl.sql).toContain("1536");
+
+      const metadata = store.getEmbeddingMetadata();
+      expect(metadata.dimension).toBe("1536");
+    });
+
+    it("should reject explicit dimensions smaller than non-MRL model output", async () => {
+      mockEmbeddingDimension.value = 1024;
+
+      await expect(createStore("openai:custom-1024-model", 256)).rejects.toThrow(
+        DimensionError,
+      );
+      store = await createStore("");
     });
 
     it("should be a no-op when dimension matches existing table", async () => {

--- a/src/store/DocumentStore.test.ts
+++ b/src/store/DocumentStore.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ScrapeResult } from "../scraper/types";
 import type { Chunk } from "../splitter/types";
@@ -8,6 +11,7 @@ import { DimensionError, EmbeddingModelChangedError } from "./errors";
 import { VersionStatus } from "./types";
 
 const mockEmbeddingDimension = vi.hoisted(() => ({ value: 1536 }));
+const mockEmbeddingCalls = vi.hoisted(() => ({ query: 0, documents: 0 }));
 
 // Mock only the embedding service to generate deterministic embeddings for testing
 // This allows us to test ranking logic while using real SQLite database
@@ -20,6 +24,7 @@ vi.mock("./embeddings/EmbeddingFactory", async () => {
     ...actual,
     createEmbeddingModel: () => ({
       embedQuery: vi.fn(async (text: string) => {
+        mockEmbeddingCalls.query += 1;
         // Generate deterministic embeddings based on text content for consistent testing
         const words = text.toLowerCase().split(/\s+/);
         const embedding = new Array(mockEmbeddingDimension.value).fill(0);
@@ -43,6 +48,7 @@ vi.mock("./embeddings/EmbeddingFactory", async () => {
         return magnitude > 0 ? embedding.map((val) => val / magnitude) : embedding;
       }),
       embedDocuments: vi.fn(async (texts: string[]) => {
+        mockEmbeddingCalls.documents += 1;
         // Generate embeddings for each text using the same logic as embedQuery
         return texts.map((text) => {
           const words = text.toLowerCase().split(/\s+/);
@@ -1620,9 +1626,13 @@ describe("DocumentStore - Common Functionality", () => {
 describe("DocumentStore - Embedding Model Change Safety", () => {
   let store: DocumentStore;
   let originalApiKey: string | undefined;
+  let tempDir: string;
 
   beforeEach(() => {
     mockEmbeddingDimension.value = 1536;
+    mockEmbeddingCalls.query = 0;
+    mockEmbeddingCalls.documents = 0;
+    tempDir = mkdtempSync(join(tmpdir(), "docs-mcp-store-"));
     // Set dummy API key so areCredentialsAvailable("openai") returns true
     // and initializeEmbeddings() proceeds (the actual API call is mocked)
     originalApiKey = process.env.OPENAI_API_KEY;
@@ -1639,6 +1649,7 @@ describe("DocumentStore - Embedding Model Change Safety", () => {
     } else {
       process.env.OPENAI_API_KEY = originalApiKey;
     }
+    rmSync(tempDir, { recursive: true, force: true });
   });
 
   /**
@@ -1648,6 +1659,7 @@ describe("DocumentStore - Embedding Model Change Safety", () => {
   async function createStore(
     modelSpec: string,
     dimension?: number,
+    dbPath = ":memory:",
   ): Promise<DocumentStore> {
     const cfg = loadConfig();
     if (modelSpec) {
@@ -1660,7 +1672,7 @@ describe("DocumentStore - Embedding Model Change Safety", () => {
       cfg.embeddings.vectorDimension = dimension;
       markVectorDimensionSource(cfg, true);
     }
-    const s = new DocumentStore(":memory:", cfg);
+    const s = new DocumentStore(dbPath, cfg);
     await s.initialize();
     return s;
   }
@@ -1889,6 +1901,36 @@ describe("DocumentStore - Embedding Model Change Safety", () => {
       expect(metadata.dimension).toBe("1024");
     });
 
+    it("should reuse stored dimensions for unknown models without another startup probe", async () => {
+      const dbPath = join(tempDir, "unknown-locked.sqlite");
+      mockEmbeddingDimension.value = 1024;
+      const firstStore = await createStore(
+        "openai:custom-locked-model",
+        undefined,
+        dbPath,
+      );
+      expect(mockEmbeddingCalls.query).toBe(1);
+      expect(firstStore.getEmbeddingMetadata().dimension).toBe("1024");
+      await firstStore.shutdown();
+
+      mockEmbeddingCalls.query = 0;
+      mockEmbeddingDimension.value = 2048;
+      store = await createStore("openai:custom-locked-model", undefined, dbPath);
+
+      expect(mockEmbeddingCalls.query).toBe(0);
+      const metadata = store.getEmbeddingMetadata();
+      expect(metadata.model).toBe("openai:custom-locked-model");
+      expect(metadata.dimension).toBe("1024");
+
+      // @ts-expect-error Accessing private property for testing
+      const ddl = store.db
+        .prepare(
+          "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'documents_vec'",
+        )
+        .get() as { sql: string };
+      expect(ddl.sql).toContain("1024");
+    });
+
     it("should auto-detect dimensions for variable-dimension known models", async () => {
       mockEmbeddingDimension.value = 6144;
       store = await createStore("openai:NovaSearch/stella_en_400M_v5");
@@ -1904,6 +1946,36 @@ describe("DocumentStore - Embedding Model Change Safety", () => {
       const metadata = store.getEmbeddingMetadata();
       expect(metadata.model).toBe("openai:NovaSearch/stella_en_400M_v5");
       expect(metadata.dimension).toBe("6144");
+    });
+
+    it("should reuse stored dimensions for variable-dimension known models without another startup probe", async () => {
+      const dbPath = join(tempDir, "variable-locked.sqlite");
+      mockEmbeddingDimension.value = 6144;
+      const firstStore = await createStore(
+        "openai:NovaSearch/stella_en_400M_v5",
+        undefined,
+        dbPath,
+      );
+      expect(mockEmbeddingCalls.query).toBe(1);
+      expect(firstStore.getEmbeddingMetadata().dimension).toBe("6144");
+      await firstStore.shutdown();
+
+      mockEmbeddingCalls.query = 0;
+      mockEmbeddingDimension.value = 8192;
+      store = await createStore("openai:NovaSearch/stella_en_400M_v5", undefined, dbPath);
+
+      expect(mockEmbeddingCalls.query).toBe(0);
+      const metadata = store.getEmbeddingMetadata();
+      expect(metadata.model).toBe("openai:NovaSearch/stella_en_400M_v5");
+      expect(metadata.dimension).toBe("6144");
+
+      // @ts-expect-error Accessing private property for testing
+      const ddl = store.db
+        .prepare(
+          "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'documents_vec'",
+        )
+        .get() as { sql: string };
+      expect(ddl.sql).toContain("6144");
     });
 
     it("should respect explicit vector dimension overrides for unknown models", async () => {

--- a/src/store/DocumentStore.test.ts
+++ b/src/store/DocumentStore.test.ts
@@ -2003,6 +2003,24 @@ describe("DocumentStore - Embedding Model Change Safety", () => {
       store = await createStore("");
     });
 
+    it("should reject invalid dimensions from provider probing", async () => {
+      mockEmbeddingDimension.value = 0;
+
+      await expect(createStore("openai:empty-vector-model")).rejects.toThrow(
+        "Invalid detected embedding dimension from embedding provider probe: 0. Must be a positive integer.",
+      );
+      store = await createStore("");
+    });
+
+    it("should reject invalid dimensions from known model lookup", async () => {
+      EmbeddingConfig.setKnownModelDimensions("invalid-known-dimension-model", 0);
+
+      await expect(createStore("openai:invalid-known-dimension-model")).rejects.toThrow(
+        "Invalid detected embedding dimension from known model dimension lookup: 0. Must be a positive integer.",
+      );
+      store = await createStore("");
+    });
+
     it("should be a no-op when dimension matches existing table", async () => {
       store = await createStore("openai:text-embedding-3-small");
 

--- a/src/store/DocumentStore.ts
+++ b/src/store/DocumentStore.ts
@@ -2,7 +2,7 @@ import type { Embeddings } from "@langchain/core/embeddings";
 import Database, { type Database as DatabaseType } from "better-sqlite3";
 import * as sqliteVec from "sqlite-vec";
 import type { ScrapeResult, ScraperOptions } from "../scraper/types";
-import type { AppConfig } from "../utils/config";
+import { type AppConfig, isVectorDimensionExplicit } from "../utils/config";
 import { logger } from "../utils/logger";
 import { compareVersionsDescending } from "../utils/version";
 import { applyMigrations } from "./applyMigrations";
@@ -70,8 +70,8 @@ export class DocumentStore {
   private readonly config: AppConfig;
 
   private readonly db: DatabaseType;
-  private embeddings!: Embeddings;
-  private readonly dbDimension: number;
+  private embeddings: Embeddings | null = null;
+  private dbDimension: number;
   private readonly searchWeightVec: number;
   private readonly searchWeightFts: number;
   private readonly searchOverfetchFactor: number;
@@ -80,7 +80,7 @@ export class DocumentStore {
   private readonly embeddingBatchSize: number;
   private readonly embeddingBatchChars: number;
   private readonly embeddingInitTimeoutMs: number;
-  private modelDimension!: number;
+  private modelDimension: number | null = null;
   private readonly embeddingConfig?: EmbeddingModelConfig | null;
   private isVectorSearchEnabled: boolean = false;
 
@@ -538,7 +538,7 @@ export class DocumentStore {
     }
 
     const currentModel = this.config.app.embeddingModel;
-    const currentDimension = String(this.config.embeddings.vectorDimension);
+    const currentDimension = String(this.dbDimension);
 
     const modelChanged = stored.model !== currentModel;
     const dimensionChanged =
@@ -626,41 +626,11 @@ export class DocumentStore {
 
     // Create embedding model
     try {
-      this.embeddings = createEmbeddingModel(config.modelSpec, {
-        requestTimeoutMs: this.config.embeddings.requestTimeoutMs,
-        vectorDimension: this.dbDimension,
-      });
-
-      // Use known dimensions if available, otherwise detect via test query
-      if (config.dimensions !== null) {
-        this.modelDimension = config.dimensions;
-      } else {
-        // Fallback: determine the model's actual dimension by embedding a test string
-        // Use a timeout to fail fast if the embedding service is unreachable
-        const testPromise = this.embeddings.embedQuery("test");
-        let timeoutId: NodeJS.Timeout | undefined;
-        const timeoutPromise = new Promise<never>((_, reject) => {
-          timeoutId = setTimeout(() => {
-            reject(
-              new Error(
-                `Embedding service connection timed out after ${this.embeddingInitTimeoutMs / 1000} seconds`,
-              ),
-            );
-          }, this.embeddingInitTimeoutMs);
-        });
-
-        try {
-          const testVector = await Promise.race([testPromise, timeoutPromise]);
-          this.modelDimension = testVector.length;
-        } finally {
-          if (timeoutId !== undefined) {
-            clearTimeout(timeoutId);
-          }
-        }
-
-        // Cache the discovered dimensions for future use
-        EmbeddingConfig.setKnownModelDimensions(config.model, this.modelDimension);
+      if (this.embeddings === null) {
+        this.embeddings = this.createEmbeddingClient(this.dbDimension);
       }
+
+      const modelDimension = this.modelDimension ?? this.dbDimension;
 
       // For models wrapped in FixedDimensionEmbeddings with truncation enabled
       // (e.g., Gemini with MRL support), the effective output dimension is capped
@@ -669,7 +639,9 @@ export class DocumentStore {
         this.embeddings instanceof FixedDimensionEmbeddings &&
         this.embeddings.allowTruncate
       ) {
-        this.modelDimension = Math.min(this.modelDimension, this.dbDimension);
+        this.modelDimension = Math.min(modelDimension, this.dbDimension);
+      } else {
+        this.modelDimension = modelDimension;
       }
 
       if (this.modelDimension > this.dbDimension) {
@@ -679,56 +651,138 @@ export class DocumentStore {
       // If we reach here, embeddings are successfully initialized
       this.isVectorSearchEnabled = true;
       logger.debug(
-        `Embeddings initialized: ${config.provider}:${config.model} (${this.modelDimension}d)`,
+        `Embeddings initialized: ${config.provider}:${config.model} (${this.dbDimension}d)`,
       );
 
       // Persist the active embedding model identity for change detection on next startup
       this.setEmbeddingMetadata(config.modelSpec, this.dbDimension);
     } catch (error) {
-      // Handle model-related errors with helpful messages
-      if (error instanceof Error) {
-        if (
-          error.message.includes("does not exist") ||
-          error.message.includes("MODEL_NOT_FOUND")
-        ) {
-          throw new ModelConfigurationError(
-            `Invalid embedding model: ${config.model}\n` +
-              `   The model "${config.model}" is not available or you don't have access to it.\n` +
-              "   See README.md for supported models or run with --help for more details.",
-          );
-        }
-        if (
-          error.message.includes("API key") ||
-          error.message.includes("401") ||
-          error.message.includes("authentication")
-        ) {
-          throw new ModelConfigurationError(
-            `Authentication failed for ${config.provider} embedding provider\n` +
-              "   Please check your API key configuration.\n" +
-              "   See README.md for configuration options or run with --help for more details.",
-          );
-        }
-        // Handle network-related errors (timeout, connection refused, etc.)
-        if (
-          error.message.includes("timed out") ||
-          error.message.includes("ECONNREFUSED") ||
-          error.message.includes("ENOTFOUND") ||
-          error.message.includes("ETIMEDOUT") ||
-          error.message.includes("ECONNRESET") ||
-          error.message.includes("network") ||
-          error.message.includes("fetch failed")
-        ) {
-          throw new ModelConfigurationError(
-            `Failed to connect to ${config.provider} embedding service\n` +
-              `   ${error.message}\n` +
-              `   Please check that the embedding service is running and accessible.\n` +
-              `   If using a local model (e.g., Ollama), ensure the service is started.`,
-          );
-        }
-      }
-      // Re-throw other embedding errors (like DimensionError) as-is
-      throw error;
+      this.throwEmbeddingInitializationError(error, config);
     }
+  }
+
+  private createEmbeddingClient(vectorDimension: number): Embeddings {
+    const config = this.embeddingConfig;
+    if (!config) {
+      throw new StoreError("Cannot create embedding client without configuration");
+    }
+
+    return createEmbeddingModel(config.modelSpec, {
+      requestTimeoutMs: this.config.embeddings.requestTimeoutMs,
+      vectorDimension,
+    });
+  }
+
+  private async detectEmbeddingDimension(embeddings: Embeddings): Promise<number> {
+    const testPromise = embeddings.embedQuery("test");
+    let timeoutId: NodeJS.Timeout | undefined;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        reject(
+          new Error(
+            `Embedding service connection timed out after ${this.embeddingInitTimeoutMs / 1000} seconds`,
+          ),
+        );
+      }, this.embeddingInitTimeoutMs);
+    });
+
+    try {
+      const testVector = await Promise.race([testPromise, timeoutPromise]);
+      return testVector.length;
+    } finally {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    }
+  }
+
+  private async resolveEffectiveEmbeddingDimension(): Promise<void> {
+    this.validateVectorDimension(this.dbDimension);
+
+    if (this.embeddingConfig === null || this.embeddingConfig === undefined) {
+      return;
+    }
+
+    const config = this.embeddingConfig;
+    if (!areCredentialsAvailable(config.provider)) {
+      return;
+    }
+
+    try {
+      let nativeDimension = config.dimensions;
+
+      if (nativeDimension === null) {
+        this.embeddings = this.createEmbeddingClient(this.dbDimension);
+        nativeDimension = await this.detectEmbeddingDimension(this.embeddings);
+        EmbeddingConfig.setKnownModelDimensions(config.model, nativeDimension);
+      }
+
+      this.modelDimension = nativeDimension;
+
+      if (!isVectorDimensionExplicit(this.config)) {
+        this.dbDimension = nativeDimension;
+        logger.info(
+          `📐 Vector dimension auto-resolved to ${this.dbDimension} for ${config.provider}:${config.model}`,
+        );
+      }
+    } catch (error) {
+      this.throwEmbeddingInitializationError(error, config);
+    }
+  }
+
+  private validateVectorDimension(dim: number): void {
+    if (typeof dim !== "number" || !Number.isInteger(dim) || dim < 1) {
+      throw new StoreError(
+        `Invalid embeddings.vectorDimension: ${dim}. Must be a positive integer.`,
+      );
+    }
+  }
+
+  private throwEmbeddingInitializationError(
+    error: unknown,
+    config: EmbeddingModelConfig,
+  ): never {
+    if (error instanceof Error) {
+      if (
+        error.message.includes("does not exist") ||
+        error.message.includes("MODEL_NOT_FOUND")
+      ) {
+        throw new ModelConfigurationError(
+          `Invalid embedding model: ${config.model}\n` +
+            `   The model "${config.model}" is not available or you don't have access to it.\n` +
+            "   See README.md for supported models or run with --help for more details.",
+        );
+      }
+      if (
+        error.message.includes("API key") ||
+        error.message.includes("401") ||
+        error.message.includes("authentication")
+      ) {
+        throw new ModelConfigurationError(
+          `Authentication failed for ${config.provider} embedding provider\n` +
+            "   Please check your API key configuration.\n" +
+            "   See README.md for configuration options or run with --help for more details.",
+        );
+      }
+      if (
+        error.message.includes("timed out") ||
+        error.message.includes("ECONNREFUSED") ||
+        error.message.includes("ENOTFOUND") ||
+        error.message.includes("ETIMEDOUT") ||
+        error.message.includes("ECONNRESET") ||
+        error.message.includes("network") ||
+        error.message.includes("fetch failed")
+      ) {
+        throw new ModelConfigurationError(
+          `Failed to connect to ${config.provider} embedding service\n` +
+            `   ${error.message}\n` +
+            `   Please check that the embedding service is running and accessible.\n` +
+            `   If using a local model (e.g., Ollama), ensure the service is started.`,
+        );
+      }
+    }
+
+    throw error;
   }
 
   /**
@@ -833,21 +887,24 @@ export class DocumentStore {
         retryDelayMs: this.config.db.migrationRetryDelayMs,
       });
 
-      // 3. Check embedding model/dimension metadata for changes
+      // 3. Resolve the effective vector dimension before metadata checks or table DDL.
+      await this.resolveEffectiveEmbeddingDimension();
+
+      // 4. Check embedding model/dimension metadata for changes
       //    Uses inline db.prepare() so it works before prepareStatements().
       //    Throws EmbeddingModelChangedError if mismatch detected.
       //    The CLI layer catches this to prompt (TTY) or fail (non-interactive).
       this.checkEmbeddingModelChange();
 
-      // 4. Create vector table at runtime with configurable dimension
+      // 5. Create vector table at runtime with resolved dimension
       //    Must run before prepareStatements() because triggers on `documents`
       //    reference `documents_vec`.
       this.ensureVectorTable();
 
-      // 5. Initialize prepared statements (after vec table exists)
+      // 6. Initialize prepared statements (after vec table exists)
       this.prepareStatements();
 
-      // 6. Initialize embeddings client (await to catch errors)
+      // 7. Initialize embeddings client (await to catch errors)
       //    On success, persists model identity to metadata table.
       await this.initializeEmbeddings();
     } catch (error) {
@@ -873,7 +930,7 @@ export class DocumentStore {
    */
   async resolveModelChange(): Promise<void> {
     const currentModel = this.config.app.embeddingModel;
-    const currentDimension = this.config.embeddings.vectorDimension;
+    const currentDimension = this.dbDimension;
 
     // Invalidate all existing vectors and update metadata
     this.invalidateAllVectors(currentModel, currentDimension);
@@ -911,12 +968,8 @@ export class DocumentStore {
    * and are handled by the model change detection system (checkEmbeddingModelChange).
    */
   private ensureVectorTable(): void {
-    const dim = this.config.embeddings.vectorDimension;
-    if (typeof dim !== "number" || !Number.isInteger(dim) || dim < 1) {
-      throw new StoreError(
-        `Invalid embeddings.vectorDimension: ${dim}. Must be a positive integer.`,
-      );
-    }
+    const dim = this.dbDimension;
+    this.validateVectorDimension(dim);
 
     const existingSql = this.db
       .prepare(
@@ -1352,7 +1405,11 @@ export class DocumentStore {
 
     try {
       // Try to embed the batch normally
-      return await this.embeddings.embedDocuments(texts);
+      const embeddings = this.embeddings;
+      if (embeddings === null) {
+        throw new StoreError("Embeddings are not initialized");
+      }
+      return await embeddings.embedDocuments(texts);
     } catch (error) {
       // Check if this is a size-related error
       if (this.isInputSizeError(error)) {
@@ -1806,7 +1863,7 @@ export class DocumentStore {
 
       const { id: versionId } = versionRow;
 
-      if (this.isVectorSearchEnabled) {
+      if (this.isVectorSearchEnabled && this.embeddings !== null) {
         // Hybrid search: vector + full-text search with RRF ranking
         const rawEmbedding = await this.embeddings.embedQuery(query);
         const embedding = this.padVector(rawEmbedding);

--- a/src/store/DocumentStore.ts
+++ b/src/store/DocumentStore.ts
@@ -510,6 +510,21 @@ export class DocumentStore {
     stmt.run("embedding_dimension", String(dimension));
   }
 
+  private getStoredDimensionForCurrentModel(): number | null {
+    const config = this.embeddingConfig;
+    if (!config) {
+      return null;
+    }
+
+    const stored = this.getEmbeddingMetadata();
+    if (stored.model !== config.modelSpec || stored.dimension === null) {
+      return null;
+    }
+
+    const dimension = Number(stored.dimension);
+    return Number.isInteger(dimension) && dimension >= 1 ? dimension : null;
+  }
+
   /**
    * Compares the configured embedding model and dimension against stored metadata.
    * Throws EmbeddingModelChangedError if either has changed since the last run.
@@ -537,7 +552,7 @@ export class DocumentStore {
       return;
     }
 
-    const currentModel = this.config.app.embeddingModel;
+    const currentModel = this.embeddingConfig.modelSpec;
     const currentDimension = String(this.dbDimension);
 
     const modelChanged = stored.model !== currentModel;
@@ -696,7 +711,9 @@ export class DocumentStore {
     }
   }
 
-  private async resolveEffectiveEmbeddingDimension(): Promise<void> {
+  private async resolveEffectiveEmbeddingDimension(
+    options: { ignoreStoredMetadata?: boolean } = {},
+  ): Promise<void> {
     this.validateVectorDimension(this.dbDimension);
 
     if (this.embeddingConfig === null || this.embeddingConfig === undefined) {
@@ -709,6 +726,33 @@ export class DocumentStore {
     }
 
     try {
+      const storedDimension = options.ignoreStoredMetadata
+        ? null
+        : this.getStoredDimensionForCurrentModel();
+      if (storedDimension !== null) {
+        if (!isVectorDimensionExplicit(this.config)) {
+          this.dbDimension = storedDimension;
+        }
+        this.modelDimension = this.dbDimension;
+        logger.debug(
+          `Vector dimension loaded from metadata: ${this.dbDimension} for ${config.provider}:${config.model}`,
+        );
+        return;
+      }
+
+      const stored = this.getEmbeddingMetadata();
+      if (
+        !options.ignoreStoredMetadata &&
+        stored.model !== null &&
+        stored.model !== config.modelSpec
+      ) {
+        if (!isVectorDimensionExplicit(this.config) && config.dimensions !== null) {
+          this.dbDimension = config.dimensions;
+          this.modelDimension = config.dimensions;
+        }
+        return;
+      }
+
       let nativeDimension = config.dimensions;
 
       if (nativeDimension === null) {
@@ -929,6 +973,8 @@ export class DocumentStore {
    * completed here after invalidation.
    */
   async resolveModelChange(): Promise<void> {
+    await this.resolveEffectiveEmbeddingDimension({ ignoreStoredMetadata: true });
+
     const currentModel = this.config.app.embeddingModel;
     const currentDimension = this.dbDimension;
 

--- a/src/store/DocumentStore.ts
+++ b/src/store/DocumentStore.ts
@@ -747,6 +747,10 @@ export class DocumentStore {
         stored.model !== config.modelSpec
       ) {
         if (!isVectorDimensionExplicit(this.config) && config.dimensions !== null) {
+          this.validateDetectedVectorDimension(
+            config.dimensions,
+            "known model dimension lookup",
+          );
           this.dbDimension = config.dimensions;
           this.modelDimension = config.dimensions;
         }
@@ -754,10 +758,17 @@ export class DocumentStore {
       }
 
       let nativeDimension = config.dimensions;
+      let nativeDimensionSource = "known model dimension lookup";
 
       if (nativeDimension === null) {
         this.embeddings = this.createEmbeddingClient(this.dbDimension);
         nativeDimension = await this.detectEmbeddingDimension(this.embeddings);
+        nativeDimensionSource = "embedding provider probe";
+      }
+
+      this.validateDetectedVectorDimension(nativeDimension, nativeDimensionSource);
+
+      if (config.dimensions === null) {
         EmbeddingConfig.setKnownModelDimensions(config.model, nativeDimension);
       }
 
@@ -778,6 +789,14 @@ export class DocumentStore {
     if (typeof dim !== "number" || !Number.isInteger(dim) || dim < 1) {
       throw new StoreError(
         `Invalid embeddings.vectorDimension: ${dim}. Must be a positive integer.`,
+      );
+    }
+  }
+
+  private validateDetectedVectorDimension(dim: number, source: string): void {
+    if (typeof dim !== "number" || !Number.isInteger(dim) || dim < 1) {
+      throw new StoreError(
+        `Invalid detected embedding dimension from ${source}: ${dim}. Must be a positive integer.`,
       );
     }
   }

--- a/src/store/embeddings/EmbeddingConfig.test.ts
+++ b/src/store/embeddings/EmbeddingConfig.test.ts
@@ -98,6 +98,40 @@ describe("EmbeddingConfig", () => {
       expect(config.getKnownDimensions("TEXT-EMBEDDING-3-SMALL")).toBe(1536);
       expect(config.getKnownDimensions("Text-Embedding-3-Small")).toBe(1536);
     });
+
+    it("should resolve common OpenAI-compatible hosted model aliases", () => {
+      const config = new EmbeddingConfig();
+
+      expect(config.getKnownDimensions("text-embedding-multilingual-e5-large")).toBe(
+        1024,
+      );
+      expect(
+        config.getKnownDimensions("keisuke-miyako/text-embedding-nomic-embed-text-v1.5"),
+      ).toBe(768);
+      expect(config.getKnownDimensions("nomic-embed-text-v1.5")).toBe(768);
+    });
+
+    it("should require runtime detection for variable-dimension MRL entries", () => {
+      const config = new EmbeddingConfig();
+
+      expect(config.getKnownDimensions("NovaSearch/stella_en_1.5B_v5")).toBeNull();
+      expect(config.getKnownDimensions("NovaSearch/stella_en_400M_v5")).toBeNull();
+      expect(config.getKnownDimensions("dunzhang/stella_en_400M_v5")).toBeNull();
+      expect(config.getKnownDimensions("NovaSearch/jasper_en_vision_language_v1")).toBe(
+        null,
+      );
+    });
+
+    it("should include current provider embedding models from upstream", () => {
+      const config = new EmbeddingConfig();
+
+      expect(config.getKnownDimensions("text-embedding-005")).toBe(768);
+      expect(config.getKnownDimensions("Cohere/Cohere-embed-v4.0")).toBe(1536);
+      expect(config.getKnownDimensions("voyage-4-large")).toBe(1024);
+      expect(config.getKnownDimensions("voyage-3.5")).toBe(1024);
+      expect(config.getKnownDimensions("nomic-ai/nomic-embed-text-v2-moe")).toBe(768);
+      expect(config.getKnownDimensions("nomic-ai/nomic-embed-code")).toBe(3584);
+    });
   });
 
   describe("setKnownDimensions", () => {

--- a/src/store/embeddings/EmbeddingConfig.ts
+++ b/src/store/embeddings/EmbeddingConfig.ts
@@ -75,6 +75,7 @@ export class EmbeddingConfig {
 
     // Google Vertex AI models
     "text-embedding-004": 768,
+    "text-embedding-005": 768,
     "textembedding-gecko@003": 768,
     "textembedding-gecko@002": 768,
     "textembedding-gecko@001": 768,
@@ -93,9 +94,13 @@ export class EmbeddingConfig {
     // Cohere models
     "cohere.embed-english-v3": 1024,
     "cohere.embed-multilingual-v3": 1024,
+    "Cohere/Cohere-embed-v4.0": 1536,
+    "embed-v4.0": 1536,
 
     // SageMaker models (hosted on AWS SageMaker)
     "intfloat/multilingual-e5-large": 1024,
+    "multilingual-e5-large": 1024,
+    "text-embedding-multilingual-e5-large": 1024,
 
     // Additional AWS models that might be supported
     // Note: Some of these might be placeholders - verify dimensions before use
@@ -138,6 +143,12 @@ export class EmbeddingConfig {
     "intfloat/multilingual-e5-base": 768,
     "voyage-3-lite": 512,
     "voyage-3": 1024,
+    "voyage-3-large": 1024,
+    "voyage-3.5": 1024,
+    "voyage-4": 1024,
+    "voyage-4-large": 1024,
+    "voyage-4-lite": 1024,
+    "voyage-code-3": 1024,
     "intfloat/multilingual-e5-small": 384,
     "Alibaba-NLP/gte-Qwen1.5-7B-instruct": 4096,
     "Snowflake/snowflake-arctic-embed-m-v2.0": 768,
@@ -158,7 +169,11 @@ export class EmbeddingConfig {
     "avsolatorio/GIST-large-Embedding-v0": 1024,
     "sdadas/mmlw-e5-large": 1024,
     "nomic-ai/nomic-embed-text-v1": 768,
+    "nomic-embed-text-v1": 768,
     "nomic-ai/nomic-embed-text-v1-ablated": 768,
+    "nomic-ai/nomic-embed-text-v2-moe": 768,
+    "nomic-ai/modernbert-embed-base": 768,
+    "nomic-ai/nomic-embed-code": 3584,
     "intfloat/e5-base-v2": 768,
     "BAAI/bge-large-en-v1.5": 1024,
     "intfloat/e5-large": 1024,
@@ -179,6 +194,8 @@ export class EmbeddingConfig {
     "avsolatorio/GIST-small-Embedding-v0": 384,
     "sdadas/mmlw-roberta-large": 1024,
     "nomic-ai/nomic-embed-text-v1.5": 768,
+    "nomic-embed-text-v1.5": 768,
+    "text-embedding-nomic-embed-text-v1.5": 768,
     "minishlab/potion-multilingual-128M": 256,
     "shibing624/text2vec-base-multilingual": 384,
     "thenlper/gte-base": 768,
@@ -259,6 +276,16 @@ export class EmbeddingConfig {
     "jinaai/jina-embeddings-v4": 2048,
   };
 
+  private readonly runtimeDetectedDimensionModels = new Set([
+    "novasearch/stella_en_1.5b_v5",
+    "stella_en_1.5b_v5",
+    "novasearch/stella_en_400m_v5",
+    "dunzhang/stella_en_400m_v5",
+    "stella_en_400m_v5",
+    "novasearch/jasper_en_vision_language_v1",
+    "jasper_en_vision_language_v1",
+  ]);
+
   /**
    * Lowercase lookup map for case-insensitive model dimension queries.
    * Built lazily from knownModelDimensions to ensure consistency.
@@ -270,6 +297,29 @@ export class EmbeddingConfig {
     for (const [model, dimensions] of Object.entries(this.knownModelDimensions)) {
       this.modelLookup.set(model.toLowerCase(), dimensions);
     }
+  }
+
+  private findKnownDimension(model: string): number | null {
+    const normalized = model.toLowerCase();
+    if (this.runtimeDetectedDimensionModels.has(normalized)) {
+      return null;
+    }
+
+    const exact = this.modelLookup?.get(normalized);
+    if (exact !== undefined) {
+      return exact;
+    }
+
+    const slashIndex = normalized.lastIndexOf("/");
+    if (slashIndex !== -1) {
+      const suffix = normalized.substring(slashIndex + 1);
+      if (this.runtimeDetectedDimensionModels.has(suffix)) {
+        return null;
+      }
+      return this.modelLookup?.get(suffix) ?? null;
+    }
+
+    return null;
   }
 
   /**
@@ -307,7 +357,7 @@ export class EmbeddingConfig {
     }
 
     // Look up known dimensions (case-insensitive)
-    const dimensions = this.modelLookup?.get(model.toLowerCase()) || null;
+    const dimensions = this.findKnownDimension(model);
 
     return {
       provider,
@@ -326,7 +376,7 @@ export class EmbeddingConfig {
    * @returns Known dimensions or null
    */
   getKnownDimensions(model: string): number | null {
-    return this.modelLookup?.get(model.toLowerCase()) || null;
+    return this.findKnownDimension(model);
   }
 
   /**

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -2,12 +2,15 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import yaml from "yaml";
 import { expandConfiguredRoot } from "./accessPolicy";
 import {
   camelToUpperSnake,
   collectLeafPaths,
+  defaults,
   getConfigValue,
   isValidConfigPath,
+  isVectorDimensionExplicit,
   loadConfig,
   parseConfigValue,
   pathToEnvVar,
@@ -17,8 +20,8 @@ import { normalizeEnvValue } from "./env";
 // Mock env-paths to return a controlled system path
 vi.mock("env-paths", () => ({
   default: () => ({
-    config: "/system/config-mock",
-    data: "/system/data-mock",
+    config: `${process.cwd()}/.vitest-config-mock`,
+    data: `${process.cwd()}/.vitest-data-mock`,
   }),
 }));
 
@@ -35,6 +38,10 @@ describe("Configuration Loading", () => {
     // Create temp directory for each test
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "docs-mcp-config-test-"));
     originalEnv = { ...process.env };
+    fs.rmSync(path.join(process.cwd(), ".vitest-config-mock"), {
+      recursive: true,
+      force: true,
+    });
 
     // Clear relevant env vars
     delete process.env.DOCS_MCP_CONFIG;
@@ -42,75 +49,27 @@ describe("Configuration Loading", () => {
     delete process.env.DOCS_MCP_READ_ONLY;
     delete process.env.DOCS_MCP_STORE_PATH;
     delete process.env.DOCS_MCP_AUTH_ENABLED;
-
-    // Redefine system paths to point to our temp dir for testing
-    // Note: We can't easily re-mock env-paths per test because imports are cached.
-    // Instead, we'll use `config.test.ts` logic to simulate system path behavior
-    // by manually ensuring directories exist or passing strict paths.
-
-    // However, the `systemPaths` constant in `config.ts` is initialized at module load time.
-    // To test "system default" behavior properly without writing to actua system paths,
-    // we must ensure `env-paths` returns a path inside `tmpDir` OR we rely on `loadConfig` options.
-    // Since `env-paths` mock relies on static string return, we effectively can't dynamicall change it per test easily.
-
-    // WORKAROUND: We will assume the `env-paths` mock returns "/system/config-mock".
-    // Since we are now using REAL FS, writing to "/system/config-mock" will fail (EACCES or ENOENT).
-    // so we CANNOT test the "default fallback writes to system path" unless we stub proper FS or use `options.searchDir`.
-
-    // Actually, checking `config.ts`:
-    // `const systemPaths = envPaths(...)` is top-level.
-
-    // FOR MERGED TESTING WITH REAL FS:
-    // We should rely on `options.searchDir` for almost everything to keep it safe.
-    // For the specific test "write to system path", we might need to skip or mock `fs` JUST for that test?
-    // Mixing mocked/real fs is hard.
-
-    // ALTERNATIVE: We update the `env-paths` mock to standard `tmpDir`?
-    // No, `tmpDir` changes per test.
-
-    // Let's rely on the strategy of using `options.searchDir` which is what we added in the previous steps.
   });
 
   afterEach(() => {
     // Cleanup
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(path.join(process.cwd(), ".vitest-config-mock"), {
+      recursive: true,
+      force: true,
+    });
     process.env = originalEnv;
     vi.resetAllMocks();
   });
 
   describe("Integration & E2E Scenarios", () => {
     it("should load system defaults and WRITE back when no config provided", () => {
-      // Setup: ensure system config path exists
-      const systemConfigDir = path.join(tmpDir, "system-config-mock");
-      fs.mkdirSync(systemConfigDir, { recursive: true });
-
-      // Mock env-paths to return this temp dir
-      // We can't re-mock, but we can rely on our top-level mock if we can control it?
-      // The top-level mock returns "/system/config-mock".
-      // Since we can't easily change the mock, let's just spy on fs.readFileSync/writeFileSync?
-      // OR, we can use the `configPath` option to simulate "determined system path" if we exposed it, but we don't.
-
-      // Better approach for unit validation:
-      // Since `systemPaths` is hardcoded in the module scope based on the mock,
-      // we can't easily integrate-test the "default path" selection without creating that directory.
-
-      // Let's rely on the fact that `config.ts` imports `env-paths` and we mocked it.
-      // We need to make sure the mocked path is writable.
-      // The mock returns `/system/config-mock`. We can't write there.
-
-      // For this test file, we should probably mock `fs` methods related to the config file
-      // OR mock the `systemPaths` used in `config.ts`? No, that's internal.
-
-      // Strategy:
-      // We will rely on explicit options being passed to `loadConfig` for most tests.
-      // For the "default" case, we accept that it tries to write to `/system/config-mock`
-      // and logs a warning (which we can suppress or inspect).
-
       const config = loadConfig({}, {}); // No args -> Default System Path
 
       expect(config.server.host).toBe("127.0.0.1");
-      // loadConfig should not throw even when the default system config path
-      // is unwritable; it should fall back to in-memory defaults.
+      expect(
+        fs.existsSync(path.join(process.cwd(), ".vitest-config-mock", "config.yaml")),
+      ).toBe(true);
     });
 
     it("should load explicit config from --config and NOT write back", () => {
@@ -567,6 +526,70 @@ describe("Auto-generated Environment Variable Overrides", () => {
     expect(() =>
       loadConfig({}, { configPath: path.join(tmpDir, "dim-neg.yaml") }),
     ).toThrow();
+  });
+
+  describe("embeddings.vectorDimension explicitness", () => {
+    const systemConfigPath = () =>
+      path.join(process.cwd(), ".vitest-config-mock", "config.yaml");
+
+    it("omits generated default vectorDimension from the managed default config", () => {
+      const config = loadConfig({}, {});
+      const content = fs.readFileSync(systemConfigPath(), "utf8");
+      const parsed = yaml.parse(content) as {
+        embeddings?: { vectorDimension?: unknown };
+      };
+
+      expect(isVectorDimensionExplicit(config)).toBe(false);
+      expect(parsed.embeddings?.vectorDimension).toBeUndefined();
+      expect(content).toContain("docs-mcp-server-managed-vector-dimension-omitted");
+    });
+
+    it("treats a default vectorDimension in a managed config as explicit", () => {
+      loadConfig({}, {});
+      const generated = fs.readFileSync(systemConfigPath(), "utf8");
+      const marker = generated
+        .split("\n")
+        .filter((line) => line.startsWith("#"))
+        .join("\n");
+      fs.writeFileSync(
+        systemConfigPath(),
+        `${marker}\nembeddings:\n  vectorDimension: ${defaults.embeddings.vectorDimension}\n`,
+      );
+
+      const config = loadConfig({}, {});
+
+      expect(config.embeddings.vectorDimension).toBe(defaults.embeddings.vectorDimension);
+      expect(isVectorDimensionExplicit(config)).toBe(true);
+      expect(fs.readFileSync(systemConfigPath(), "utf8")).toContain("vectorDimension");
+    });
+
+    it("migrates legacy generated default vectorDimension to implicit omission", () => {
+      fs.mkdirSync(path.dirname(systemConfigPath()), { recursive: true });
+      fs.writeFileSync(systemConfigPath(), yaml.stringify(defaults));
+
+      const config = loadConfig({}, {});
+      const content = fs.readFileSync(systemConfigPath(), "utf8");
+      const parsed = yaml.parse(content) as {
+        embeddings?: { vectorDimension?: unknown };
+      };
+
+      expect(isVectorDimensionExplicit(config)).toBe(false);
+      expect(parsed.embeddings?.vectorDimension).toBeUndefined();
+      expect(content).toContain("docs-mcp-server-managed-vector-dimension-omitted");
+    });
+
+    it("treats a user-authored default vectorDimension as explicit", () => {
+      fs.mkdirSync(path.dirname(systemConfigPath()), { recursive: true });
+      fs.writeFileSync(
+        systemConfigPath(),
+        `embeddings:\n  vectorDimension: ${defaults.embeddings.vectorDimension}\n`,
+      );
+
+      const config = loadConfig({}, {});
+
+      expect(config.embeddings.vectorDimension).toBe(defaults.embeddings.vectorDimension);
+      expect(isVectorDimensionExplicit(config)).toBe(true);
+    });
   });
 
   it("loads scraper security defaults", () => {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -6,6 +6,16 @@ import { z } from "zod";
 import { normalizeEnvValue } from "./env";
 import { logger } from "./logger";
 
+const managedConfigVectorDimensionOmissionMarker =
+  "docs-mcp-server-managed-vector-dimension-omitted";
+const managedConfigHeader = [
+  `# ${managedConfigVectorDimensionOmissionMarker}`,
+  "# embeddings.vectorDimension is omitted when it comes from generated defaults.",
+  "# Add embeddings.vectorDimension explicitly to override native model dimensions.",
+  "",
+].join("\n");
+const vectorDimensionPath = ["embeddings", "vectorDimension"];
+
 const envStringArray = z
   .union([z.array(z.string()), z.string()])
   .transform((value) => {
@@ -472,20 +482,13 @@ export function loadConfig(
 
   // 2. Load Config File (if exists) or use empty object
   const fileConfig = loadConfigFile(configPath) || {};
+  const hasManagedVectorDimensionOmissionMarker =
+    hasManagedConfigVectorDimensionOmissionMarker(configPath);
 
   // 3. Merge Defaults < File
   const baseConfig = deepMerge(defaults, fileConfig) as ConfigObject;
 
-  // 4. Write back to file (Auto-Update) - ONLY if using default path
-  if (!isReadOnlyConfig) {
-    try {
-      saveConfigFile(configPath, baseConfig);
-    } catch (error) {
-      logger.warn(`Failed to save config file to ${configPath}: ${error}`);
-    }
-  }
-
-  // 5. Map Env Vars and CLI Args
+  // 4. Map Env Vars and CLI Args
   const envConfig = mapEnvToConfig();
   const cliConfig = mapCliToConfig(cliArgs);
   const vectorDimensionWasExplicit = wasVectorDimensionExplicit(
@@ -493,7 +496,27 @@ export function loadConfig(
     envConfig,
     cliConfig,
     isReadOnlyConfig,
+    hasManagedVectorDimensionOmissionMarker,
   );
+  const fileVectorDimensionWasExplicit = wasVectorDimensionExplicit(
+    fileConfig,
+    {},
+    {},
+    isReadOnlyConfig,
+    hasManagedVectorDimensionOmissionMarker,
+  );
+
+  // 5. Write back to file (Auto-Update) - ONLY if using default path
+  if (!isReadOnlyConfig) {
+    try {
+      saveConfigFile(configPath, baseConfig, {
+        managedDefaultConfig: true,
+        omitVectorDimension: !fileVectorDimensionWasExplicit,
+      });
+    } catch (error) {
+      logger.warn(`Failed to save config file to ${configPath}: ${error}`);
+    }
+  }
 
   // 6. Merge: Base < Env < CLI
   const mergedInput = deepMerge(
@@ -549,16 +572,31 @@ export function loadConfig(
   const fallback = AppConfigSchema.parse(fallbackInput);
   const fallbackConfig = markVectorDimensionSource(
     fallback as AppConfig,
-    wasVectorDimensionExplicit({}, envConfig, cliConfig, false),
+    wasVectorDimensionExplicit({}, envConfig, cliConfig, false, false),
   );
   if (!isReadOnlyConfig) {
     try {
-      saveConfigFile(configPath, fallbackConfig as unknown as ConfigObject);
+      saveConfigFile(configPath, fallbackConfig as unknown as ConfigObject, {
+        managedDefaultConfig: true,
+        omitVectorDimension: true,
+      });
     } catch (error) {
       logger.warn(`Failed to write fresh config file ${configPath}: ${error}`);
     }
   }
   return fallbackConfig;
+}
+
+function hasManagedConfigVectorDimensionOmissionMarker(filePath: string): boolean {
+  if (!fs.existsSync(filePath)) return false;
+
+  try {
+    return fs
+      .readFileSync(filePath, "utf8")
+      .includes(managedConfigVectorDimensionOmissionMarker);
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -605,35 +643,75 @@ function wasVectorDimensionExplicit(
   envConfig: ConfigObject,
   cliConfig: ConfigObject,
   isReadOnlyConfig: boolean,
+  hasManagedVectorDimensionOmissionMarker: boolean,
 ): boolean {
-  const pathArr = ["embeddings", "vectorDimension"];
   if (
-    getAtPath(envConfig, pathArr) !== undefined ||
-    getAtPath(cliConfig, pathArr) !== undefined
+    getAtPath(envConfig, vectorDimensionPath) !== undefined ||
+    getAtPath(cliConfig, vectorDimensionPath) !== undefined
   ) {
     return true;
   }
 
-  const fileValue = getAtPath(fileConfig, pathArr);
+  const fileValue = getAtPath(fileConfig, vectorDimensionPath);
   if (fileValue === undefined) {
     return false;
   }
 
-  return isReadOnlyConfig || fileValue !== DEFAULT_CONFIG.embeddings.vectorDimension;
+  if (
+    isReadOnlyConfig ||
+    fileValue !== DEFAULT_CONFIG.embeddings.vectorDimension ||
+    hasManagedVectorDimensionOmissionMarker
+  ) {
+    return true;
+  }
+
+  return !looksLikeLegacyGeneratedEmbeddingDefaults(fileConfig);
 }
 
-function saveConfigFile(filePath: string, config: Record<string, unknown>): void {
+function looksLikeLegacyGeneratedEmbeddingDefaults(fileConfig: ConfigObject): boolean {
+  const embeddings = fileConfig.embeddings;
+  if (
+    typeof embeddings !== "object" ||
+    embeddings === null ||
+    Array.isArray(embeddings)
+  ) {
+    return false;
+  }
+
+  return Object.keys(DEFAULT_CONFIG.embeddings).every((key) =>
+    Object.hasOwn(embeddings, key),
+  );
+}
+
+interface SaveConfigOptions {
+  managedDefaultConfig?: boolean;
+  omitVectorDimension?: boolean;
+}
+
+function saveConfigFile(
+  filePath: string,
+  config: Record<string, unknown>,
+  options: SaveConfigOptions = {},
+): void {
   const dir = path.dirname(filePath);
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
 
+  const configToWrite = cloneConfigValue(config) as ConfigObject;
+  if (options.omitVectorDimension) {
+    unsetAtPath(configToWrite, vectorDimensionPath);
+  }
+
   let content: string;
   if (filePath.endsWith(".json")) {
-    content = JSON.stringify(config, null, 2);
+    content = JSON.stringify(configToWrite, null, 2);
   } else {
     // Default to YAML
-    content = yaml.stringify(config);
+    content = yaml.stringify(configToWrite);
+    if (options.managedDefaultConfig) {
+      content = `${managedConfigHeader}${content}`;
+    }
   }
 
   logger.debug(`Updating config file at ${filePath}`);
@@ -743,6 +821,36 @@ function getAtPath(obj: ConfigObject, pathArr: string[]): unknown {
     current = (current as ConfigObject)[key];
   }
   return current;
+}
+
+function unsetAtPath(obj: ConfigObject, pathArr: string[]): void {
+  let current: unknown = obj;
+  for (const key of pathArr.slice(0, -1)) {
+    if (typeof current !== "object" || current === null) {
+      return;
+    }
+    current = (current as ConfigObject)[key];
+  }
+
+  if (typeof current === "object" && current !== null) {
+    delete (current as ConfigObject)[pathArr[pathArr.length - 1]];
+  }
+}
+
+function cloneConfigValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneConfigValue(item));
+  }
+
+  if (typeof value === "object" && value !== null) {
+    const output: ConfigObject = {};
+    for (const [key, child] of Object.entries(value)) {
+      output[key] = cloneConfigValue(child);
+    }
+    return output;
+  }
+
+  return value;
 }
 
 function deepMerge(target: unknown, source: unknown): unknown {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -369,10 +369,18 @@ export const AppConfigSchema = z.object({
     .default(DEFAULT_CONFIG.assembly),
 });
 
-export type AppConfig = z.infer<typeof AppConfigSchema>;
+const vectorDimensionExplicit = Symbol("vectorDimensionExplicit");
+
+type ParsedAppConfig = z.infer<typeof AppConfigSchema>;
+
+export type AppConfig = Omit<ParsedAppConfig, "embeddings"> & {
+  embeddings: ParsedAppConfig["embeddings"] & {
+    [vectorDimensionExplicit]?: boolean;
+  };
+};
 
 // Get defaults from the schema
-export const defaults = AppConfigSchema.parse({});
+export const defaults = AppConfigSchema.parse({}) as AppConfig;
 
 // --- Mapping Configuration ---
 // Maps flat env vars and CLI args to the nested config structure
@@ -480,6 +488,12 @@ export function loadConfig(
   // 5. Map Env Vars and CLI Args
   const envConfig = mapEnvToConfig();
   const cliConfig = mapCliToConfig(cliArgs);
+  const vectorDimensionWasExplicit = wasVectorDimensionExplicit(
+    fileConfig,
+    envConfig,
+    cliConfig,
+    isReadOnlyConfig,
+  );
 
   // 6. Merge: Base < Env < CLI
   const mergedInput = deepMerge(
@@ -494,7 +508,10 @@ export function loadConfig(
 
   const parseResult = AppConfigSchema.safeParse(mergedInput);
   if (parseResult.success) {
-    return parseResult.data;
+    return markVectorDimensionSource(
+      parseResult.data as AppConfig,
+      vectorDimensionWasExplicit,
+    );
   }
 
   // The file on disk is structurally wrong (e.g., array fields saved as
@@ -530,14 +547,41 @@ export function loadConfig(
     setAtPath(fallbackInput, ["app", "embeddingModel"], "text-embedding-3-small");
   }
   const fallback = AppConfigSchema.parse(fallbackInput);
+  const fallbackConfig = markVectorDimensionSource(
+    fallback as AppConfig,
+    wasVectorDimensionExplicit({}, envConfig, cliConfig, false),
+  );
   if (!isReadOnlyConfig) {
     try {
-      saveConfigFile(configPath, fallback as unknown as ConfigObject);
+      saveConfigFile(configPath, fallbackConfig as unknown as ConfigObject);
     } catch (error) {
       logger.warn(`Failed to write fresh config file ${configPath}: ${error}`);
     }
   }
-  return fallback;
+  return fallbackConfig;
+}
+
+/**
+ * Returns true when the embedding vector dimension was set by user config,
+ * environment, or CLI rather than coming from generated defaults.
+ */
+export function isVectorDimensionExplicit(config: AppConfig): boolean {
+  return config.embeddings[vectorDimensionExplicit] === true;
+}
+
+/**
+ * Marks an AppConfig as having an explicit or default-derived vector dimension.
+ */
+export function markVectorDimensionSource(
+  config: AppConfig,
+  explicit: boolean,
+): AppConfig {
+  Object.defineProperty(config.embeddings, vectorDimensionExplicit, {
+    value: explicit,
+    enumerable: false,
+    configurable: true,
+  });
+  return config;
 }
 
 function loadConfigFile(filePath: string): Record<string, unknown> | null {
@@ -548,11 +592,34 @@ function loadConfigFile(filePath: string): Record<string, unknown> | null {
     if (filePath.endsWith(".json")) {
       return JSON.parse(content);
     }
+
     return yaml.parse(content) || {};
   } catch (error) {
     logger.warn(`Failed to parse config file ${filePath}: ${error}`);
     return null;
   }
+}
+
+function wasVectorDimensionExplicit(
+  fileConfig: ConfigObject,
+  envConfig: ConfigObject,
+  cliConfig: ConfigObject,
+  isReadOnlyConfig: boolean,
+): boolean {
+  const pathArr = ["embeddings", "vectorDimension"];
+  if (
+    getAtPath(envConfig, pathArr) !== undefined ||
+    getAtPath(cliConfig, pathArr) !== undefined
+  ) {
+    return true;
+  }
+
+  const fileValue = getAtPath(fileConfig, pathArr);
+  if (fileValue === undefined) {
+    return false;
+  }
+
+  return isReadOnlyConfig || fileValue !== DEFAULT_CONFIG.embeddings.vectorDimension;
 }
 
 function saveConfigFile(filePath: string, config: Record<string, unknown>): void {


### PR DESCRIPTION
Unknown and variable-dimension OpenAI-compatible embedding models could create vector storage using a configured/default dimension instead of the provider's actual output shape. This PR resolves one effective dimension before vector table creation, metadata checks, and embedding initialization so storage and model metadata stay consistent.

Highlights:
- Track explicit `embeddings.vectorDimension` overrides separately from generated defaults.
- Use known dimensions for stable fixed-output models, but runtime-probe unknown and variable-dimension models such as Stella/Jasper entries.
- Apply the resolved dimension consistently to `documents_vec`, metadata persistence, model-change checks, normalization, and validation.
- Reject unsafe oversized non-MRL vectors instead of silently truncating them.
- Add OpenSpec artifacts, docs, and regression coverage for custom, explicit override, and variable-dimension cases.

Fixes #429