### PR TITLE
ci: upgrade github actions to node24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22.x" # Match engines requirement in package.json
           cache: "npm"
@@ -35,10 +35,10 @@ jobs:
     needs: lint # Run after linting passes
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22.x"
           cache: "npm"
@@ -58,10 +58,10 @@ jobs:
     needs: test # Run after tests pass
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22.x"
           cache: "npm"
@@ -78,10 +78,10 @@ jobs:
     needs: build # Only run once unit tests + build pass
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22.x"
           cache: "npm"
@@ -90,10 +90,10 @@ jobs:
         run: npm ci
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -37,9 +37,9 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22.x"
           cache: "npm"
@@ -53,7 +53,7 @@ jobs:
       # to dataset.yaml or when source docs have changed substantially).
       - name: Restore docs store cache
         id: store-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/docs-mcp-server
           key: docs-store-v1-${{ hashFiles('tests/search-eval/dataset.yaml') }}
@@ -90,7 +90,7 @@ jobs:
       # regression — we want the data either way.
       - name: Upload summary
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: search-eval-summary-${{ github.run_id }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,12 @@ jobs:
       - name: Checkout code
         # Need fetch-depth: 0 for semantic-release to analyze all relevant commits
         # and commit package.json/CHANGELOG.md changes
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22.x" # Match engines requirement in package.json
           registry-url: "https://registry.npmjs.org" # Specify npm registry
@@ -61,7 +61,7 @@ jobs:
       - name: Determine next version (dry-run)
         id: semantic-dry
         if: steps.release-mode.outputs.manual_release != 'true'
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@v6
         with:
           dry_run: true
         env:
@@ -78,7 +78,7 @@ jobs:
       - name: Run semantic-release
         id: semantic # Give step an ID to reference its outputs
         if: steps.release-mode.outputs.manual_release != 'true'
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -110,7 +110,7 @@ jobs:
 
       - name: Create GitHub release (manual)
         if: steps.release-mode.outputs.manual_release == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.release-mode.outputs.release_version }}
           generate_release_notes: true
@@ -143,16 +143,16 @@ jobs:
     steps:
       - name: Checkout code
         # Checkout the specific commit tagged by semantic-release
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Use the tag name determined by the release job
           ref: v${{ needs.release.outputs.new_release_version }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -160,7 +160,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           # Use the version from the semantic-release output
@@ -173,7 +173,7 @@ jobs:
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -186,7 +186,7 @@ jobs:
             POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v4
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push.outputs.digest }}


### PR DESCRIPTION
## Why

GitHub is retiring the `node20` action runtime. An audit of our three workflows found that **every** JS-based action we pin currently executes on `node20`, so the whole CI surface is on the deprecated runtime today. This bumps each action to its latest major to move them onto the `node24` runtime before the deprecation bites.

## What changed

Bumped 11 actions across `ci.yml`, `release.yml`, and `eval.yml`:

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-node | v4 | v6 |
| actions/cache | v4 | v5 |
| actions/upload-artifact | v4 | v7 |
| docker/setup-buildx-action | v3 | v4 |
| docker/login-action | v3 | v4 |
| docker/metadata-action | v5 | v6 |
| docker/build-push-action | v6 | v7 |
| softprops/action-gh-release | v2 | v3 |
| actions/attest-build-provenance | v1 | v4 |
| cycjimmy/semantic-release-action | v4 | v6 |

## Notes for reviewers

- **This is purely the action execution runtime, not our app's Node.** `node-version: "22.x"`, `.nvmrc`, the `node:22` Docker base, and `engines: ">=22"` are all intentionally unchanged. We stay on Node 22 because `better-sqlite3` ships an ABI-pinned native binary.
- **`semantic-release-action` v4 -> v6** is the only bump with a meaningful payload change: v6 bundles semantic-release 25. This aligns the action with the `semantic-release@^25` already declared in `package.json` devDependencies, so there is no config migration. `release.yml` only runs on `workflow_dispatch`, so it is not exercised by this PR; the dry-run step validates the path before anything publishes.
- `ci.yml` and `eval.yml` exercise the bumped actions automatically on this PR.