### PR TITLE
feat: scrape quality gates — classify outcome and roll back unusable indexes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -248,6 +248,16 @@ The pipeline system manages asynchronous job processing with persistent state an
 
 Job states progress through: QUEUED → RUNNING → COMPLETED/FAILED/CANCELLED. All state transitions persist to database and emit events, enabling both recovery after restart and real-time monitoring. See [Event Bus Architecture](docs/concepts/eventbus-architecture.md) for detailed event flow diagrams.
 
+#### Quality Gates
+
+Before promoting a finished job to `COMPLETED`, `PipelineManager` runs a quality gate at a single seam (the spot that previously set `COMPLETED` unconditionally). The gate classifies the scrape from its stored metrics and, on a failing verdict, discards the staged version and marks the job `FAILED` with a typed `errorCode` — a **gate-then-rollback** flow:
+
+1. **Classify** — `evaluateOutcome()` (a pure function in `src/pipeline/outcomeGate.ts`) maps `JobOutcomeMetrics` (document count, distinct URLs, in-scope ratio, expect-terms match) to a `ScrapeOutcome` and optional `ScrapeErrorCode`. Order: empty → thin → off-topic → scope-drift → indexed.
+2. **Relevance signals** — when the caller supplies `expectTerms`, `src/pipeline/relevanceGate.ts` computes a ref-agnostic in-scope URL ratio (`computeInScopeRatio`, aligning a GitHub `/tree/` root with its `/blob/` children) and samples stored chunks for the expected terms (`sampleExpectTermsMatch`). These relevance axes are opt-in for this release; `denyPaths` exclusions apply to every scrape.
+3. **Rollback** — on a non-`indexed` verdict the manager calls `removeVersion()` to delete the half-indexed docs, then rejects job completion with a `QualityGateError` carrying the remediation hint. **Refresh and append jobs (`isRefresh` / `clean === false`) skip the gate entirely** so a transient thin re-index can never wipe pre-existing good docs.
+
+The resulting `outcome` and `errorCode` are surfaced on the public `PipelineJob` and exposed through `get_job_info` and `list_jobs`. Error codes: `EMPTY_RESULT`, `THIN_RESULT`, `OFF_TOPIC`, `SCOPE_DRIFT`, `LOCALE_REDIRECT_LOOP` (cyclic locale redirect detected in `HttpFetcher`), and `GITHUB_SUBPATH_NOT_FOUND` (a GitHub `/tree/` subpath matched no files).
+
 ### Content Processing
 
 Content processing follows a modular strategy-pipeline-splitter architecture:

--- a/README.md
+++ b/README.md
@@ -155,6 +155,39 @@ See **[Embedding Models](docs/guides/embedding-models.md)** for configuring **Ol
 -   Web requests send `Accept: text/markdown, text/html;q=0.9, */*;q=0.8` by default. Servers that support Markdown content negotiation, including Cloudflare Markdown for Agents, can return Markdown directly so the scraper bypasses HTML-to-Markdown conversion for cleaner output.
 -   This behavior is automatic and requires no configuration. Custom `Accept` headers are preserved when provided.
 
+### Scrape Quality Gates
+
+A scrape is marked `completed` only when it indexed usable documentation. When a quality gate fails, the job is marked `failed`, the half-indexed version is rolled back (gate-then-rollback), and a machine-readable `errorCode` is reported through `get_job_info` / `list_jobs`.
+
+`scrape_docs` accepts these additional optional parameters:
+
+| Parameter | Type | Description |
+|---|---|---|
+| `expectTerms` | `string[]` | Terms expected to appear in the indexed docs. When set, sampled chunks are checked; an off-topic result fails with `OFF_TOPIC` (also enables scope-drift checks). |
+| `denyPaths` | `string[]` | Glob patterns (minimatch) excluded from indexing even when in scope. Defaults to `demos/**` and `examples/**` at any depth. |
+| `localeStrategy` | `"pin-en" \| "strip" \| "passthrough"` | Locale handling for fetched URLs. `pin-en` (default) sends `Accept-Language: en` and strips `hl`/`lang`/`locale` query params; `strip` only removes those params; `passthrough` leaves URL and headers unchanged. |
+
+Each finished job carries an `outcome` classification, and a failing gate also sets an `errorCode`:
+
+| `outcome` | Meaning |
+|---|---|
+| `indexed` | Useful documentation was indexed (success). |
+| `empty` | The crawl finished but indexed no content. |
+| `thin` | Fewer chunks than the minimum threshold were indexed. |
+| `degenerate` | Content was indexed but failed a relevance check (off-topic or scope drift). |
+| `failed` | The job failed before classification (scraper error). |
+
+`errorCode` values surfaced on failed jobs:
+
+-   `EMPTY_RESULT` — crawl indexed no content (check reachability, JS gating, redirect/anti-bot walls).
+-   `THIN_RESULT` — too few chunks indexed (widen `maxPages`/`maxDepth` or point at a richer docs root).
+-   `OFF_TOPIC` — indexed content did not contain the expected terms (pick a more specific URL).
+-   `SCOPE_DRIFT` — too few indexed URLs fall under the requested path (narrow the URL or set `denyPaths`).
+-   `LOCALE_REDIRECT_LOOP` — a cyclic locale redirect (e.g. `?hl=` ping-pong) was detected.
+-   `GITHUB_SUBPATH_NOT_FOUND` — a GitHub `/tree/` subpath matched no files (the error lists available top-level paths).
+
+The remediation hint for a failed gate is included in the job's `errorMessage`.
+
 ### Key Concepts & Architecture
 -   **[Deployment Modes](docs/infrastructure/deployment-modes.md)**: Standalone vs. Distributed (Docker Compose).
 -   **[Authentication](docs/infrastructure/authentication.md)**: Securing your server with OAuth2/OIDC.

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -71,6 +71,18 @@ export function createMcpServerInstance(
           .boolean()
           .optional()
           .describe("Preserve hash fragments for hash-routed SPA documentation sites."),
+        expectTerms: z
+          .array(z.string())
+          .optional()
+          .describe("Terms expected in the docs; off-topic scrapes fail with OFF_TOPIC."),
+        denyPaths: z
+          .array(z.string())
+          .optional()
+          .describe("Glob paths excluded from indexing (default: demos/examples)."),
+        localeStrategy: z
+          .enum(["pin-en", "strip", "passthrough"])
+          .optional()
+          .describe("Locale handling for fetched URLs (default pin-en)."),
       },
       {
         title: "Scrape New Library Documentation",
@@ -86,6 +98,9 @@ export function createMcpServerInstance(
         scope,
         followRedirects,
         preserveHashes,
+        expectTerms,
+        denyPaths,
+        localeStrategy,
       }) => {
         // Track MCP tool usage
         telemetry.track(TelemetryEvent.TOOL_USED, {
@@ -113,6 +128,9 @@ export function createMcpServerInstance(
               scope,
               followRedirects,
               preserveHashes,
+              expectTerms,
+              denyPaths,
+              localeStrategy,
             },
           });
 

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -72,11 +72,13 @@ export function createMcpServerInstance(
           .optional()
           .describe("Preserve hash fragments for hash-routed SPA documentation sites."),
         expectTerms: z
-          .array(z.string())
+          .array(z.string().max(200))
+          .max(50)
           .optional()
           .describe("Terms expected in the docs; off-topic scrapes fail with OFF_TOPIC."),
         denyPaths: z
-          .array(z.string())
+          .array(z.string().max(200))
+          .max(50)
           .optional()
           .describe("Glob paths excluded from indexing (default: demos/examples)."),
         localeStrategy: z

--- a/src/pipeline/PipelineManager.test.ts
+++ b/src/pipeline/PipelineManager.test.ts
@@ -23,7 +23,7 @@ import { type AppConfig, loadConfig } from "../utils/config";
 import { PipelineManager } from "./PipelineManager";
 import { PipelineWorker } from "./PipelineWorker";
 import type { InternalPipelineJob, PipelineJob, PipelineManagerCallbacks } from "./types";
-import { PipelineJobStatus } from "./types";
+import { PipelineJobStatus, ScrapeErrorCode, ScrapeOutcome } from "./types";
 
 // Mock dependencies
 vi.mock("../store/DocumentManagementService");
@@ -131,6 +131,13 @@ describe("PipelineManager", () => {
         id: 1,
         name: "test-lib",
       }),
+      // Quality-gate methods: default to a healthy result so existing happy-path
+      // jobs still transition to COMPLETED.
+      getVersionMetrics: vi.fn().mockResolvedValue({
+        documentCount: 10,
+        distinctUrls: 5,
+      }),
+      removeVersion: vi.fn().mockResolvedValue(undefined),
     };
 
     // Mock the worker's executeJob method
@@ -267,6 +274,53 @@ describe("PipelineManager", () => {
     const jobAfter = await manager.getJob(jobId);
     expect(jobAfter?.status).toBe(PipelineJobStatus.FAILED);
     expect(jobAfter?.error?.message).toBe("fail");
+  });
+
+  it("rolls back and fails the job when the gate returns empty", async () => {
+    // Arrange: a store whose getVersionMetrics reports zero docs after scrape.
+    (mockStore.getVersionMetrics as Mock).mockResolvedValue({
+      documentCount: 0,
+      distinctUrls: 0,
+    });
+    const removeSpy = mockStore.removeVersion as Mock;
+
+    const jobId = await manager.enqueueScrapeJob("lib", "1.0.0", {
+      url: "https://x/tree",
+      library: "lib",
+      version: "1.0.0",
+    });
+    await manager.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await manager.waitForJobCompletion(jobId).catch(() => {}); // gate failure rejects
+
+    const job = await manager.getJob(jobId);
+    expect(job?.status).toBe(PipelineJobStatus.FAILED);
+    expect(job?.outcome).toBe(ScrapeOutcome.EMPTY);
+    expect(job?.errorCode).toBe(ScrapeErrorCode.EMPTY_RESULT);
+    expect(removeSpy).toHaveBeenCalledWith("lib", "1.0.0");
+  });
+
+  it("does NOT roll back a refresh job that fails the gate (no data loss)", async () => {
+    // A refresh preserves pre-existing good docs; a failing gate must never removeVersion.
+    (mockStore.getVersionMetrics as Mock).mockResolvedValue({
+      documentCount: 0,
+      distinctUrls: 0,
+    });
+    const removeSpy = mockStore.removeVersion as Mock;
+
+    const jobId = await manager.enqueueScrapeJob("lib", "1.0.0", {
+      url: "https://x/tree",
+      library: "lib",
+      version: "1.0.0",
+      isRefresh: true,
+    });
+    await manager.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await manager.waitForJobCompletion(jobId).catch(() => {});
+
+    const job = await manager.getJob(jobId);
+    expect(removeSpy).not.toHaveBeenCalled();
+    expect(job?.outcome).toBe(ScrapeOutcome.INDEXED); // gate skipped for refresh
   });
 
   it("should cancel a job via cancelJob API", async () => {

--- a/src/pipeline/PipelineManager.test.ts
+++ b/src/pipeline/PipelineManager.test.ts
@@ -138,6 +138,9 @@ describe("PipelineManager", () => {
         distinctUrls: 5,
       }),
       removeVersion: vi.fn().mockResolvedValue(undefined),
+      // Relevance-gate methods (only consulted when expectTerms is set).
+      sampleChunks: vi.fn().mockResolvedValue([]),
+      listIndexedUrls: vi.fn().mockResolvedValue([]),
     };
 
     // Mock the worker's executeJob method
@@ -321,6 +324,33 @@ describe("PipelineManager", () => {
     const job = await manager.getJob(jobId);
     expect(removeSpy).not.toHaveBeenCalled();
     expect(job?.outcome).toBe(ScrapeOutcome.INDEXED); // gate skipped for refresh
+  });
+
+  it("fails as OFF_TOPIC when expectTerms are absent from sampled chunks", async () => {
+    (mockStore.getVersionMetrics as Mock).mockResolvedValue({
+      documentCount: 50,
+      distinctUrls: 40,
+    });
+    (mockStore.sampleChunks as Mock).mockResolvedValue([
+      "list-it demo",
+      "mood-food demo",
+    ]);
+    (mockStore.listIndexedUrls as Mock).mockResolvedValue([]);
+    const removeSpy = mockStore.removeVersion as Mock;
+
+    const jobId = await manager.enqueueScrapeJob("gemini", "1.0.0", {
+      url: "https://github.com/google/generative-ai-docs",
+      library: "gemini",
+      version: "1.0.0",
+      expectTerms: ["generateContent"],
+    });
+    await manager.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await manager.waitForJobCompletion(jobId).catch(() => {});
+
+    const job = await manager.getJob(jobId);
+    expect(job?.errorCode).toBe(ScrapeErrorCode.OFF_TOPIC);
+    expect(removeSpy).toHaveBeenCalled();
   });
 
   it("should cancel a job via cancelJob API", async () => {

--- a/src/pipeline/PipelineManager.ts
+++ b/src/pipeline/PipelineManager.ts
@@ -16,12 +16,14 @@ import { ScrapeMode } from "../scraper/types";
 import type { DocumentManagementService } from "../store";
 import { VersionStatus } from "../store/types";
 import type { AppConfig } from "../utils/config";
+import { ScraperError } from "../utils/errors";
 import { logger } from "../utils/logger";
-import { CancellationError, PipelineStateError } from "./errors";
+import { CancellationError, PipelineStateError, QualityGateError } from "./errors";
+import { evaluateOutcome, type OutcomeVerdict } from "./outcomeGate";
 import { PipelineWorker } from "./PipelineWorker"; // Import the worker
 import type { IPipeline } from "./trpc/interfaces";
-import type { InternalPipelineJob, PipelineJob } from "./types";
-import { PipelineJobStatus } from "./types";
+import type { InternalPipelineJob, JobOutcomeMetrics, PipelineJob } from "./types";
+import { PipelineJobStatus, type ScrapeErrorCode, ScrapeOutcome } from "./types";
 
 /**
  * Manages a queue of document processing jobs, controlling concurrency and tracking progress.
@@ -83,6 +85,8 @@ export class PipelineManager implements IPipeline {
       updatedAt: job.updatedAt,
       sourceUrl: job.sourceUrl,
       scraperOptions: job.scraperOptions,
+      outcome: job.outcome,
+      errorCode: job.errorCode,
     };
   }
 
@@ -630,6 +634,46 @@ export class PipelineManager implements IPipeline {
   }
 
   /**
+   * Runs quality gates on a finished job. On a failing verdict, discards the staged
+   * version (gate-then-rollback) and returns the verdict; otherwise returns null.
+   *
+   * @param job - The finished internal job to evaluate.
+   * @returns The failing verdict (after rolling back), or null when the job passed.
+   */
+  private async applyQualityGate(
+    job: InternalPipelineJob,
+  ): Promise<OutcomeVerdict | null> {
+    // SAFETY (review F2): never gate-rollback a refresh or append (clean=false). Those
+    // flows preserve a version that may already hold good docs; removeVersion() would
+    // destroy them (data loss). Refresh only updates changed pages, so a transient thin
+    // re-index must not wipe the prior index. Treat as indexed and skip the gate.
+    if (job.scraperOptions.isRefresh || job.scraperOptions.clean === false) {
+      job.outcome = ScrapeOutcome.INDEXED;
+      return null;
+    }
+    const counts = await this.store.getVersionMetrics(job.library, job.version);
+    const metrics: JobOutcomeMetrics = {
+      documentCount: counts.documentCount,
+      distinctUrls: counts.distinctUrls,
+      pagesScraped: job.progressPages ?? 0,
+      // relevance inputs filled in M4; undefined here means "skip those checks"
+    };
+    const verdict = evaluateOutcome(metrics);
+    if (verdict.outcome === ScrapeOutcome.INDEXED) {
+      job.outcome = ScrapeOutcome.INDEXED;
+      return null;
+    }
+    logger.warn(
+      `❌ Quality gate failed for ${job.library}@${job.version}: ` +
+        `${verdict.outcome} (${verdict.errorCode}) — discarding staged docs`,
+    );
+    await this.store.removeVersion(job.library, job.version);
+    job.outcome = verdict.outcome;
+    job.errorCode = verdict.errorCode;
+    return verdict;
+  }
+
+  /**
    * Executes a single pipeline job by delegating to a PipelineWorker.
    * Handles final status updates and promise resolution/rejection.
    */
@@ -662,6 +706,23 @@ export class PipelineManager implements IPipeline {
         throw new CancellationError("Job cancelled just before completion");
       }
 
+      // Quality gate: only promote to COMPLETED if useful docs were indexed.
+      const gateFailure = await this.applyQualityGate(job);
+      if (gateFailure) {
+        await this.updateJobStatus(
+          job,
+          PipelineJobStatus.FAILED,
+          gateFailure.remediation,
+        );
+        job.errorCode = gateFailure.errorCode;
+        job.finishedAt = new Date();
+        const err = new QualityGateError(gateFailure);
+        job.error = err;
+        logger.info(`❌ Job failed quality gate: ${jobId}: ${gateFailure.errorCode}`);
+        job.rejectCompletion(err);
+        return;
+      }
+
       // Mark as completed
       await this.updateJobStatus(job, PipelineJobStatus.COMPLETED);
       job.finishedAt = new Date();
@@ -684,6 +745,9 @@ export class PipelineManager implements IPipeline {
       } else {
         // Handle other errors
         const errorMessage = error instanceof Error ? error.message : String(error);
+        if (error instanceof ScraperError && error.code) {
+          job.errorCode = error.code as ScrapeErrorCode;
+        }
         await this.updateJobStatus(job, PipelineJobStatus.FAILED, errorMessage);
         job.error = error instanceof Error ? error : new Error(String(error));
         job.finishedAt = new Date();

--- a/src/pipeline/PipelineManager.ts
+++ b/src/pipeline/PipelineManager.ts
@@ -21,6 +21,7 @@ import { logger } from "../utils/logger";
 import { CancellationError, PipelineStateError, QualityGateError } from "./errors";
 import { evaluateOutcome, type OutcomeVerdict } from "./outcomeGate";
 import { PipelineWorker } from "./PipelineWorker"; // Import the worker
+import { computeInScopeRatio, sampleExpectTermsMatch } from "./relevanceGate";
 import type { IPipeline } from "./trpc/interfaces";
 import type { InternalPipelineJob, JobOutcomeMetrics, PipelineJob } from "./types";
 import { PipelineJobStatus, type ScrapeErrorCode, ScrapeOutcome } from "./types";
@@ -652,11 +653,25 @@ export class PipelineManager implements IPipeline {
       return null;
     }
     const counts = await this.store.getVersionMetrics(job.library, job.version);
+    const opts = job.scraperOptions;
+    let inScopeUrlRatio: number | undefined;
+    let expectTermsMatched: boolean | undefined;
+    // Review F6: scope-drift and off-topic are OPT-IN for v1 (rollout is hard-fail-immediate).
+    // Both relevance axes are computed only when the caller signals intent via `expectTerms`.
+    // denyPaths still trims demos/examples for everyone; a future release can promote
+    // scope-drift to default-on once warn-mode telemetry confirms low false-positive rates.
+    if (opts.expectTerms?.length) {
+      const urls = await this.store.listIndexedUrls(job.library, job.version);
+      inScopeUrlRatio = urls.length ? computeInScopeRatio(opts.url, urls) : undefined;
+      const chunks = await this.store.sampleChunks(job.library, job.version, 20);
+      expectTermsMatched = sampleExpectTermsMatch(chunks, opts.expectTerms);
+    }
     const metrics: JobOutcomeMetrics = {
       documentCount: counts.documentCount,
       distinctUrls: counts.distinctUrls,
       pagesScraped: job.progressPages ?? 0,
-      // relevance inputs filled in M4; undefined here means "skip those checks"
+      inScopeUrlRatio,
+      expectTermsMatched,
     };
     const verdict = evaluateOutcome(metrics);
     if (verdict.outcome === ScrapeOutcome.INDEXED) {

--- a/src/pipeline/errors.ts
+++ b/src/pipeline/errors.ts
@@ -1,3 +1,5 @@
+import type { OutcomeVerdict } from "./outcomeGate";
+
 export class PipelineError extends Error {
   constructor(
     message: string,
@@ -12,6 +14,17 @@ export class PipelineError extends Error {
 }
 
 export class PipelineStateError extends PipelineError {}
+
+/**
+ * Raised when a scrape finished but failed a quality gate (empty/thin/degenerate).
+ * Carries the full verdict (outcome, errorCode, remediation) for callers.
+ */
+export class QualityGateError extends Error {
+  constructor(public readonly verdict: OutcomeVerdict) {
+    super(verdict.remediation ?? `Quality gate failed: ${verdict.outcome}`);
+    this.name = "QualityGateError";
+  }
+}
 
 /**
  * Error indicating that an operation was cancelled.

--- a/src/pipeline/outcomeGate.test.ts
+++ b/src/pipeline/outcomeGate.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { evaluateOutcome, type QualityGateConfig } from "./outcomeGate";
+import { ScrapeErrorCode, ScrapeOutcome } from "./types";
+
+const cfg: QualityGateConfig = { minDocs: 1, minInScopeRatio: 0.5 };
+
+describe("evaluateOutcome", () => {
+  it("classifies zero documents as empty", () => {
+    const v = evaluateOutcome(
+      { documentCount: 0, distinctUrls: 0, pagesScraped: 0 },
+      cfg,
+    );
+    expect(v.outcome).toBe(ScrapeOutcome.EMPTY);
+    expect(v.errorCode).toBe(ScrapeErrorCode.EMPTY_RESULT);
+    expect(v.remediation).toMatch(/no .*content/i);
+  });
+
+  it("classifies below-threshold documents as thin", () => {
+    const v = evaluateOutcome(
+      { documentCount: 1, distinctUrls: 1, pagesScraped: 1 },
+      { minDocs: 3, minInScopeRatio: 0.5 },
+    );
+    expect(v.outcome).toBe(ScrapeOutcome.THIN);
+    expect(v.errorCode).toBe(ScrapeErrorCode.THIN_RESULT);
+  });
+
+  it("classifies failed expectTerms as degenerate/off-topic", () => {
+    const v = evaluateOutcome(
+      {
+        documentCount: 50,
+        distinctUrls: 40,
+        pagesScraped: 40,
+        expectTermsMatched: false,
+      },
+      cfg,
+    );
+    expect(v.outcome).toBe(ScrapeOutcome.DEGENERATE);
+    expect(v.errorCode).toBe(ScrapeErrorCode.OFF_TOPIC);
+  });
+
+  it("classifies low in-scope ratio as degenerate/scope-drift", () => {
+    const v = evaluateOutcome(
+      { documentCount: 50, distinctUrls: 40, pagesScraped: 40, inScopeUrlRatio: 0.1 },
+      cfg,
+    );
+    expect(v.outcome).toBe(ScrapeOutcome.DEGENERATE);
+    expect(v.errorCode).toBe(ScrapeErrorCode.SCOPE_DRIFT);
+  });
+
+  it("passes healthy results as indexed", () => {
+    const v = evaluateOutcome(
+      {
+        documentCount: 50,
+        distinctUrls: 40,
+        pagesScraped: 40,
+        inScopeUrlRatio: 0.95,
+        expectTermsMatched: true,
+      },
+      cfg,
+    );
+    expect(v.outcome).toBe(ScrapeOutcome.INDEXED);
+    expect(v.errorCode).toBeUndefined();
+  });
+});

--- a/src/pipeline/outcomeGate.ts
+++ b/src/pipeline/outcomeGate.ts
@@ -1,0 +1,80 @@
+import { type JobOutcomeMetrics, ScrapeErrorCode, ScrapeOutcome } from "./types";
+
+/** Tunable thresholds for the outcome gate. Conservative defaults avoid false positives. */
+export interface QualityGateConfig {
+  /** Minimum stored chunks to count as more than "thin". Default 1 (only 0 is blocked). */
+  minDocs: number;
+  /** Minimum fraction of indexed URLs under the requested root before SCOPE_DRIFT. */
+  minInScopeRatio: number;
+}
+
+export const DEFAULT_QUALITY_GATE: QualityGateConfig = {
+  minDocs: 1,
+  minInScopeRatio: 0.25,
+};
+
+/** Verdict returned by the quality gate. */
+export interface OutcomeVerdict {
+  outcome: ScrapeOutcome;
+  errorCode?: ScrapeErrorCode;
+  /** Human-readable, caller-facing fix suggestion (only when failing). */
+  remediation?: string;
+}
+
+/**
+ * Classifies a finished scrape from its metrics. Pure: no I/O, fully unit-testable.
+ * Order: empty -> thin -> relevance (off-topic before scope-drift) -> indexed.
+ *
+ * @param metrics - Counters collected when the job finished.
+ * @param config - Tunable thresholds; defaults to {@link DEFAULT_QUALITY_GATE}.
+ * @returns The classification verdict, including a typed error code and remediation when failing.
+ */
+export function evaluateOutcome(
+  metrics: JobOutcomeMetrics,
+  config: QualityGateConfig = DEFAULT_QUALITY_GATE,
+): OutcomeVerdict {
+  if (metrics.documentCount === 0) {
+    return {
+      outcome: ScrapeOutcome.EMPTY,
+      errorCode: ScrapeErrorCode.EMPTY_RESULT,
+      remediation:
+        "The crawl finished but indexed no content. Check the URL is reachable, " +
+        "renders without JavaScript gating, and is not a redirect/anti-bot wall.",
+    };
+  }
+
+  if (metrics.documentCount < config.minDocs) {
+    return {
+      outcome: ScrapeOutcome.THIN,
+      errorCode: ScrapeErrorCode.THIN_RESULT,
+      remediation:
+        `Only ${metrics.documentCount} chunk(s) indexed (min ${config.minDocs}). ` +
+        "Widen maxPages/maxDepth or point at a richer docs root.",
+    };
+  }
+
+  if (metrics.expectTermsMatched === false) {
+    return {
+      outcome: ScrapeOutcome.DEGENERATE,
+      errorCode: ScrapeErrorCode.OFF_TOPIC,
+      remediation:
+        "Indexed content did not contain the expected terms. The source likely " +
+        "covers a different topic than requested; pick a more specific URL.",
+    };
+  }
+
+  if (
+    metrics.inScopeUrlRatio !== undefined &&
+    metrics.inScopeUrlRatio < config.minInScopeRatio
+  ) {
+    return {
+      outcome: ScrapeOutcome.DEGENERATE,
+      errorCode: ScrapeErrorCode.SCOPE_DRIFT,
+      remediation:
+        `Only ${Math.round(metrics.inScopeUrlRatio * 100)}% of indexed URLs are under ` +
+        "the requested path. Narrow the URL or set denyPaths/includePatterns.",
+    };
+  }
+
+  return { outcome: ScrapeOutcome.INDEXED };
+}

--- a/src/pipeline/relevanceGate.test.ts
+++ b/src/pipeline/relevanceGate.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { computeInScopeRatio, sampleExpectTermsMatch } from "./relevanceGate";
+
+describe("relevanceGate", () => {
+  it("computes the fraction of URLs under the requested root", () => {
+    const ratio = computeInScopeRatio("https://github.com/o/r", [
+      "https://github.com/o/r/blob/main/site/a.md",
+      "https://github.com/o/r/blob/main/demos/x.js",
+      "https://github.com/o/r/blob/main/demos/y.js",
+    ]);
+    expect(ratio).toBeCloseTo(1.0); // all under /o/r
+  });
+
+  it("aligns a github /tree/ root with /blob/ children (review F1: no false scope drift)", () => {
+    // Real shape: root is a /tree/<branch>/<subpath>, children are /blob/<branch>/<path>.
+    // A naive pathname-prefix compare would score 0 here; the ref-agnostic key must score 2/3.
+    const ratio = computeInScopeRatio("https://github.com/o/r/tree/main/site/en", [
+      "https://github.com/o/r/blob/main/site/en/a.md",
+      "https://github.com/o/r/blob/main/site/en/sub/b.md",
+      "https://github.com/o/r/blob/main/demos/x.js",
+    ]);
+    expect(ratio).toBeCloseTo(2 / 3); // 2 under site/en, demos out of scope
+  });
+
+  it("matches expectTerms against sampled chunk text (keyword path)", () => {
+    const matched = sampleExpectTermsMatch(
+      ["use generateContent to call the model", "unrelated text"],
+      ["generateContent"],
+    );
+    expect(matched).toBe(true);
+  });
+
+  it("reports no match when terms are absent", () => {
+    const matched = sampleExpectTermsMatch(
+      ["list-it demo", "mood-food demo"],
+      ["generateContent"],
+    );
+    expect(matched).toBe(false);
+  });
+});

--- a/src/pipeline/relevanceGate.ts
+++ b/src/pipeline/relevanceGate.ts
@@ -1,0 +1,74 @@
+/**
+ * Relevance gate helpers: path/scope coherence and `expectTerms` sampling.
+ *
+ * Pure functions with no I/O, fully unit-testable. Consumed by the
+ * PipelineManager quality-gate seam to compute the optional relevance axes
+ * (SCOPE_DRIFT and OFF_TOPIC) when a caller opts in via `expectTerms`.
+ *
+ * @module relevanceGate
+ */
+
+/**
+ * Normalizes a URL to a host-qualified, ref-agnostic path for scope comparison.
+ *
+ * GitHub blob/tree URLs collapse `/owner/repo/(blob|tree)/<branch>/<rest>` to
+ * `/owner/repo/<rest>` so a `/tree/` root and its `/blob/` children align
+ * (review F1). Non-GitHub URLs keep their pathname unchanged. A trailing slash
+ * is stripped so prefix comparisons behave consistently.
+ *
+ * @param rawUrl - The URL to normalize.
+ * @returns The host and ref-agnostic path, or null if the URL cannot be parsed.
+ */
+export function toScopeKey(rawUrl: string): { host: string; path: string } | null {
+  try {
+    const u = new URL(rawUrl);
+    let path = u.pathname;
+    if (u.hostname.endsWith("github.com")) {
+      const ref = path.match(/^\/([^/]+)\/([^/]+)\/(?:blob|tree)\/[^/]+\/(.*)$/);
+      if (ref) {
+        path = `/${ref[1]}/${ref[2]}/${ref[3]}`;
+      } else {
+        const base = path.match(/^\/([^/]+)\/([^/]+)/);
+        if (base) path = `/${base[1]}/${base[2]}`;
+      }
+    }
+    return { host: u.hostname, path: path.replace(/\/+$/, "") };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Computes the fraction (0..1) of `indexedUrls` whose scope key is under the
+ * root URL's scope key (same host, path prefix). Returns 0 when there are no
+ * indexed URLs or the root is unparseable.
+ *
+ * @param rootUrl - The requested scrape root.
+ * @param indexedUrls - The URLs actually indexed.
+ * @returns The in-scope ratio in the range 0..1.
+ */
+export function computeInScopeRatio(rootUrl: string, indexedUrls: string[]): number {
+  if (indexedUrls.length === 0) return 0;
+  const root = toScopeKey(rootUrl);
+  if (!root) return 0;
+  const inScope = indexedUrls.filter((u) => {
+    const k = toScopeKey(u);
+    return k !== null && k.host === root.host && k.path.startsWith(root.path);
+  }).length;
+  return inScope / indexedUrls.length;
+}
+
+/**
+ * Returns true if any sampled chunk contains any expected term
+ * (case-insensitive substring match). An empty `expectTerms` list is treated
+ * as a pass (no expectation to satisfy).
+ *
+ * @param chunks - Sampled chunk contents.
+ * @param expectTerms - Terms expected to appear in the indexed docs.
+ * @returns Whether at least one term was found.
+ */
+export function sampleExpectTermsMatch(chunks: string[], expectTerms: string[]): boolean {
+  if (expectTerms.length === 0) return true;
+  const haystack = chunks.join("\n").toLowerCase();
+  return expectTerms.some((t) => haystack.includes(t.toLowerCase()));
+}

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -17,6 +17,39 @@ export enum PipelineJobStatus {
   CANCELLED = "cancelled",
 }
 
+/** Classification of a finished scrape job's usefulness, beyond raw success/failure. */
+export enum ScrapeOutcome {
+  INDEXED = "indexed",
+  EMPTY = "empty",
+  THIN = "thin",
+  DEGENERATE = "degenerate",
+  FAILED = "failed",
+}
+
+/** Machine-readable reason a job failed a quality gate, with caller remediation. */
+export enum ScrapeErrorCode {
+  EMPTY_RESULT = "EMPTY_RESULT",
+  THIN_RESULT = "THIN_RESULT",
+  OFF_TOPIC = "OFF_TOPIC",
+  SCOPE_DRIFT = "SCOPE_DRIFT",
+  LOCALE_REDIRECT_LOOP = "LOCALE_REDIRECT_LOOP",
+  GITHUB_SUBPATH_NOT_FOUND = "GITHUB_SUBPATH_NOT_FOUND",
+}
+
+/** Counters collected when a job finishes, fed into the quality gate. */
+export interface JobOutcomeMetrics {
+  /** Number of stored chunks for the (library, version). */
+  documentCount: number;
+  /** Number of distinct indexed URLs. */
+  distinctUrls: number;
+  /** Pages the scraper reported processing. */
+  pagesScraped: number;
+  /** Fraction (0..1) of indexed URLs under the requested root path. undefined if not computed. */
+  inScopeUrlRatio?: number;
+  /** Whether sampled chunks matched `expectTerms`. undefined when no expectTerms given. */
+  expectTermsMatched?: boolean;
+}
+
 /**
  * Public interface for pipeline jobs exposed through API boundaries.
  * Contains only serializable fields suitable for JSON transport.
@@ -56,6 +89,10 @@ export interface PipelineJob {
   sourceUrl: string | null;
   /** Stored scraper options for reproducibility. */
   scraperOptions: ScraperOptions | null;
+  /** Quality classification of the finished job (undefined while running). */
+  outcome?: ScrapeOutcome;
+  /** Typed reason when the job failed a quality gate. */
+  errorCode?: ScrapeErrorCode;
 }
 
 /**

--- a/src/scraper/fetcher/HttpFetcher.test.ts
+++ b/src/scraper/fetcher/HttpFetcher.test.ts
@@ -649,4 +649,52 @@ describe("HttpFetcher", () => {
       expect(resultWithoutEtag.etag).toBeUndefined();
     });
   });
+
+  describe("LOCALE handling", () => {
+    beforeEach(() => {
+      mockedAxios.get.mockReset();
+    });
+
+    it("aborts with LOCALE_REDIRECT_LOOP on a cyclic ?hl redirect", async () => {
+      const fetcher = createFetcher();
+      // The harness mocks axios (no live server). Simulate a server that ping-pongs
+      // between two locale variants: /docs?hl=pt <-> /docs?hl=en. passthrough keeps the
+      // query params, so the manual redirect loop revisits a normalized Location.
+      mockedAxios.get.mockImplementation((requestUrl: string) => {
+        const u = new URL(requestUrl);
+        const hl = u.searchParams.get("hl");
+        const next = hl === "pt" ? "en" : "pt";
+        return Promise.resolve({
+          status: 302,
+          data: Buffer.from(""),
+          headers: { location: `https://example.com/docs?hl=${next}` },
+        });
+      });
+
+      await expect(
+        fetcher.fetch("https://example.com/docs?hl=pt", {
+          localeStrategy: "passthrough",
+        }),
+      ).rejects.toMatchObject({ code: "LOCALE_REDIRECT_LOOP" });
+    });
+
+    it("pins Accept-Language and strips hl with pin-en", async () => {
+      const fetcher = createFetcher();
+      // RawContent has no requestHeaders/finalUrl; assert via the axios-captured config
+      // (request URL + Accept-Language header) and res.source for the final URL.
+      mockedAxios.get.mockResolvedValue({
+        data: Buffer.from("<html><body>OK</body></html>", "utf-8"),
+        headers: { "content-type": "text/html" },
+      });
+
+      const res = await fetcher.fetch("https://example.com/docs?hl=pt-br", {
+        localeStrategy: "pin-en",
+      });
+
+      const [requestedUrl, config] = mockedAxios.get.mock.calls[0];
+      expect(requestedUrl).not.toMatch(/hl=/);
+      expect((config?.headers as Record<string, string>)["Accept-Language"]).toBe("en");
+      expect(res.source).not.toMatch(/hl=/);
+    });
+  });
 });

--- a/src/scraper/fetcher/HttpFetcher.ts
+++ b/src/scraper/fetcher/HttpFetcher.ts
@@ -110,18 +110,49 @@ export class HttpFetcher implements ContentFetcher {
     baseDelay: number = this.baseDelayDefaultMs,
     followRedirects: boolean = true,
   ): Promise<RawContent> {
-    await this.accessPolicy.assertNetworkUrlAllowed(source);
+    // Locale normalization: strip locale query params (hl/lang/locale) so the
+    // crawler does not get redirected into a localized variant, and optionally pin
+    // Accept-Language to English. 'passthrough' leaves both the URL and headers as-is.
+    const localeStrategy = options?.localeStrategy ?? "pin-en";
+    let normalizedSource = source;
+    if (localeStrategy !== "passthrough") {
+      try {
+        const u = new URL(source);
+        let removedLocaleParam = false;
+        for (const p of ["hl", "lang", "locale"]) {
+          if (u.searchParams.has(p)) {
+            u.searchParams.delete(p);
+            removedLocaleParam = true;
+          }
+        }
+        // Only rewrite the URL when a locale param was actually stripped, so the
+        // common no-locale case keeps its exact original form (no added trailing slash).
+        if (removedLocaleParam) {
+          normalizedSource = u.toString();
+        }
+      } catch {
+        // Non-absolute/unparseable URLs (e.g. tests) pass through unchanged.
+      }
+    }
+    const localeHeaders: Record<string, string> =
+      localeStrategy === "pin-en" ? { "Accept-Language": "en" } : {};
+
+    await this.accessPolicy.assertNetworkUrlAllowed(normalizedSource);
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       try {
-        let currentUrl = source;
+        let currentUrl = normalizedSource;
         let redirectCount = 0;
+        // Track normalized Locations to detect a cyclic redirect (e.g. a locale
+        // ping-pong) within the existing MAX_REDIRECTS cap.
+        const seenLocations = new Set<string>([currentUrl]);
 
         while (true) {
           const fingerprint = this.fingerprintGenerator.generateHeaders();
           const headers = withMarkdownPreferredAccept(
             {
               ...fingerprint,
+              ...localeHeaders, // Accept-Language pin (pin-en) before user overrides
               ...options?.headers, // User-provided headers override generated ones
             },
             options?.headers,
@@ -194,6 +225,19 @@ export class HttpFetcher implements ContentFetcher {
             }
 
             const redirectUrl = new URL(location, currentUrl).href;
+
+            // Detect a cyclic redirect (commonly a locale ping-pong, e.g.
+            // ?hl=pt -> ?hl=en -> ?hl=pt) before exhausting the redirect budget.
+            if (seenLocations.has(redirectUrl)) {
+              const err = new ScraperError(
+                `Redirect loop detected at ${redirectUrl} (cyclic Location).`,
+                false,
+              );
+              err.code = "LOCALE_REDIRECT_LOOP";
+              throw err;
+            }
+            seenLocations.add(redirectUrl);
+
             await this.accessPolicy.assertNetworkUrlAllowed(redirectUrl);
 
             currentUrl = redirectUrl;

--- a/src/scraper/fetcher/types.ts
+++ b/src/scraper/fetcher/types.ts
@@ -92,6 +92,14 @@ export interface FetchOptions {
   etag?: string | null;
   /** Internal-only allowlist roots for application-managed temporary files. */
   internalAllowedFileRoots?: string[];
+  /**
+   * Locale handling for fetched URLs.
+   * - 'pin-en': send `Accept-Language: en` and strip `hl`/`lang`/`locale` query params (default)
+   * - 'strip': strip locale query params, no Accept-Language override
+   * - 'passthrough': leave URL and headers unchanged
+   * @default 'pin-en'
+   */
+  localeStrategy?: "pin-en" | "strip" | "passthrough";
 }
 
 /**

--- a/src/scraper/strategies/BaseScraperStrategy.ts
+++ b/src/scraper/strategies/BaseScraperStrategy.ts
@@ -3,7 +3,7 @@ import { URL } from "node:url";
 import { CancellationError } from "../../pipeline/errors";
 import type { ProgressCallback } from "../../types";
 import { fileUrlToPathLoose } from "../../utils/accessPolicy";
-import type { AppConfig } from "../../utils/config";
+import { type AppConfig, DEFAULT_DENY_PATHS } from "../../utils/config";
 import { ScraperError } from "../../utils/errors";
 import { logger } from "../../utils/logger";
 import { normalizeUrl, type UrlNormalizerOptions } from "../../utils/url";
@@ -17,7 +17,7 @@ import type {
   ScraperStrategy,
 } from "../types";
 import { isLlmsTxtUrl } from "../utils/llmsTxtParser";
-import { shouldIncludeUrl } from "../utils/patternMatcher";
+import { matchesAnyPattern, shouldIncludeUrl } from "../utils/patternMatcher";
 import { isInScope } from "../utils/scope";
 
 export interface BaseScraperStrategyOptions {
@@ -141,6 +141,18 @@ export abstract class BaseScraperStrategy implements ScraperStrategy {
         return false;
       }
     }
+
+    // Exclude denied paths (demos/examples by default) matched against the URL pathname.
+    const denyPaths = options.denyPaths ?? DEFAULT_DENY_PATHS;
+    if (denyPaths.length > 0) {
+      try {
+        const pathname = new URL(url).pathname;
+        if (matchesAnyPattern(pathname, denyPaths)) return false;
+      } catch {
+        // Non-parseable URL: fall through to include/exclude handling.
+      }
+    }
+
     return shouldIncludeUrl(url, options.includePatterns, options.excludePatterns);
   }
 

--- a/src/scraper/strategies/GitHubScraperStrategy.test.ts
+++ b/src/scraper/strategies/GitHubScraperStrategy.test.ts
@@ -666,5 +666,27 @@ describe("GitHubScraperStrategy", () => {
         /permissions|rate-limited/,
       );
     });
+
+    it("throws GITHUB_SUBPATH_NOT_FOUND when a /tree/ subpath matches no files", async () => {
+      // fetchRepositoryTree returns { tree: <full API response>, resolvedBranch }.
+      // processItem reads tree.tree (the entries array), so the mock's `tree` IS the
+      // whole response object. Do NOT pass fixture.tree here — that double-unwraps.
+      const treeResponse = require("../../../test/fixtures/github-tree-generative-ai-docs.json");
+      vi.spyOn(strategy as any, "fetchRepositoryTree").mockResolvedValue({
+        tree: treeResponse,
+        resolvedBranch: "main",
+      });
+      await expect(
+        strategy.processItem(
+          {
+            url: "https://github.com/google/generative-ai-docs/tree/main/docs",
+            depth: 0,
+          },
+          {
+            url: "https://github.com/google/generative-ai-docs/tree/main/docs",
+          } as any,
+        ),
+      ).rejects.toMatchObject({ code: "GITHUB_SUBPATH_NOT_FOUND" });
+    });
   });
 });

--- a/src/scraper/strategies/GitHubScraperStrategy.test.ts
+++ b/src/scraper/strategies/GitHubScraperStrategy.test.ts
@@ -688,5 +688,23 @@ describe("GitHubScraperStrategy", () => {
         ),
       ).rejects.toMatchObject({ code: "GITHUB_SUBPATH_NOT_FOUND" });
     });
+
+    it("denyPaths excludes demos/** from a repo-root crawl", async () => {
+      const treeResponse = require("../../../test/fixtures/github-tree-generative-ai-docs.json");
+      vi.spyOn(strategy as any, "fetchRepositoryTree").mockResolvedValue({
+        tree: treeResponse,
+        resolvedBranch: "main",
+      });
+      const res = await strategy.processItem(
+        { url: "https://github.com/google/generative-ai-docs", depth: 0 },
+        {
+          url: "https://github.com/google/generative-ai-docs",
+          denyPaths: ["**/demos/**", "demos/**"],
+        } as any,
+      );
+      const demoLinks = (res.links ?? []).filter((l) => l.includes("/demos/"));
+      expect(demoLinks).toHaveLength(0);
+      expect((res.links ?? []).some((l) => l.includes("/site/"))).toBe(true);
+    });
   });
 });

--- a/src/scraper/strategies/GitHubScraperStrategy.ts
+++ b/src/scraper/strategies/GitHubScraperStrategy.ts
@@ -1,12 +1,12 @@
 import type { ProgressCallback } from "../../types";
-import type { AppConfig } from "../../utils/config";
+import { type AppConfig, DEFAULT_DENY_PATHS } from "../../utils/config";
 import { ScraperError } from "../../utils/errors";
 import { logger } from "../../utils/logger";
 import { MimeTypeUtils } from "../../utils/mimeTypeUtils";
 import { HttpFetcher } from "../fetcher";
 import { FetchStatus } from "../fetcher/types";
 import type { QueueItem, ScraperOptions, ScraperProgressEvent } from "../types";
-import { shouldIncludeUrl } from "../utils/patternMatcher";
+import { matchesAnyPattern, shouldIncludeUrl } from "../utils/patternMatcher";
 import { BaseScraperStrategy, type ProcessItemResult } from "./BaseScraperStrategy";
 import type {
   GitHubRepoInfo,
@@ -507,6 +507,12 @@ export class GitHubScraperStrategy extends BaseScraperStrategy {
    */
   private shouldProcessFile(item: GitHubTreeItem, options: ScraperOptions): boolean {
     if (item.type !== "blob") {
+      return false;
+    }
+
+    // Exclude denied paths (demos/examples by default) before any other check.
+    const denyPaths = options.denyPaths ?? DEFAULT_DENY_PATHS;
+    if (denyPaths.length > 0 && matchesAnyPattern(item.path, denyPaths)) {
       return false;
     }
 

--- a/src/scraper/strategies/GitHubScraperStrategy.ts
+++ b/src/scraper/strategies/GitHubScraperStrategy.ts
@@ -653,6 +653,28 @@ export class GitHubScraperStrategy extends BaseScraperStrategy {
         `Discovered ${fileItems.length} processable files in repository (branch: ${resolvedBranch})`,
       );
 
+      // FM-3 guard: a /tree/<branch>/<subPath> URL that matches no files is almost
+      // always a typo or a renamed directory. Failing loudly (with the real top-level
+      // paths) is far more useful than silently indexing only the wiki link.
+      if (repoInfo.subPath && fileItems.length === 0) {
+        const topDirs = [
+          ...new Set(
+            tree.tree
+              .filter((treeItem) => treeItem.type === "blob")
+              .map((treeItem) => treeItem.path.split("/")[0]),
+          ),
+        ]
+          .sort()
+          .slice(0, 20);
+        const err = new ScraperError(
+          `GitHub subpath "${repoInfo.subPath}" matched no files in ` +
+            `${owner}/${repo}@${resolvedBranch}. Available top-level paths: ${topDirs.join(", ")}.`,
+          false,
+        );
+        err.code = "GITHUB_SUBPATH_NOT_FOUND";
+        throw err;
+      }
+
       // Create HTTPS blob URLs for storage in database
       // These are user-friendly, clickable URLs that work outside the system
       const fileUrls = fileItems.map(

--- a/src/scraper/strategies/WebScraperStrategy.ts
+++ b/src/scraper/strategies/WebScraperStrategy.ts
@@ -95,6 +95,7 @@ export class WebScraperStrategy extends BaseScraperStrategy {
       followRedirects: options.followRedirects,
       headers: options.headers,
       etag: item.etag,
+      localeStrategy: options.localeStrategy,
       ...(item.internalAllowedFileRoots
         ? { internalAllowedFileRoots: item.internalAllowedFileRoots }
         : {}),

--- a/src/scraper/types.ts
+++ b/src/scraper/types.ts
@@ -130,6 +130,17 @@ export interface ScraperOptions {
    */
   internalAllowedFileRoots?: string[];
   /**
+   * Glob patterns (minimatch) whose matching paths are excluded from indexing,
+   * even when in scope. Applied on top of scope/includePatterns.
+   * @default DEFAULT_DENY_PATHS (demos/examples at any depth)
+   */
+  denyPaths?: string[];
+  /**
+   * Optional terms expected to appear in the indexed docs. When set, the quality gate
+   * samples stored chunks and fails as OFF_TOPIC if none match.
+   */
+  expectTerms?: string[];
+  /**
    * Locale handling for fetched URLs.
    * - 'pin-en': send `Accept-Language: en` and strip `hl`/`lang`/`locale` query params (default)
    * - 'strip': strip locale query params, no Accept-Language override

--- a/src/scraper/types.ts
+++ b/src/scraper/types.ts
@@ -129,6 +129,14 @@ export interface ScraperOptions {
    * Internal-only allowlist roots for application-managed temporary files.
    */
   internalAllowedFileRoots?: string[];
+  /**
+   * Locale handling for fetched URLs.
+   * - 'pin-en': send `Accept-Language: en` and strip `hl`/`lang`/`locale` query params (default)
+   * - 'strip': strip locale query params, no Accept-Language override
+   * - 'passthrough': leave URL and headers unchanged
+   * @default 'pin-en'
+   */
+  localeStrategy?: "pin-en" | "strip" | "passthrough";
 }
 
 /**

--- a/src/store/DocumentManagementService.test.ts
+++ b/src/store/DocumentManagementService.test.ts
@@ -1057,6 +1057,69 @@ describe("DocumentManagementService", () => {
       });
     });
 
+    describe("getVersionMetrics", () => {
+      it("getVersionMetrics returns document and distinct-url counts", async () => {
+        const metricsMap = new Map<string, any[]>([
+          [
+            "lib",
+            [
+              {
+                version: "1.0.0",
+                versionId: 1,
+                status: "completed",
+                progressPages: 5,
+                progressMaxPages: 5,
+                sourceUrl: null,
+                documentCount: 12,
+                uniqueUrlCount: 4,
+                indexedAt: "2024-01-01T00:00:00.000Z",
+              },
+            ],
+          ],
+        ]);
+        mockStore.queryLibraryVersions.mockResolvedValue(metricsMap);
+
+        const m = await docService.getVersionMetrics("lib", "1.0.0");
+        expect(m.documentCount).toBeGreaterThan(0);
+        expect(m.distinctUrls).toBeGreaterThan(0);
+        expect(m.documentCount).toBe(12);
+        expect(m.distinctUrls).toBe(4);
+      });
+
+      it("getVersionMetrics returns zero counts for an unknown version", async () => {
+        mockStore.queryLibraryVersions.mockResolvedValue(new Map());
+        const m = await docService.getVersionMetrics("missing", "1.0.0");
+        expect(m).toEqual({ documentCount: 0, distinctUrls: 0 });
+      });
+
+      it("getVersionMetrics normalizes library casing and version", async () => {
+        const metricsMap = new Map<string, any[]>([
+          [
+            "lib",
+            [
+              {
+                version: "",
+                versionId: 2,
+                status: "completed",
+                progressPages: 1,
+                progressMaxPages: 1,
+                sourceUrl: null,
+                documentCount: 3,
+                uniqueUrlCount: 2,
+                indexedAt: null,
+              },
+            ],
+          ],
+        ]);
+        mockStore.queryLibraryVersions.mockResolvedValue(metricsMap);
+
+        // Uppercase library + null version should resolve the lowercased,
+        // empty-string ("") entry.
+        const m = await docService.getVersionMetrics("LIB", null);
+        expect(m).toEqual({ documentCount: 3, distinctUrls: 2 });
+      });
+    });
+
     describe("cleanup", () => {
       it("should shutdown without errors", async () => {
         const eventBus = new EventBusService();

--- a/src/store/DocumentManagementService.ts
+++ b/src/store/DocumentManagementService.ts
@@ -223,6 +223,33 @@ export class DocumentManagementService {
   }
 
   /**
+   * Returns up to `limit` stored chunk contents for sampling-based relevance checks.
+   *
+   * @param library - Library name (matched case-insensitively in the store).
+   * @param version - Version string; null/undefined resolves to the unversioned ("") entry.
+   * @param limit - Maximum number of chunk contents to return.
+   * @returns An array of chunk content strings (possibly empty).
+   */
+  async sampleChunks(
+    library: string,
+    version?: string | null,
+    limit = 20,
+  ): Promise<string[]> {
+    return this.store.sampleChunkContents(library, this.normalizeVersion(version), limit);
+  }
+
+  /**
+   * Returns the distinct indexed page URLs for a (library, version).
+   *
+   * @param library - Library name (matched case-insensitively in the store).
+   * @param version - Version string; null/undefined resolves to the unversioned ("") entry.
+   * @returns The distinct URLs indexed under the (library, version).
+   */
+  async listIndexedUrls(library: string, version?: string | null): Promise<string[]> {
+    return this.store.listPageUrls(library, this.normalizeVersion(version));
+  }
+
+  /**
    * Finds versions that were indexed from the same source URL.
    */
   async findVersionsBySourceUrl(url: string): Promise<DbVersionWithLibrary[]> {

--- a/src/store/DocumentManagementService.ts
+++ b/src/store/DocumentManagementService.ts
@@ -200,6 +200,29 @@ export class DocumentManagementService {
   }
 
   /**
+   * Returns chunk and distinct-URL counts for a specific (library, version).
+   * Reuses the aggregate computed by the store's version listing.
+   *
+   * @param library - Library name (matched case-insensitively).
+   * @param version - Version string; null/undefined resolves to the unversioned ("") entry.
+   * @returns The stored document (chunk) count and distinct indexed-URL count, both 0 if absent.
+   */
+  async getVersionMetrics(
+    library: string,
+    version?: string | null,
+  ): Promise<{ documentCount: number; distinctUrls: number }> {
+    const normalizedVersion = this.normalizeVersion(version);
+    const summaries = await this.store.queryLibraryVersions();
+    const entry = summaries
+      .get(library.toLowerCase())
+      ?.find((v) => (v.version ?? "") === normalizedVersion);
+    return {
+      documentCount: entry?.documentCount ?? 0,
+      distinctUrls: entry?.uniqueUrlCount ?? 0,
+    };
+  }
+
+  /**
    * Finds versions that were indexed from the same source URL.
    */
   async findVersionsBySourceUrl(url: string): Promise<DbVersionWithLibrary[]> {

--- a/src/store/DocumentStore.ts
+++ b/src/store/DocumentStore.ts
@@ -122,6 +122,8 @@ export class DocumentStore {
     queryVersions: Database.Statement<[string]>;
     checkExists: Database.Statement<[string, string]>;
     queryLibraryVersions: Database.Statement<[]>;
+    sampleChunkContents: Database.Statement<[string, string, number]>;
+    listPageUrls: Database.Statement<[string, string]>;
     getChildChunks: Database.Statement<
       [string, string, string, number, string, bigint, number]
     >;
@@ -363,6 +365,26 @@ export class DocumentStore {
         LEFT JOIN documents d ON d.page_id = p.id
         GROUP BY v.id
         ORDER BY l.name, version`,
+      ),
+      // Quality-gate relevance sampling: up to LIMIT chunk contents for a (library, version).
+      sampleChunkContents: this.db.prepare<[string, string, number]>(
+        `SELECT d.content
+         FROM documents d
+         JOIN pages p ON d.page_id = p.id
+         JOIN versions v ON p.version_id = v.id
+         JOIN libraries l ON v.library_id = l.id
+         WHERE l.name = ?
+         AND COALESCE(v.name, '') = COALESCE(?, '')
+         LIMIT ?`,
+      ),
+      // Quality-gate scope check: distinct indexed page URLs for a (library, version).
+      listPageUrls: this.db.prepare<[string, string]>(
+        `SELECT DISTINCT p.url
+         FROM pages p
+         JOIN versions v ON p.version_id = v.id
+         JOIN libraries l ON v.library_id = l.id
+         WHERE l.name = ?
+         AND COALESCE(v.name, '') = COALESCE(?, '')`,
       ),
       getChildChunks: this.db.prepare<
         [string, string, string, number, string, bigint, number]
@@ -1309,6 +1331,48 @@ export class DocumentStore {
       return result !== undefined;
     } catch (error) {
       throw new ConnectionError("Failed to check document existence", error);
+    }
+  }
+
+  /**
+   * Returns up to `limit` stored chunk contents for a (library, version),
+   * used by the quality gate to sample text for relevance checks.
+   * @param library Library name (matched case-insensitively)
+   * @param version Normalized version string ("" for unversioned)
+   * @param limit Maximum number of chunk contents to return
+   */
+  async sampleChunkContents(
+    library: string,
+    version: string,
+    limit: number,
+  ): Promise<string[]> {
+    try {
+      const rows = this.statements.sampleChunkContents.all(
+        library.toLowerCase(),
+        version,
+        limit,
+      ) as Array<{ content: string }>;
+      return rows.map((row) => row.content);
+    } catch (error) {
+      throw new ConnectionError("Failed to sample chunk contents", error);
+    }
+  }
+
+  /**
+   * Returns the distinct indexed page URLs for a (library, version), used by the
+   * quality gate to compute the in-scope URL ratio.
+   * @param library Library name (matched case-insensitively)
+   * @param version Normalized version string ("" for unversioned)
+   */
+  async listPageUrls(library: string, version: string): Promise<string[]> {
+    try {
+      const rows = this.statements.listPageUrls.all(
+        library.toLowerCase(),
+        version,
+      ) as Array<{ url: string }>;
+      return rows.map((row) => row.url);
+    } catch (error) {
+      throw new ConnectionError("Failed to list page URLs", error);
     }
   }
 

--- a/src/tools/GetJobInfoTool.test.ts
+++ b/src/tools/GetJobInfoTool.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PipelineManager } from "../pipeline/PipelineManager";
-import { type PipelineJob, PipelineJobStatus } from "../pipeline/types";
+import {
+  type PipelineJob,
+  PipelineJobStatus,
+  ScrapeErrorCode,
+  ScrapeOutcome,
+} from "../pipeline/types";
 import { ToolError } from "./errors";
 import { GetJobInfoTool } from "./GetJobInfoTool"; // Updated import
 
@@ -65,6 +70,24 @@ describe("GetJobInfoTool", () => {
     expect(result.job?.startedAt).toBe(mockJob.startedAt?.toISOString());
     expect(result.job?.finishedAt).toBeNull(); // Based on mockJob
     expect(result.job?.error).toBeNull(); // Based on mockJob
+  });
+
+  it("exposes outcome and errorCode for a gate-failed job", async () => {
+    const gateFailedJob: PipelineJob = {
+      ...mockJob,
+      id: "gate-failed-job",
+      status: PipelineJobStatus.FAILED,
+      outcome: ScrapeOutcome.EMPTY,
+      errorCode: ScrapeErrorCode.EMPTY_RESULT,
+    };
+    (mockManagerInstance.getJob as ReturnType<typeof vi.fn>).mockResolvedValue(
+      gateFailedJob,
+    );
+
+    const result = await getJobInfoTool.execute({ jobId: "gate-failed-job" });
+
+    expect(result.job.outcome).toBe("empty");
+    expect(result.job.errorCode).toBe("EMPTY_RESULT");
   });
 
   it("should throw ToolError if the job is not found", async () => {

--- a/src/tools/GetJobInfoTool.ts
+++ b/src/tools/GetJobInfoTool.ts
@@ -1,5 +1,9 @@
 import type { IPipeline } from "../pipeline/trpc/interfaces";
-import type { PipelineJobStatus } from "../pipeline/types";
+import type {
+  PipelineJobStatus,
+  ScrapeErrorCode,
+  ScrapeOutcome,
+} from "../pipeline/types";
 import type { VersionStatus } from "../store/types";
 import { ToolError, ValidationError } from "./errors";
 
@@ -33,6 +37,10 @@ export interface JobInfo {
   // Additional database fields
   updatedAt?: string;
   errorMessage?: string; // Database error message
+  /** Quality classification of the finished job. */
+  outcome?: ScrapeOutcome;
+  /** Typed gate-failure reason with remediation in `errorMessage`. */
+  errorCode?: ScrapeErrorCode;
 }
 
 /**
@@ -99,6 +107,8 @@ export class GetJobInfoTool {
           : undefined,
       updatedAt: job.updatedAt?.toISOString(),
       errorMessage: job.errorMessage ?? undefined,
+      outcome: job.outcome,
+      errorCode: job.errorCode,
     };
 
     return { job: jobInfo };

--- a/src/tools/ListJobsTool.ts
+++ b/src/tools/ListJobsTool.ts
@@ -62,6 +62,8 @@ export class ListJobsTool {
             : undefined,
         updatedAt: job.updatedAt?.toISOString(),
         errorMessage: job.errorMessage ?? undefined,
+        outcome: job.outcome,
+        errorCode: job.errorCode,
       };
     });
 

--- a/src/tools/ScrapeTool.test.ts
+++ b/src/tools/ScrapeTool.test.ts
@@ -197,6 +197,30 @@ describe("ScrapeTool", () => {
     );
   });
 
+  it("forwards expectTerms, denyPaths, and localeStrategy into the scraper options", async () => {
+    const options: ScrapeToolOptions = {
+      ...getBaseOptions("1.0.0"),
+      waitForCompletion: false,
+      options: {
+        expectTerms: ["generateContent"],
+        denyPaths: ["**/demos/**"],
+        localeStrategy: "pin-en",
+      },
+    };
+
+    await scrapeTool.execute(options);
+
+    expect(mockManagerInstance.enqueueScrapeJob).toHaveBeenCalledWith(
+      "test-lib",
+      "1.0.0",
+      expect.objectContaining({
+        expectTerms: ["generateContent"],
+        denyPaths: ["**/demos/**"],
+        localeStrategy: "pin-en",
+      }),
+    );
+  });
+
   it("should pass preserveHashes to the pipeline manager", async () => {
     const options: ScrapeToolOptions = {
       ...getBaseOptions("2.0.0"),

--- a/src/tools/ScrapeTool.ts
+++ b/src/tools/ScrapeTool.ts
@@ -60,6 +60,21 @@ export interface ScrapeToolOptions {
      * @default true
      */
     clean?: boolean;
+    /**
+     * Terms expected to appear in the indexed docs. When set, the quality gate
+     * samples stored chunks and fails the job as OFF_TOPIC if none match.
+     */
+    expectTerms?: string[];
+    /**
+     * Glob patterns (minimatch) whose matching paths are excluded from indexing,
+     * even when in scope (default: demos/examples).
+     */
+    denyPaths?: string[];
+    /**
+     * Locale handling for fetched URLs ('pin-en' | 'strip' | 'passthrough').
+     * @default 'pin-en'
+     */
+    localeStrategy?: "pin-en" | "strip" | "passthrough";
   };
   /** If false, returns jobId immediately without waiting. Defaults to true. */
   waitForCompletion?: boolean;
@@ -154,6 +169,9 @@ export class ScrapeTool {
       preserveHashes: scraperOptions?.preserveHashes,
       headers: scraperOptions?.headers, // <-- propagate headers
       clean: scraperOptions?.clean, // <-- propagate clean option
+      expectTerms: scraperOptions?.expectTerms, // <-- quality gate: off-topic check
+      denyPaths: scraperOptions?.denyPaths, // <-- quality gate: path exclusions
+      localeStrategy: scraperOptions?.localeStrategy, // <-- locale normalization
     });
 
     // Conditionally wait for completion

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -173,6 +173,20 @@ export const DEFAULT_CONFIG = {
   },
 } as const;
 
+/**
+ * Default glob patterns (minimatch) excluded from indexing across all scrapes.
+ *
+ * Covers demo/example directories that bloat the index with non-documentation
+ * code. Both top-level (`demos/**`) and nested (`**\/demos/**`) forms are listed
+ * because minimatch's `**\/demos/**` does not match a top-level `demos/...` path.
+ */
+export const DEFAULT_DENY_PATHS = [
+  "demos/**",
+  "**/demos/**",
+  "examples/**",
+  "**/examples/**",
+];
+
 // --- Configuration Schema (Nested) ---
 
 export const AppConfigSchema = z.object({

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,4 +1,7 @@
 class ScraperError extends Error {
+  /** Optional machine-readable code surfaced to callers as errorCode. */
+  public code?: string;
+
   constructor(
     message: string,
     public readonly isRetryable: boolean = false,

--- a/test/fixtures/github-tree-generative-ai-docs.json
+++ b/test/fixtures/github-tree-generative-ai-docs.json
@@ -1,0 +1,8120 @@
+{
+  "sha": "866a0781ded2ff687f0e333ae82e0a99b0d6ecf1",
+  "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/866a0781ded2ff687f0e333ae82e0a99b0d6ecf1",
+  "tree": [
+    {
+      "path": ".github",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "d950ef7b16096e9ab1cd4a08eed01ef3e65df299",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/d950ef7b16096e9ab1cd4a08eed01ef3e65df299"
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "b1de0d2056f781ed37b51da9d4a8fa6285ee4c43",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/b1de0d2056f781ed37b51da9d4a8fa6285ee4c43"
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/bug_report.yml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "42860da3f81db2af8b5a65604800f525ef0b6f56",
+      "size": 699,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/42860da3f81db2af8b5a65604800f525ef0b6f56"
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/feature_request.yml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "af506e50ab5f4d4a86a07f3cca6ca8b0f5a5bb2f",
+      "size": 765,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/af506e50ab5f4d4a86a07f3cca6ca8b0f5a5bb2f"
+    },
+    {
+      "path": ".github/header-checker-lint.yml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "10307f9b530e5a590f9dc7cf3fbfba7037877cd9",
+      "size": 271,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/10307f9b530e5a590f9dc7cf3fbfba7037877cd9"
+    },
+    {
+      "path": ".github/labeler.yml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2ff705b08ff8025427ce44e43df853b22b47dbb5",
+      "size": 556,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2ff705b08ff8025427ce44e43df853b22b47dbb5"
+    },
+    {
+      "path": ".github/pull_request_template.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d5e614ea8f77a50661b87d51f9f5977bd62e740f",
+      "size": 1045,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d5e614ea8f77a50661b87d51f9f5977bd62e740f"
+    },
+    {
+      "path": ".github/workflows",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "6bae20049a0db5a1a02420bd78c7afbef7dcd92c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/6bae20049a0db5a1a02420bd78c7afbef7dcd92c"
+    },
+    {
+      "path": ".github/workflows/labeler.yml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6dcd9ab153bca36c17349d0d6cddcffb891bd0a6",
+      "size": 308,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6dcd9ab153bca36c17349d0d6cddcffb891bd0a6"
+    },
+    {
+      "path": ".github/workflows/notebooks.yml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "cce8386b9a900ffd343429d61b81ddf29e7742e3",
+      "size": 5085,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/cce8386b9a900ffd343429d61b81ddf29e7742e3"
+    },
+    {
+      "path": ".github/workflows/remove-issue-labels.yml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "43f43dd13bb10054d6dd5915783af454e580abad",
+      "size": 323,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/43f43dd13bb10054d6dd5915783af454e580abad"
+    },
+    {
+      "path": ".github/workflows/remove-pr-labels.yml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3aed6ced772c1f38ab4b069cc4c55fa9fa2236b1",
+      "size": 366,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3aed6ced772c1f38ab4b069cc4c55fa9fa2236b1"
+    },
+    {
+      "path": ".github/workflows/stale.yml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a4be21a69bb86771bf4615f5e65562cededb4bb5",
+      "size": 1916,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a4be21a69bb86771bf4615f5e65562cededb4bb5"
+    },
+    {
+      "path": ".gitignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b25b3fda422b93eeef9523b7364146b96aecf7a4",
+      "size": 121,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b25b3fda422b93eeef9523b7364146b96aecf7a4"
+    },
+    {
+      "path": "CODEOWNERS",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "15bac3062070f0f9c4a40409cb365379aa1fcf2d",
+      "size": 551,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/15bac3062070f0f9c4a40409cb365379aa1fcf2d"
+    },
+    {
+      "path": "CONTRIBUTING.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c4f7b2459f84e9a78f4256ef5215bd0806024530",
+      "size": 1513,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c4f7b2459f84e9a78f4256ef5215bd0806024530"
+    },
+    {
+      "path": "DEMO_MAINTAINERS.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "762573f779182a4612eb179ac69bd499cdc0eea5",
+      "size": 2827,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/762573f779182a4612eb179ac69bd499cdc0eea5"
+    },
+    {
+      "path": "LICENSE",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d645695673349e3947e8e5ae42332d0ac3164cd7",
+      "size": 11358,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d645695673349e3947e8e5ae42332d0ac3164cd7"
+    },
+    {
+      "path": "README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7e46c55c04420ea5eb309782b4b304aa7ab3e8c3",
+      "size": 1032,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7e46c55c04420ea5eb309782b4b304aa7ab3e8c3"
+    },
+    {
+      "path": "demos",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "452653fe0983184d12d16718cf67ae2965c10446",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/452653fe0983184d12d16718cf67ae2965c10446"
+    },
+    {
+      "path": "demos/palm",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "8e181f3aafd61e12572ffd6157972dccb2a33222",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/8e181f3aafd61e12572ffd6157972dccb2a33222"
+    },
+    {
+      "path": "demos/palm/README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "55daa6c6e56e5d7dce951c3cd573a0bd9ecd54a0",
+      "size": 767,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/55daa6c6e56e5d7dce951c3cd573a0bd9ecd54a0"
+    },
+    {
+      "path": "demos/palm/web",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "2a189b524a5a5f7597611b3762aedd3b95899294",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/2a189b524a5a5f7597611b3762aedd3b95899294"
+    },
+    {
+      "path": "demos/palm/web/list-it",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "076378da56c75f307ad54013377b2d106aa553d4",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/076378da56c75f307ad54013377b2d106aa553d4"
+    },
+    {
+      "path": "demos/palm/web/list-it/.eslintignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1eae0cf6700cebfee743504d0bdeaf642a11f012",
+      "size": 20,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1eae0cf6700cebfee743504d0bdeaf642a11f012"
+    },
+    {
+      "path": "demos/palm/web/list-it/.eslintrc.cjs",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b098e098244b30f83e44a086d2f8d5391dabe591",
+      "size": 1064,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b098e098244b30f83e44a086d2f8d5391dabe591"
+    },
+    {
+      "path": "demos/palm/web/list-it/.gcloudignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7ff76d8214940a25afdf6149b7cf64d225eae34d",
+      "size": 590,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7ff76d8214940a25afdf6149b7cf64d225eae34d"
+    },
+    {
+      "path": "demos/palm/web/list-it/.gitignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a547bf36d8d11a4f89c59c144f24795749086dd1",
+      "size": 253,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a547bf36d8d11a4f89c59c144f24795749086dd1"
+    },
+    {
+      "path": "demos/palm/web/list-it/.prettierrc",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4fa13de42002dfcf4d3d14cf17622a7dac731eeb",
+      "size": 181,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4fa13de42002dfcf4d3d14cf17622a7dac731eeb"
+    },
+    {
+      "path": "demos/palm/web/list-it/CONTRIBUTING.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "37ae0a447173aa160503302b2a55d10b7bc10eee",
+      "size": 1129,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/37ae0a447173aa160503302b2a55d10b7bc10eee"
+    },
+    {
+      "path": "demos/palm/web/list-it/LICENSE",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7a4a3ea2424c09fbe48d455aed1eaa94d9124835",
+      "size": 11357,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7a4a3ea2424c09fbe48d455aed1eaa94d9124835"
+    },
+    {
+      "path": "demos/palm/web/list-it/README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6291a2941dac4ec79399ce4c79d8da1fc9d7b8fe",
+      "size": 5761,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6291a2941dac4ec79399ce4c79d8da1fc9d7b8fe"
+    },
+    {
+      "path": "demos/palm/web/list-it/app.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5cba007b2a537c75e1e5c6f122c1d2a215ad66c0",
+      "size": 741,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5cba007b2a537c75e1e5c6f122c1d2a215ad66c0"
+    },
+    {
+      "path": "demos/palm/web/list-it/dev.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "72bbe6e154e5682f569533cbfee43c2eb23b38fd",
+      "size": 755,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/72bbe6e154e5682f569533cbfee43c2eb23b38fd"
+    },
+    {
+      "path": "demos/palm/web/list-it/index.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4e359a170ea640932fefda7866c42e0c5fa32996",
+      "size": 1252,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4e359a170ea640932fefda7866c42e0c5fa32996"
+    },
+    {
+      "path": "demos/palm/web/list-it/package-lock.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f69a9e4526bd158f91909a4035790120516944ad",
+      "size": 347377,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f69a9e4526bd158f91909a4035790120516944ad"
+    },
+    {
+      "path": "demos/palm/web/list-it/package.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "05ac0e27bd96db2d2517acdb23183a9510de8fbd",
+      "size": 1049,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/05ac0e27bd96db2d2517acdb23183a9510de8fbd"
+    },
+    {
+      "path": "demos/palm/web/list-it/src",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "23f079e4dc3d341f6f02925f002a9093acd377b2",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/23f079e4dc3d341f6f02925f002a9093acd377b2"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/App.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a6227b909d4ed2e10d4cf47a4c35015d9c563763",
+      "size": 2952,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a6227b909d4ed2e10d4cf47a4c35015d9c563763"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/assets",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "40388b87e48da567b8055ace7f3c1fa6c8190b00",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/40388b87e48da567b8055ace7f3c1fa6c8190b00"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/assets/icons",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "0d420a76962ea171e4b0c508245cb043f782d337",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/0d420a76962ea171e4b0c508245cb043f782d337"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/assets/icons/close.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "41142a15445efda8346fa994b314dbfb5ce2b238",
+      "size": 959,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/41142a15445efda8346fa994b314dbfb5ce2b238"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/assets/icons/lightbulb.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "378a55e40beae4870d928c33103d5e8b89da9178",
+      "size": 5031,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/378a55e40beae4870d928c33103d5e8b89da9178"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "140049231a4d2aac93bf68d0cbaac33621438a9b",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/140049231a4d2aac93bf68d0cbaac33621438a9b"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/list",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "c540697618ebc37456f121287b86ff30d3e01a7c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/c540697618ebc37456f121287b86ff30d3e01a7c"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/list/list.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "74a960208009370609e5d89f193344a1fb66b3f1",
+      "size": 4991,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/74a960208009370609e5d89f193344a1fb66b3f1"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/list/list.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "419b1f0523c165cfc7db440b7b560f5e534f0dc5",
+      "size": 4977,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/419b1f0523c165cfc7db440b7b560f5e534f0dc5"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/listLoading",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "a1deaceca3da62b084c7d2a448161edcaa18f1bc",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/a1deaceca3da62b084c7d2a448161edcaa18f1bc"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/listLoading/listLoading.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ab9a776f8c819f4e137a0e14ba5dac42f4d18c9e",
+      "size": 946,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ab9a776f8c819f4e137a0e14ba5dac42f4d18c9e"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/listLoading/listLoading.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c0310b845b81ca07010470468b94c1a7b5764856",
+      "size": 743,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c0310b845b81ca07010470468b94c1a7b5764856"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/listSuggestions",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "5aafd1036399d6512820931cc108968c3bb6fe73",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/5aafd1036399d6512820931cc108968c3bb6fe73"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/listSuggestions/listSuggestions.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b14bbd3b9880a1499fbff4c7f1c2b7b3611436f9",
+      "size": 1455,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b14bbd3b9880a1499fbff4c7f1c2b7b3611436f9"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/listSuggestions/listSuggestions.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e0958c2d1c0de215b1e2d548f5d6cd5f81e14ef5",
+      "size": 1035,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e0958c2d1c0de215b1e2d548f5d6cd5f81e14ef5"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/textarea",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "3a33c5a94137a1086b2ad7bc6e9ed4daed6b15c5",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/3a33c5a94137a1086b2ad7bc6e9ed4daed6b15c5"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/textarea/textarea.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3238a4872b1f7e7f3cbf72ae3b2a684328c41637",
+      "size": 6708,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3238a4872b1f7e7f3cbf72ae3b2a684328c41637"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/textarea/textarea.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7fc99ef0769e6a2666e3a5f78fbb1d97d3efe142",
+      "size": 3550,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7fc99ef0769e6a2666e3a5f78fbb1d97d3efe142"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/tip",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "7dba43289ca81490dfa9717f972e4fd8c7be425b",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/7dba43289ca81490dfa9717f972e4fd8c7be425b"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/tip/tip.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c301cbe6c5f08dd50b883a3b3b2f8f01c389116e",
+      "size": 1543,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c301cbe6c5f08dd50b883a3b3b2f8f01c389116e"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/tip/tip.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e1c712482ca74a01e195024c682b0f3b174c80a8",
+      "size": 2434,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e1c712482ca74a01e195024c682b0f3b174c80a8"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "5b51177fdf1660ab46d0ac1676c1495246bd24d3",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/5b51177fdf1660ab46d0ac1676c1495246bd24d3"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui/button",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "de583dac86215ba010dc878222969e57ac9cdb9f",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/de583dac86215ba010dc878222969e57ac9cdb9f"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui/button/button.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e375a53e66d8b1ff56a9f1c6b03e0a259e22d42a",
+      "size": 1429,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e375a53e66d8b1ff56a9f1c6b03e0a259e22d42a"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui/button/button.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b1999a0dbb54bbeef3437860310ee44c846b46dc",
+      "size": 1673,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b1999a0dbb54bbeef3437860310ee44c846b46dc"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui/errorComponent",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "93c5af65b267520c02610ef4b574718b12b8ded5",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/93c5af65b267520c02610ef4b574718b12b8ded5"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui/errorComponent/errorComponent.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5782a379d76756f9493934cd292d1377ad30fe1d",
+      "size": 1978,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5782a379d76756f9493934cd292d1377ad30fe1d"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui/errorComponent/errorComponent.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bc9e70c0090f590d2b129b9999acc4b2dcb08154",
+      "size": 2006,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bc9e70c0090f590d2b129b9999acc4b2dcb08154"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui/header",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "e5b50a1ba55b662ece123c921cd32b8257569502",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/e5b50a1ba55b662ece123c921cd32b8257569502"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui/header/header.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8bb8abe7cb9dcc1c893b83a91cc56f4ffdd51457",
+      "size": 1872,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8bb8abe7cb9dcc1c893b83a91cc56f4ffdd51457"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui/header/header.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5ac116cac6d946c3e0618b626c260db861ca445c",
+      "size": 1969,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5ac116cac6d946c3e0618b626c260db861ca445c"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui/icon",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "c6ffc6d169fae9b96d23c896322dcf1dd44f4c30",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/c6ffc6d169fae9b96d23c896322dcf1dd44f4c30"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui/icon/icon.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bf653a422a36941533a1d294a4f6f03c7b79ff9b",
+      "size": 957,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bf653a422a36941533a1d294a4f6f03c7b79ff9b"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui/icon/icon.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f8489c3e6b39c8ffe424fd76475bb949188387ec",
+      "size": 691,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f8489c3e6b39c8ffe424fd76475bb949188387ec"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui/loading",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "eedcecbb5da1fc01890810aaf9f6f40762e5c2f4",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/eedcecbb5da1fc01890810aaf9f6f40762e5c2f4"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui/loading/loading.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6da71eaeb0492f98234739be57e00d867a38a3fd",
+      "size": 1022,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6da71eaeb0492f98234739be57e00d867a38a3fd"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui/loading/loading.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "31d5f3cb5c407c6e3adc39aa4d7ce40a37ab79a9",
+      "size": 873,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/31d5f3cb5c407c6e3adc39aa4d7ce40a37ab79a9"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui/spacer",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "18dba3c51562d5706dd4354709723b21fb0d6db6",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/18dba3c51562d5706dd4354709723b21fb0d6db6"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui/spacer/spacer.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "94d0a80c2d6c73725303fa587631f50260d2836d",
+      "size": 2962,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/94d0a80c2d6c73725303fa587631f50260d2836d"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/components/ui/spacer/spacer.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ca2ce443816b5d300feb3025c5c078e7864d4879",
+      "size": 777,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ca2ce443816b5d300feb3025c5c078e7864d4879"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/lib",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "49a37d47b5e522e6c394c0614e1f8d1ce335b73f",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/49a37d47b5e522e6c394c0614e1f8d1ce335b73f"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/lib/api.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a028246620ea031c859725a67ff180539df27716",
+      "size": 3092,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a028246620ea031c859725a67ff180539df27716"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/lib/firebase.config.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "92621fab16de7d0018f284c9f3bee6e3aaabfb52",
+      "size": 2050,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/92621fab16de7d0018f284c9f3bee6e3aaabfb52"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/lib/priming.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1801fd5f3fd5aff5ebabc719065fea146818760d",
+      "size": 5312,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1801fd5f3fd5aff5ebabc719065fea146818760d"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/lib/utils.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "eb75e0d3dc88e3ff265d8245c6b84d5ab2be5a7e",
+      "size": 3536,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/eb75e0d3dc88e3ff265d8245c6b84d5ab2be5a7e"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/main.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6b3cb2c31d704398d926d09322dc2275c67f33f8",
+      "size": 757,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6b3cb2c31d704398d926d09322dc2275c67f33f8"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/store.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8d245af35e6247c78dd37cc41434c197cd3389ed",
+      "size": 2633,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8d245af35e6247c78dd37cc41434c197cd3389ed"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/styles",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "040ba91844d42cbde73bcd0e74d00738c6681368",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/040ba91844d42cbde73bcd0e74d00738c6681368"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/styles/app.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1488fd3fe269ed3c403893c2ad6c9020535d5bd4",
+      "size": 2356,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1488fd3fe269ed3c403893c2ad6c9020535d5bd4"
+    },
+    {
+      "path": "demos/palm/web/list-it/src/styles/variables.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d98c338854804d0ddd87c0f2c07391a6dfbb1cad",
+      "size": 1109,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d98c338854804d0ddd87c0f2c07391a6dfbb1cad"
+    },
+    {
+      "path": "demos/palm/web/list-it/staging.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "81b676dbc6d7c5f81786bb1cf3dbf4786f13af3d",
+      "size": 759,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/81b676dbc6d7c5f81786bb1cf3dbf4786f13af3d"
+    },
+    {
+      "path": "demos/palm/web/list-it/vite.config.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5c49bfc58698d4a8b5130bf76b7fbf5b6490bea1",
+      "size": 899,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5c49bfc58698d4a8b5130bf76b7fbf5b6490bea1"
+    },
+    {
+      "path": "demos/palm/web/list-it/yarn.lock",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a42fec95de091038d673596af2cdfe398514a3db",
+      "size": 131316,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a42fec95de091038d673596af2cdfe398514a3db"
+    },
+    {
+      "path": "demos/palm/web/mood-food",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "7517cde333c538a0b63ae97c7591911f3ddfbb39",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/7517cde333c538a0b63ae97c7591911f3ddfbb39"
+    },
+    {
+      "path": "demos/palm/web/mood-food/.env",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "32ae33af3315ecd44b43565665167ec036cdcdab",
+      "size": 42,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/32ae33af3315ecd44b43565665167ec036cdcdab"
+    },
+    {
+      "path": "demos/palm/web/mood-food/.eslintignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "78282dc9bd5962287e07787c94d50eb68ab7fc78",
+      "size": 130,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/78282dc9bd5962287e07787c94d50eb68ab7fc78"
+    },
+    {
+      "path": "demos/palm/web/mood-food/.eslintrc",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4661567c5b7d9b1ab1354edfaa6f4808c01b2284",
+      "size": 1777,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4661567c5b7d9b1ab1354edfaa6f4808c01b2284"
+    },
+    {
+      "path": "demos/palm/web/mood-food/.gcloudignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f4b4ef500f9bfacb4f1c3701d51964a72766231c",
+      "size": 135,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f4b4ef500f9bfacb4f1c3701d51964a72766231c"
+    },
+    {
+      "path": "demos/palm/web/mood-food/.gitignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d4734d12fa3baf8b6eddad4bda8c8d00fe050576",
+      "size": 281,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d4734d12fa3baf8b6eddad4bda8c8d00fe050576"
+    },
+    {
+      "path": "demos/palm/web/mood-food/.prettierignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e38ee0acc9ec0ffac8301e1f2b86a0fd17e1b287",
+      "size": 69,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e38ee0acc9ec0ffac8301e1f2b86a0fd17e1b287"
+    },
+    {
+      "path": "demos/palm/web/mood-food/.prettierrc",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6f5526c7ebe3adfaa5050c45149b86d8c4faa71a",
+      "size": 90,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6f5526c7ebe3adfaa5050c45149b86d8c4faa71a"
+    },
+    {
+      "path": "demos/palm/web/mood-food/CODE_OF_CONDUCT.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9cbae80c5766a6b85ff07f6382d38e1dbf7efa95",
+      "size": 4473,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9cbae80c5766a6b85ff07f6382d38e1dbf7efa95"
+    },
+    {
+      "path": "demos/palm/web/mood-food/CONTRIBUTING.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8956a61b820b4e6e69be58f329bc53f62557c3f2",
+      "size": 1067,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8956a61b820b4e6e69be58f329bc53f62557c3f2"
+    },
+    {
+      "path": "demos/palm/web/mood-food/LICENSE",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64",
+      "size": 11357,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64"
+    },
+    {
+      "path": "demos/palm/web/mood-food/README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f31ee181c1383737f02d5bc7a9f96f9a422ef989",
+      "size": 8640,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f31ee181c1383737f02d5bc7a9f96f9a422ef989"
+    },
+    {
+      "path": "demos/palm/web/mood-food/app.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "740f32c479040052cc12b5e97e2827e3bc7f266b",
+      "size": 820,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/740f32c479040052cc12b5e97e2827e3bc7f266b"
+    },
+    {
+      "path": "demos/palm/web/mood-food/config-overrides.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "edafdfeb1c4a80fc4bb3e0474fd38e3a1b71f4ef",
+      "size": 1132,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/edafdfeb1c4a80fc4bb3e0474fd38e3a1b71f4ef"
+    },
+    {
+      "path": "demos/palm/web/mood-food/docs",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "39369e2f0304232bc96ff55cfc8f3e8a39141e7f",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/39369e2f0304232bc96ff55cfc8f3e8a39141e7f"
+    },
+    {
+      "path": "demos/palm/web/mood-food/docs/llm_prompt_design_diagram.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "98f2d802f70c304c1a8c47eeec10cffb3f8397e4",
+      "size": 81352,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/98f2d802f70c304c1a8c47eeec10cffb3f8397e4"
+    },
+    {
+      "path": "demos/palm/web/mood-food/docs/mood_food_demo.gif",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7e269cf0a677c4da100c291bd23c2817d502fc9d",
+      "size": 994215,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7e269cf0a677c4da100c291bd23c2817d502fc9d"
+    },
+    {
+      "path": "demos/palm/web/mood-food/docs/mood_food_header.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "856e40b9bd6ea5641498e1108815a7bc22132d3b",
+      "size": 91641,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/856e40b9bd6ea5641498e1108815a7bc22132d3b"
+    },
+    {
+      "path": "demos/palm/web/mood-food/index.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0afdd86c7b59722d716ca55e549bb6a32a2af64c",
+      "size": 1264,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0afdd86c7b59722d716ca55e549bb6a32a2af64c"
+    },
+    {
+      "path": "demos/palm/web/mood-food/jsconfig.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a0f1aca809451aca36fa8b742a277370264c59b3",
+      "size": 178,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a0f1aca809451aca36fa8b742a277370264c59b3"
+    },
+    {
+      "path": "demos/palm/web/mood-food/package.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f6cc23ddb65f3adc5c11427a172ac03bffe62891",
+      "size": 1137,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f6cc23ddb65f3adc5c11427a172ac03bffe62891"
+    },
+    {
+      "path": "demos/palm/web/mood-food/public",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "03383788385f67c8604111903203e179a0b44f9b",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/03383788385f67c8604111903203e179a0b44f9b"
+    },
+    {
+      "path": "demos/palm/web/mood-food/public/icon.svg",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2c330e1f85c2d6a4be84ca25c775da4ef67f9819",
+      "size": 8134,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2c330e1f85c2d6a4be84ca25c775da4ef67f9819"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "894f60d8443b23097cdd8f79b6a9e0633942bb3a",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/894f60d8443b23097cdd8f79b6a9e0633942bb3a"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/apis",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "0165d4c7e00525a2b2b821f58f53d0ce9e341650",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/0165d4c7e00525a2b2b821f58f53d0ce9e341650"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/apis/llmCaller.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f7c7e704a9bca2c26cab65cfe1411b72603afec7",
+      "size": 1662,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f7c7e704a9bca2c26cab65cfe1411b72603afec7"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "858c20b1288f286221ca564082fa8f4a6f386d95",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/858c20b1288f286221ca564082fa8f4a6f386d95"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets/icons",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "9c7321b39f44273a688cc4dac502b7ff4988276f",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/9c7321b39f44273a688cc4dac502b7ff4988276f"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets/icons/ChefLogo.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "262e5db9a79d97f85cc10c551bb3d7eed45a6b40",
+      "size": 8848,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/262e5db9a79d97f85cc10c551bb3d7eed45a6b40"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets/icons/Close.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "91a91bc515ae912f3fdf88a55eca18a0507c1c93",
+      "size": 939,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/91a91bc515ae912f3fdf88a55eca18a0507c1c93"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets/icons/Decorator.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a09d448f5ede93eed1c7c6a5bb6d5ab93618b68a",
+      "size": 6956,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a09d448f5ede93eed1c7c6a5bb6d5ab93618b68a"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets/icons/MoodFoodLogo.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "161e8308a699ecfd75437f6aca6512a219b219f9",
+      "size": 28006,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/161e8308a699ecfd75437f6aca6512a219b219f9"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets/icons/ServingLogo.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bcaa72c62f18de73de20e2fdae6370863f8c48c6",
+      "size": 6139,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bcaa72c62f18de73de20e2fdae6370863f8c48c6"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets/icons/SolidArrowDown.svg",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d826c9b3eb58f5051dfc6b6ae85689c1fc1b2fac",
+      "size": 149,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d826c9b3eb58f5051dfc6b6ae85689c1fc1b2fac"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets/icons/index.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "336b4a28092714f4614d20295607dbae36ea72ed",
+      "size": 848,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/336b4a28092714f4614d20295607dbae36ea72ed"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets/lotties",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "8587b649dad090bf3ec64037ff68dda60b4cbcaa",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/8587b649dad090bf3ec64037ff68dda60b4cbcaa"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets/lotties/loading_pan_01.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "130790c4503b4977247bd05726eb504566baf5f5",
+      "size": 9578,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/130790c4503b4977247bd05726eb504566baf5f5"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets/patterns",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "446e9b8b696bb85fdb68a63fffef909acd3ca238",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/446e9b8b696bb85fdb68a63fffef909acd3ca238"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets/patterns/index.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "53b7b924d8d2540151795b2f87c0c2ada35faad5",
+      "size": 884,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/53b7b924d8d2540151795b2f87c0c2ada35faad5"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets/patterns/pattern1.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "758c54b0fd00002b522c7606a410b2f6c7559100",
+      "size": 6259,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/758c54b0fd00002b522c7606a410b2f6c7559100"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets/patterns/pattern2.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5337d2ba00cb27aaf10dc8939b376c5dfc1acbde",
+      "size": 6958,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5337d2ba00cb27aaf10dc8939b376c5dfc1acbde"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets/patterns/pattern3.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a342ade705fae3704449e32469b5359619e553d8",
+      "size": 22832,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a342ade705fae3704449e32469b5359619e553d8"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets/patterns/pattern4.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b888f2d82badb361fd1b05128f9772bb0c702f33",
+      "size": 10684,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b888f2d82badb361fd1b05128f9772bb0c702f33"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets/patterns/pattern5.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9f6a15bf401652114cafe33879111f8c43acc81c",
+      "size": 7017,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9f6a15bf401652114cafe33879111f8c43acc81c"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/assets/patterns/pattern6.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d076dfe86f1c78b1e4ed830de6e4122a3e8b2d41",
+      "size": 12084,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d076dfe86f1c78b1e4ed830de6e4122a3e8b2d41"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/components",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "f9615d5a1c44253244c14e66a8a33678499ab05b",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/f9615d5a1c44253244c14e66a8a33678499ab05b"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/components/BotResponses.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d6284deb3d3d47100d4d5dc6dfcba4102a1be21c",
+      "size": 2729,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d6284deb3d3d47100d4d5dc6dfcba4102a1be21c"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/components/ChatInput.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3960f38fc3a11a6ea50e7b228cc38c8936faa0fe",
+      "size": 1721,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3960f38fc3a11a6ea50e7b228cc38c8936faa0fe"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/components/Dialogue.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e189790be3254b61e8ba7d24b6320b608a0f10be",
+      "size": 1173,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e189790be3254b61e8ba7d24b6320b608a0f10be"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/components/HeroCard.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bbe7a1329636331b4431ddfca54a81d7860c96a4",
+      "size": 2784,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bbe7a1329636331b4431ddfca54a81d7860c96a4"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/components/ImageGenerator.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "33934addfc10ae23b251886cc5013a95a3cd1a83",
+      "size": 2060,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/33934addfc10ae23b251886cc5013a95a3cd1a83"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/components/Ingredients.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ce431386b96f4b6649a6b07745f0eeb6b6b3f141",
+      "size": 5797,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ce431386b96f4b6649a6b07745f0eeb6b6b3f141"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/components/OnBoardingCard.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "54f239f40e2a549694be6fb73afaa471e26d5e03",
+      "size": 3271,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/54f239f40e2a549694be6fb73afaa471e26d5e03"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/components/PrePromptsPanel.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2944f08f6b3e6a9e65872314756403bc48d5254d",
+      "size": 1766,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2944f08f6b3e6a9e65872314756403bc48d5254d"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/components/PredefineMessage.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "791eba38aaa976f03bde32beace561a44e5587d5",
+      "size": 1009,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/791eba38aaa976f03bde32beace561a44e5587d5"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/components/PromptCard.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1b667d13e29f2d7133198d677d49a87d05a4dbeb",
+      "size": 1170,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1b667d13e29f2d7133198d677d49a87d05a4dbeb"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/data",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "1630a7fd9864dc3d30541ec34c6290b02754175b",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/1630a7fd9864dc3d30541ec34c6290b02754175b"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/data/fonts.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "58d7c34a727b86e4a3cb61d9ae853d1b895322de",
+      "size": 741,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/58d7c34a727b86e4a3cb61d9ae853d1b895322de"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/data/hero.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e61951950657ef943a7cbe72af08cca74380bc3c",
+      "size": 1502,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e61951950657ef943a7cbe72af08cca74380bc3c"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/data/palettes.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "90edec243c305d2ed2349e73b77bb79752793e53",
+      "size": 899,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/90edec243c305d2ed2349e73b77bb79752793e53"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/fonts.css",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f98c244d454a3f1adf05ebbc91c9c07c077c14bf",
+      "size": 2289,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f98c244d454a3f1adf05ebbc91c9c07c077c14bf"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/fonts",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "065df133ea8ef0ddd3d367c2a679fa84d9bf955c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/065df133ea8ef0ddd3d367c2a679fa84d9bf955c"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/fonts/GoogleSans",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "740e6a6483c69be504ed9ea37ddf96ce08100087",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/740e6a6483c69be504ed9ea37ddf96ce08100087"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/fonts/GoogleSans/GoogleSans-Bold.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "80497666ec8ca0abb81ce5bd9ce649896555753e",
+      "size": 117916,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/80497666ec8ca0abb81ce5bd9ce649896555753e"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/fonts/GoogleSans/GoogleSans-BoldItalic.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e940d022ecbcfe05b53085f48a871ce39509fa30",
+      "size": 121080,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e940d022ecbcfe05b53085f48a871ce39509fa30"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/fonts/GoogleSans/GoogleSans-Italic.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bfb1a2cd2c63a5dd176fe273c06a19184ce556fb",
+      "size": 121280,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bfb1a2cd2c63a5dd176fe273c06a19184ce556fb"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/fonts/GoogleSans/GoogleSans-Medium.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1543660daf312c87535cb387f57da10c2e626626",
+      "size": 118508,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1543660daf312c87535cb387f57da10c2e626626"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/fonts/GoogleSans/GoogleSans-MediumItalic.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7c1667bbfbcfb996e5a59e725602158537da20b6",
+      "size": 121216,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7c1667bbfbcfb996e5a59e725602158537da20b6"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/fonts/GoogleSans/GoogleSans-Regular.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ab605f9e2e3c347708a810435ba3a7debc52e1df",
+      "size": 119984,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ab605f9e2e3c347708a810435ba3a7debc52e1df"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/hooks",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "b6b27d79604b2e1463250d2e029ff0d80ec1adb5",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/b6b27d79604b2e1463250d2e029ff0d80ec1adb5"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/hooks/useChat.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0ad15d36a4e6f5894f4f732ce03d88311a637f33",
+      "size": 9477,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0ad15d36a4e6f5894f4f732ce03d88311a637f33"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/hooks/useImageResize.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b27b85b482c175d816e5713703be9fdc53be6553",
+      "size": 1173,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b27b85b482c175d816e5713703be9fdc53be6553"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/index.css",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "22c1995a5d4c0bacfdea6f90712001229351471b",
+      "size": 1411,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/22c1995a5d4c0bacfdea6f90712001229351471b"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/main.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ef96b186a266795e75ae5ab731fda6b6b8e84085",
+      "size": 1401,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ef96b186a266795e75ae5ab731fda6b6b8e84085"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/pages",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "300cd154464d085e752f1a674c9f306bd86bbecc",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/300cd154464d085e752f1a674c9f306bd86bbecc"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/pages/chat.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b425b3d6870a6aa04b19aeef66d36a01b4c527c2",
+      "size": 4875,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b425b3d6870a6aa04b19aeef66d36a01b4c527c2"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/pages/home.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3d2e60f0f99a2aecc48a8688eb30aaac2f74a65a",
+      "size": 2614,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3d2e60f0f99a2aecc48a8688eb30aaac2f74a65a"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/utils",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "60622fdb0133f521a9ea94b7af345b61d15dea66",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/60622fdb0133f521a9ea94b7af345b61d15dea66"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/utils/images.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "747a1f0e4a5e3ca3cfcca7d679fec1444fd07e61",
+      "size": 2335,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/747a1f0e4a5e3ca3cfcca7d679fec1444fd07e61"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/utils/ingredientHeader.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ced10dcfa77f8468f0c19836ed43fe2d7a136ea8",
+      "size": 2084,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ced10dcfa77f8468f0c19836ed43fe2d7a136ea8"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/utils/llmTextParser.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a4e51b218b712e7912854a39f2292718c7f6487f",
+      "size": 1592,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a4e51b218b712e7912854a39f2292718c7f6487f"
+    },
+    {
+      "path": "demos/palm/web/mood-food/src/utils/orderlist.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c26b57ff74abbb14822bf4829053b3b59415dbb1",
+      "size": 736,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c26b57ff74abbb14822bf4829053b3b59415dbb1"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "3cf60415e48747da1b1ce246f1bd3a9bf95b63e5",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/3cf60415e48747da1b1ce246f1bd3a9bf95b63e5"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "97fd95559bf45e136bf1287e319156d72213ee77",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/97fd95559bf45e136bf1287e319156d72213ee77"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/CinzelDecorative",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "9131c81df3ba1025260668faa8dca62b1494387f",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/9131c81df3ba1025260668faa8dca62b1494387f"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/CinzelDecorative/CinzelDecorative-Regular.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f2ae7a05e1ee89dd39dd6c0f1fe6f8b2a89d4764",
+      "size": 58828,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f2ae7a05e1ee89dd39dd6c0f1fe6f8b2a89d4764"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/CinzelDecorative/OFL.txt",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "efe1168f1c8de9d560f84355f9b8d699536118d5",
+      "size": 4393,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/efe1168f1c8de9d560f84355f9b8d699536118d5"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/JosefinSans",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "6bdfbad6a7884fbad7fd62e331eebd0e38855d9b",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/6bdfbad6a7884fbad7fd62e331eebd0e38855d9b"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/JosefinSans/JosefinSans-Regular.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "15e9d8fd1ec7719b7840a3113ea00dc3a97c5467",
+      "size": 59296,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/15e9d8fd1ec7719b7840a3113ea00dc3a97c5467"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/JosefinSans/OFL.txt",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b87b0194e76d65530c1ecf08bb3f3631c6ea4459",
+      "size": 4449,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b87b0194e76d65530c1ecf08bb3f3631c6ea4459"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/Milonga",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "e7acab3153900ad135707297323836666459d2e4",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/e7acab3153900ad135707297323836666459d2e4"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/Milonga/Milonga-Regular.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e2938e55cfa6d0f604f8f840011f4f78501ae5b9",
+      "size": 205448,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e2938e55cfa6d0f604f8f840011f4f78501ae5b9"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/Milonga/OFL.txt",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "170ce53d7314bbfda569a341ff8ce1f5bbc47c13",
+      "size": 4555,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/170ce53d7314bbfda569a341ff8ce1f5bbc47c13"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/Sacramento",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "9c664e2c03ad97b1c944a95053296e5a8bf1257c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/9c664e2c03ad97b1c944a95053296e5a8bf1257c"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/Sacramento/OFL.txt",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ab66add4d8995ca32408b2098794791852644676",
+      "size": 4431,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ab66add4d8995ca32408b2098794791852644676"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/Sacramento/Sacramento-Regular.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b1972ff1bdf0cc2f26daa5d6120d2589c3552d79",
+      "size": 64808,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b1972ff1bdf0cc2f26daa5d6120d2589c3552d79"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/TulpenOne",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "d525587d514c5c48e9b8cdeced88b22ea7acdb83",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/d525587d514c5c48e9b8cdeced88b22ea7acdb83"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/TulpenOne/OFL.txt",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1d33d0a8a436e44e55e9851a2cab9a2a52df84f6",
+      "size": 4391,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1d33d0a8a436e44e55e9851a2cab9a2a52df84f6"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/TulpenOne/TulpenOne-Regular.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d74e3ee7ed913c59b08c8dc13d9242f52f4f6f2e",
+      "size": 33916,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d74e3ee7ed913c59b08c8dc13d9242f52f4f6f2e"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/Ultra",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "277809b903aefb42e37a3ce74aa1a43a9a107f80",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/277809b903aefb42e37a3ce74aa1a43a9a107f80"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/Ultra/LICENSE.txt",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d645695673349e3947e8e5ae42332d0ac3164cd7",
+      "size": 11358,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d645695673349e3947e8e5ae42332d0ac3164cd7"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/Ultra/Ultra-Regular.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "22526d4ec3951aa4c0886c66f0ce1cefd26b8ddc",
+      "size": 51084,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/22526d4ec3951aa4c0886c66f0ce1cefd26b8ddc"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/Urbanist",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "18c0bffed4fdebb042638ecbb7bc8cff7ddc6abb",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/18c0bffed4fdebb042638ecbb7bc8cff7ddc6abb"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/Urbanist/OFL.txt",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "828d6f7cb00f110ebfeffb0bcf1fe43312f53d3f",
+      "size": 4385,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/828d6f7cb00f110ebfeffb0bcf1fe43312f53d3f"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/Urbanist/Urbanist-Regular.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e4199ed0f863fda41bb63987e95943ce9047e700",
+      "size": 42028,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e4199ed0f863fda41bb63987e95943ce9047e700"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/WireOne",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "fa17fd70219b3e2c1e91571e2ac1dc771b50656c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/fa17fd70219b3e2c1e91571e2ac1dc771b50656c"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/WireOne/OFL.txt",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d7dc15434b2eca94e76b684b5a96f79bc85cda7b",
+      "size": 4388,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d7dc15434b2eca94e76b684b5a96f79bc85cda7b"
+    },
+    {
+      "path": "demos/palm/web/mood-food/third_party/fonts/WireOne/WireOne-Regular.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "cb7de8b09d10d467f85f4c77eed256bc684830d9",
+      "size": 46192,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/cb7de8b09d10d467f85f4c77eed256bc684830d9"
+    },
+    {
+      "path": "demos/palm/web/mood-food/vite.config.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c0306ca046a6ae661359fc6f00edc8804a3b9b4c",
+      "size": 1568,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c0306ca046a6ae661359fc6f00edc8804a3b9b4c"
+    },
+    {
+      "path": "demos/palm/web/mood-food/yarn.lock",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "40427ced061c80c307e204e1600f9c722d001871",
+      "size": 403248,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/40427ced061c80c307e204e1600f9c722d001871"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "700ec958730b17d0b1fe86ca994b9672d88a642c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/700ec958730b17d0b1fe86ca994b9672d88a642c"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/.eslintignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "763301fc0025d020fbc9fb3a0781097e8e036d9c",
+      "size": 19,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/763301fc0025d020fbc9fb3a0781097e8e036d9c"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/.eslintrc.cjs",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b098e098244b30f83e44a086d2f8d5391dabe591",
+      "size": 1064,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b098e098244b30f83e44a086d2f8d5391dabe591"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/.gcloudignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "be08419a8cecf7c9cb3c10e87cfe4b8300652f23",
+      "size": 73,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/be08419a8cecf7c9cb3c10e87cfe4b8300652f23"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/.gitignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a547bf36d8d11a4f89c59c144f24795749086dd1",
+      "size": 253,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a547bf36d8d11a4f89c59c144f24795749086dd1"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/.prettierrc",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4fa13de42002dfcf4d3d14cf17622a7dac731eeb",
+      "size": 181,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4fa13de42002dfcf4d3d14cf17622a7dac731eeb"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/CONTRIBUTING.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "37ae0a447173aa160503302b2a55d10b7bc10eee",
+      "size": 1129,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/37ae0a447173aa160503302b2a55d10b7bc10eee"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/LICENSE",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7a4a3ea2424c09fbe48d455aed1eaa94d9124835",
+      "size": 11357,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7a4a3ea2424c09fbe48d455aed1eaa94d9124835"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "021fdc116a4fafa925c25dbe68c7f0945c25cc58",
+      "size": 6926,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/021fdc116a4fafa925c25dbe68c7f0945c25cc58"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/app.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5cba007b2a537c75e1e5c6f122c1d2a215ad66c0",
+      "size": 741,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5cba007b2a537c75e1e5c6f122c1d2a215ad66c0"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/dev.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "72bbe6e154e5682f569533cbfee43c2eb23b38fd",
+      "size": 755,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/72bbe6e154e5682f569533cbfee43c2eb23b38fd"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/index.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "23318b1177bd1b04b892c2e75a9063c8e18c7c25",
+      "size": 1570,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/23318b1177bd1b04b892c2e75a9063c8e18c7c25"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/package-lock.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c929a59cf65028a6b788f5362b8c1c52df7776fc",
+      "size": 330653,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c929a59cf65028a6b788f5362b8c1c52df7776fc"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/package.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9ac5e1c42dfdbb3cde026b1d80441c1d263c6067",
+      "size": 1130,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9ac5e1c42dfdbb3cde026b1d80441c1d263c6067"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/public",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "2ff1fd5148c20d1664ce15b35a99cff5cfebb8f7",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/2ff1fd5148c20d1664ce15b35a99cff5cfebb8f7"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/public/android-chrome-192x192.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0f7d8e1b8ed955a10841750a1dff7d931a2adb89",
+      "size": 6900,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0f7d8e1b8ed955a10841750a1dff7d931a2adb89"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/public/android-chrome-512x512.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bee974866225a22ce289b6371cbafc716a33169d",
+      "size": 23015,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bee974866225a22ce289b6371cbafc716a33169d"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/public/apple-touch-icon.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "593a199bac97a0aa4a94aebbf940427e8821e035",
+      "size": 6176,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/593a199bac97a0aa4a94aebbf940427e8821e035"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/public/favicon-16x16.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d32ee3855e88d49d8c0d9c67af27f3ceb458ae28",
+      "size": 419,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d32ee3855e88d49d8c0d9c67af27f3ceb458ae28"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/public/favicon-32x32.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ac663e84be6539ee108af261f500f839c77d79b1",
+      "size": 926,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ac663e84be6539ee108af261f500f839c77d79b1"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/public/favicon.ico",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b2d3b139f6d0063bc9048fe3d14aaf0c42ac61b6",
+      "size": 15406,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b2d3b139f6d0063bc9048fe3d14aaf0c42ac61b6"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/public/img",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "deb347513a5fae414e952c880daa5b9df1525c8c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/deb347513a5fae414e952c880daa5b9df1525c8c"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/public/img/emojis.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fbc355678edb889a930e8bc4a8ccf05a04081b0f",
+      "size": 285200,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fbc355678edb889a930e8bc4a8ccf05a04081b0f"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/public/site.webmanifest",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fa99de77db6ead952ba6fef2e42f1525cc0a2968",
+      "size": 360,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fa99de77db6ead952ba6fef2e42f1525cc0a2968"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/public/sounds",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "1b65fe698048a0802c56d9262fe2868395265809",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/1b65fe698048a0802c56d9262fe2868395265809"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/public/sounds/forbidden-word.mp3",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "785c46876a05889f5c9ad2b6d1b5a19355929ea8",
+      "size": 4223,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/785c46876a05889f5c9ad2b6d1b5a19355929ea8"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/public/sounds/game-end.mp3",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8fb593e4918710a7f87b13da05fbac0553721d5a",
+      "size": 39750,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8fb593e4918710a7f87b13da05fbac0553721d5a"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/public/sounds/point-get.mp3",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d4cd9d9d3ca71b36c6af3118f9388a5b268b3557",
+      "size": 4223,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d4cd9d9d3ca71b36c6af3118f9388a5b268b3557"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "a1ec87478a4029b6d644ad3e4a37f50318842bb8",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/a1ec87478a4029b6d644ad3e4a37f50318842bb8"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/App.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bd96fbf3df4104ab353d4f6a7a24fd6b93541517",
+      "size": 4068,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bd96fbf3df4104ab353d4f6a7a24fd6b93541517"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "824db24e9920b12f788adb2832ec560cc8734641",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/824db24e9920b12f788adb2832ec560cc8734641"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "cd89bc579b0286fa32cabd528e057e8e94043678",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/cd89bc579b0286fa32cabd528e057e8e94043678"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/borderButton",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "d49d56b849878bb2e586313a1bed33a933117e50",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/d49d56b849878bb2e586313a1bed33a933117e50"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/borderButton/borderButton.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2f51b4ed96d03f507d830dfde9f0dcb235bfeac6",
+      "size": 1145,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2f51b4ed96d03f507d830dfde9f0dcb235bfeac6"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/borderButton/borderButton.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4cf00d76217d6eb5025e7e32d7cd2a4c1e597c9c",
+      "size": 1127,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4cf00d76217d6eb5025e7e32d7cd2a4c1e597c9c"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/button",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "f757bfb696f4229b95558c5d523cc542c557276a",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/f757bfb696f4229b95558c5d523cc542c557276a"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/button/button.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9d29803dea7ae75abf0e0dd54232c7e24c3444c6",
+      "size": 2612,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9d29803dea7ae75abf0e0dd54232c7e24c3444c6"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/button/button.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9b183be036d4254018b843e59029d95387e0c27f",
+      "size": 1161,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9b183be036d4254018b843e59029d95387e0c27f"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/container",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "a4f9bd9e00c73375a667292d9578424f8085d266",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/a4f9bd9e00c73375a667292d9578424f8085d266"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/container/container.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "abe6a403bcd4e9e548a0da4996ee0653df478535",
+      "size": 1064,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/abe6a403bcd4e9e548a0da4996ee0653df478535"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/container/container.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "04fd85a5cf2201ca6eb2053ba99d882fddb0ffd4",
+      "size": 1204,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/04fd85a5cf2201ca6eb2053ba99d882fddb0ffd4"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/emojiBackground",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "2368773248cc466bc6340ca9389ca55a3526f3b9",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/2368773248cc466bc6340ca9389ca55a3526f3b9"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/emojiBackground/emojiBackground.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3fcbfb2c474bc495407360ca6c1e6c10ebaddd32",
+      "size": 1301,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3fcbfb2c474bc495407360ca6c1e6c10ebaddd32"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/emojiBackground/emojiBackground.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "aa95fc37fc1c5d6e4544593c1dc1c8075f317294",
+      "size": 5178,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/aa95fc37fc1c5d6e4544593c1dc1c8075f317294"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/emojisplosion",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "8f1fcc904620c6bfc7fb38ef5b79967f4dec798f",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/8f1fcc904620c6bfc7fb38ef5b79967f4dec798f"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/emojisplosion/emojisplosion.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e8dff7efac9f61a00e85b2ba130b963f3a6c52d9",
+      "size": 1460,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e8dff7efac9f61a00e85b2ba130b963f3a6c52d9"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/emojisplosion/emojisplosion.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fb646133fa04ec62b05804a87ae4dfd576305e56",
+      "size": 1743,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fb646133fa04ec62b05804a87ae4dfd576305e56"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/header",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "6dca7a02f7a49d77787998f410f2bcf1dbb53ea0",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/6dca7a02f7a49d77787998f410f2bcf1dbb53ea0"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/header/header.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "958aafaca599434c210159ffa6bcb12e348639b3",
+      "size": 2377,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/958aafaca599434c210159ffa6bcb12e348639b3"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/header/header.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "90a75dc2141e998d77535d8061379888d6f2ff23",
+      "size": 2545,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/90a75dc2141e998d77535d8061379888d6f2ff23"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/input",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "d826a9122c7854f3cecf15b12d98c74018e6b4df",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/d826a9122c7854f3cecf15b12d98c74018e6b4df"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/input/input.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d70e1d0f75fdd001cb1295d49a511724e5d96370",
+      "size": 3047,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d70e1d0f75fdd001cb1295d49a511724e5d96370"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/input/input.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7cc905d50b13c4ac4842a0fc0834b9693bed0330",
+      "size": 2020,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7cc905d50b13c4ac4842a0fc0834b9693bed0330"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/statusBar",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "169de96cafc87e539a1638d8fd3ab8dd9654213f",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/169de96cafc87e539a1638d8fd3ab8dd9654213f"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/statusBar/statusBar.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a5d9f74708607de247a55c4396d5c22b349cc9e1",
+      "size": 1069,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a5d9f74708607de247a55c4396d5c22b349cc9e1"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/statusBar/statusBar.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8496cdcc3fe0ad4ce5aa8f056b76a89c28de30f3",
+      "size": 851,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8496cdcc3fe0ad4ce5aa8f056b76a89c28de30f3"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/toggle",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "24585a4c05f4a8798d6944f4e7ba462a76ed6341",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/24585a4c05f4a8798d6944f4e7ba462a76ed6341"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/toggle/toggle.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3c6c359e36aa50afa809eb80ad9a9addb5be12fa",
+      "size": 949,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3c6c359e36aa50afa809eb80ad9a9addb5be12fa"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/generic/toggle/toggle.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "03e035a8e07dd7003752a0cb0ddec19b1ffb3b25",
+      "size": 1015,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/03e035a8e07dd7003752a0cb0ddec19b1ffb3b25"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/layouts",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "5bc2f8a78195b460de7fb7ef1d7ca058701473d3",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/5bc2f8a78195b460de7fb7ef1d7ca058701473d3"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/layouts/aboutScreen",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "03e0d84f56dd1949c2cb5364f5026de4b55d62ca",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/03e0d84f56dd1949c2cb5364f5026de4b55d62ca"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/layouts/aboutScreen/aboutScreen.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1d39cc589e67fee514eee8be9ef1e34ddb30d221",
+      "size": 2242,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1d39cc589e67fee514eee8be9ef1e34ddb30d221"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/layouts/aboutScreen/aboutScreen.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "377e8a0c4d963c7840c990c07ff51c0aac71239f",
+      "size": 1918,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/377e8a0c4d963c7840c990c07ff51c0aac71239f"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/layouts/gameOverScreen",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "e1162cd89f67b43973bda885d8d9b28db59b8b78",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/e1162cd89f67b43973bda885d8d9b28db59b8b78"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/layouts/gameOverScreen/gameOverScreen.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2cfaaff64773fb45540e7cbbc6d2833761180ca8",
+      "size": 2188,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2cfaaff64773fb45540e7cbbc6d2833761180ca8"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/layouts/gameOverScreen/gameOverScreen.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2c1b7ac4ab00f7b39eba6a5d78d621981764eeb0",
+      "size": 1045,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2c1b7ac4ab00f7b39eba6a5d78d621981764eeb0"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/layouts/gameScreen",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "44f892bcff38a362ce7193a86675c7528c2dd4e9",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/44f892bcff38a362ce7193a86675c7528c2dd4e9"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/layouts/gameScreen/gameScreen.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b2910b016b0f3936cdc7fb4e98d20fc3f4f0ffb6",
+      "size": 6940,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b2910b016b0f3936cdc7fb4e98d20fc3f4f0ffb6"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/layouts/gameScreen/gameScreen.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f690dc5668055d0dfe8936a9f7ab1f7aa3aaaf4b",
+      "size": 4588,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f690dc5668055d0dfe8936a9f7ab1f7aa3aaaf4b"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/layouts/startScreen",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "7ad31b4aec1f23eba8c511cd164a808b01eacf7a",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/7ad31b4aec1f23eba8c511cd164a808b01eacf7a"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/layouts/startScreen/startScreen.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3f9b59445957b6472260899260d61da3263cf9c8",
+      "size": 1781,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3f9b59445957b6472260899260d61da3263cf9c8"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/layouts/startScreen/startScreen.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a75d6c5aff5720152bfd75bfa455c847cde8e907",
+      "size": 2117,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a75d6c5aff5720152bfd75bfa455c847cde8e907"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "0eb143717e5076bf48df227216b8f2aab1c3f02f",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/0eb143717e5076bf48df227216b8f2aab1c3f02f"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/bottomSheet",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "a4e09452b917b852f2ef29e74a5a6223c169947c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/a4e09452b917b852f2ef29e74a5a6223c169947c"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/bottomSheet/bottomSheet.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f606b29dbee8aac5ea2e39f355b3951b2e548cf9",
+      "size": 3578,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f606b29dbee8aac5ea2e39f355b3951b2e548cf9"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/bottomSheet/bottomSheet.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "83da81437df296a98e526161a73a431d5bd849e5",
+      "size": 2312,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/83da81437df296a98e526161a73a431d5bd849e5"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/card",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "e49c15bd6730843b982d1a952b46db51f797594c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/e49c15bd6730843b982d1a952b46db51f797594c"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/card/card.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bc9911569c99b7f21b3b18e44c2e372955fc9891",
+      "size": 2016,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bc9911569c99b7f21b3b18e44c2e372955fc9891"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/card/card.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9adb63717563b516f9c5ebc1236ebf64cd2de334",
+      "size": 2896,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9adb63717563b516f9c5ebc1236ebf64cd2de334"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/endCard",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "0b708c22213c7ace337c6f314bea35ad9b59bfb1",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/0b708c22213c7ace337c6f314bea35ad9b59bfb1"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/endCard/endCard.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "71f844395306c0af0bd75af53274165bf7aabaf6",
+      "size": 1779,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/71f844395306c0af0bd75af53274165bf7aabaf6"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/endCard/endCard.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fe712ab069da3566d6303878174116d69404568b",
+      "size": 1930,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fe712ab069da3566d6303878174116d69404568b"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/forbiddenPopup",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "d20e466c1a2bded03616c6f85380dece62869fde",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/d20e466c1a2bded03616c6f85380dece62869fde"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/forbiddenPopup/forbiddenPopup.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1cf09d9f787f4dc0627dc5a2084914cc07e05d2a",
+      "size": 2448,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1cf09d9f787f4dc0627dc5a2084914cc07e05d2a"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/forbiddenPopup/forbiddenPopup.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5281ce6f831fe97dafcdb13703b0f3fc8f9c54d4",
+      "size": 2645,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5281ce6f831fe97dafcdb13703b0f3fc8f9c54d4"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/score",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "fc5d9892a0f6a6a144fb2611cc69471984e9c13a",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/fc5d9892a0f6a6a144fb2611cc69471984e9c13a"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/score/score.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "761fbd31f9a21e5bd308f28562bfa94eee9b9859",
+      "size": 985,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/761fbd31f9a21e5bd308f28562bfa94eee9b9859"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/score/score.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "35b64537a6522f157c595f6ffba31c4c0eeb2800",
+      "size": 1098,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/35b64537a6522f157c595f6ffba31c4c0eeb2800"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/settings",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "188e50af95fca4c8b39dc4489e0ae1b96751d029",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/188e50af95fca4c8b39dc4489e0ae1b96751d029"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/settings/settings.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d0fcd6c5ef7a16d6716abbd256ac57c7bf9ebaf5",
+      "size": 4522,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d0fcd6c5ef7a16d6716abbd256ac57c7bf9ebaf5"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/settings/settings.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "309c66c96d8ce61571ae91c36da3bc329ce7a675",
+      "size": 2893,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/309c66c96d8ce61571ae91c36da3bc329ce7a675"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/successPopup",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "01a6c7f8957a9a5d15d43d4106c27e16d9282b9d",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/01a6c7f8957a9a5d15d43d4106c27e16d9282b9d"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/successPopup/successPopup.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d29aaaf17d9ea5698393e839ae1a03238df1a9ad",
+      "size": 2278,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d29aaaf17d9ea5698393e839ae1a03238df1a9ad"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/successPopup/successPopup.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8aad6227a9e9f522e3430dc55efe0f26fa76268b",
+      "size": 2201,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8aad6227a9e9f522e3430dc55efe0f26fa76268b"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/timer",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "b4623d0467fc9f3d861cffb441dd1a7d523b4d71",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/b4623d0467fc9f3d861cffb441dd1a7d523b4d71"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/timer/timer.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0d634b36ef6b4834e25370260a7c9acc753ba478",
+      "size": 1356,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0d634b36ef6b4834e25370260a7c9acc753ba478"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/timer/timer.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "05fc29777c0d54edb971b20df5a9f9dc6248b084",
+      "size": 1574,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/05fc29777c0d54edb971b20df5a9f9dc6248b084"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/transcript",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "4f7e63a45bd979ff6c3f9f1e663c818caccad62d",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/4f7e63a45bd979ff6c3f9f1e663c818caccad62d"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/transcript/transcript.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e03e388560332375cb3faa65c7eb0609bdaf1e55",
+      "size": 2116,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e03e388560332375cb3faa65c7eb0609bdaf1e55"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/components/ui/transcript/transcript.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ff446258dec57a30652ba80f35fa11764baa160b",
+      "size": 1801,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ff446258dec57a30652ba80f35fa11764baa160b"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/lib",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "e2c734db07873e11223dae4c93eceb8274d2fcd3",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/e2c734db07873e11223dae4c93eceb8274d2fcd3"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/lib/api.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f9d3fbb9a6effc3a46989c0a8da7b4c92d34b9ef",
+      "size": 3803,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f9d3fbb9a6effc3a46989c0a8da7b4c92d34b9ef"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/lib/error_responses.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "25950cc1f70846eff268fa70b0935822bdb2186b",
+      "size": 772,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/25950cc1f70846eff268fa70b0935822bdb2186b"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/lib/excluded_words.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fb03c5b6938deebb4bbc3ba3ab7bf48e0f74a25a",
+      "size": 913,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fb03c5b6938deebb4bbc3ba3ab7bf48e0f74a25a"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/lib/firebase.config.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "92621fab16de7d0018f284c9f3bee6e3aaabfb52",
+      "size": 2050,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/92621fab16de7d0018f284c9f3bee6e3aaabfb52"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/lib/priming.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c0478703361a329f6d637d3a188a80c264e05316",
+      "size": 4069,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c0478703361a329f6d637d3a188a80c264e05316"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/lib/sound.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3759a90ef98658fcad7defe5465d9582ea461fbf",
+      "size": 1793,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3759a90ef98658fcad7defe5465d9582ea461fbf"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/lib/speech.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c4abc6b31fe20123d92164c3a1c55243289bf0b6",
+      "size": 2154,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c4abc6b31fe20123d92164c3a1c55243289bf0b6"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/lib/utils.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4b5a62e6f970f908f011cef389728ad4bcf3a0fb",
+      "size": 3147,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4b5a62e6f970f908f011cef389728ad4bcf3a0fb"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/lib/words.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e9e489dbf86322623b5ef10630bce174304816a2",
+      "size": 32368,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e9e489dbf86322623b5ef10630bce174304816a2"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/main.jsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6b3cb2c31d704398d926d09322dc2275c67f33f8",
+      "size": 757,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6b3cb2c31d704398d926d09322dc2275c67f33f8"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/store.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a0041f131b225439cdfa1f6425a5f257e00260b7",
+      "size": 14372,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a0041f131b225439cdfa1f6425a5f257e00260b7"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/styles",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "5c1f5cc87377baed10c7bff797455d26ab90757a",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/5c1f5cc87377baed10c7bff797455d26ab90757a"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/styles/app.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "dc0d580293c45c17d332aa58757af2baa15fb5ce",
+      "size": 2786,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/dc0d580293c45c17d332aa58757af2baa15fb5ce"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/src/styles/variables.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "12e6e11a2d0f912aedea9b05f6434e9b4ec4fb7c",
+      "size": 995,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/12e6e11a2d0f912aedea9b05f6434e9b4ec4fb7c"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/staging.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "81b676dbc6d7c5f81786bb1cf3dbf4786f13af3d",
+      "size": 759,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/81b676dbc6d7c5f81786bb1cf3dbf4786f13af3d"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/vite.config.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "892c433565e80bfda6465287aaada076dd3db7fb",
+      "size": 855,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/892c433565e80bfda6465287aaada076dd3db7fb"
+    },
+    {
+      "path": "demos/palm/web/quick-prompt/yarn.lock",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "47641e284c80e1b7b09854de0145275bd736bbbc",
+      "size": 125515,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/47641e284c80e1b7b09854de0145275bd736bbbc"
+    },
+    {
+      "path": "demos/palm/web/talking-character",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "156dc00a5b2ac5aa79645a2458b0a79091c530ac",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/156dc00a5b2ac5aa79645a2458b0a79091c530ac"
+    },
+    {
+      "path": "demos/palm/web/talking-character/CODE_OF_CONDUCT.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "29b584d078b4a3e1d73d326238650edc3bcefc2b",
+      "size": 4450,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/29b584d078b4a3e1d73d326238650edc3bcefc2b"
+    },
+    {
+      "path": "demos/palm/web/talking-character/CONTRIBUTING.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8956a61b820b4e6e69be58f329bc53f62557c3f2",
+      "size": 1067,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8956a61b820b4e6e69be58f329bc53f62557c3f2"
+    },
+    {
+      "path": "demos/palm/web/talking-character/LICENSE",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d645695673349e3947e8e5ae42332d0ac3164cd7",
+      "size": 11358,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d645695673349e3947e8e5ae42332d0ac3164cd7"
+    },
+    {
+      "path": "demos/palm/web/talking-character/README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "80d8ee28d03539ce1a6d908042e01fe00fb4f2f2",
+      "size": 9260,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/80d8ee28d03539ce1a6d908042e01fe00fb4f2f2"
+    },
+    {
+      "path": "demos/palm/web/talking-character/docs",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "a544b1c51aa05740fe70599dd29e63ff5f98af06",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/a544b1c51aa05740fe70599dd29e63ff5f98af06"
+    },
+    {
+      "path": "demos/palm/web/talking-character/docs/llm_prompt_design_diagram.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ec2c91a24169ab51411a49610aa217474650d1d5",
+      "size": 41547,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ec2c91a24169ab51411a49610aa217474650d1d5"
+    },
+    {
+      "path": "demos/palm/web/talking-character/docs/talking-character-demo.gif",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bcc5857399d3e1502e7c1293a4b27e1a89c13aa1",
+      "size": 1651373,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bcc5857399d3e1502e7c1293a4b27e1a89c13aa1"
+    },
+    {
+      "path": "demos/palm/web/talking-character/docs/talking-character-header.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a58bccd717789fed998b5a661391df4ff4800136",
+      "size": 129105,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a58bccd717789fed998b5a661391df4ff4800136"
+    },
+    {
+      "path": "demos/palm/web/talking-character/docs/talking-character-screen.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7b466c14410d44c6994da69cb947ec71690777b7",
+      "size": 246483,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7b466c14410d44c6994da69cb947ec71690777b7"
+    },
+    {
+      "path": "demos/palm/web/talking-character/package-lock.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b3e14134cf4236c82b7710acd6db50c1f5e5567f",
+      "size": 671699,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b3e14134cf4236c82b7710acd6db50c1f5e5567f"
+    },
+    {
+      "path": "demos/palm/web/talking-character/package.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7095067bd2d38e2cb6cedb2d8bbdcf5753b8bfa8",
+      "size": 1503,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7095067bd2d38e2cb6cedb2d8bbdcf5753b8bfa8"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "0b74251ae9f31305f8adade99567ae895df42da2",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/0b74251ae9f31305f8adade99567ae895df42da2"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/Doggo07.glb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "071d17c54c8855c5cf58d7b5841fdbb1f641d6d6",
+      "size": 8471936,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/071d17c54c8855c5cf58d7b5841fdbb1f641d6d6"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/ZEPETO_TORSO_3_clean2.glb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8bf57a4780d645897a797f2e4f6732f24fe04547",
+      "size": 25656392,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8bf57a4780d645897a797f2e4f6732f24fe04547"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/favicon.ico",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a11777cc471a4344702741ab1c8a588998b1311a",
+      "size": 3870,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a11777cc471a4344702741ab1c8a588998b1311a"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/index.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b1d27a59cc3cb51f44f89df09f8af050269c29a0",
+      "size": 1337,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b1d27a59cc3cb51f44f89df09f8af050269c29a0"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/logo192.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fc44b0a3796c0e0a64c3d858ca038bd4570465d9",
+      "size": 5347,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fc44b0a3796c0e0a64c3d858ca038bd4570465d9"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/logo512.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a4e47a6545bc15971f8f63fba70e4013df88a664",
+      "size": 9664,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a4e47a6545bc15971f8f63fba70e4013df88a664"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/manifest.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "080d6c77ac21bb2ef88a6992b2b73ad93daaca92",
+      "size": 492,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/080d6c77ac21bb2ef88a6992b2b73ad93daaca92"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/robots.txt",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e9e57dc4d41b9b46e05112e9f45b7ea6ac0ba15e",
+      "size": 67,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e9e57dc4d41b9b46e05112e9f45b7ea6ac0ba15e"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v1",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "82c75d89741d106a5a78427a10d35935cd8aa845",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/82c75d89741d106a5a78427a10d35935cd8aa845"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v1/talking_heads_blendshapes_internal.data",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v1/talking_heads_blendshapes_internal.fetch.js",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v1/talking_heads_blendshapes_internal.html",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v1/talking_heads_blendshapes_internal.js",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "1b98c58c609cab3336b2db808f8e368d6ee7d405",
+      "size": 205908,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1b98c58c609cab3336b2db808f8e368d6ee7d405"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v1/talking_heads_blendshapes_internal.mem",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v1/talking_heads_blendshapes_internal.wasm",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "8eaf1c7904e3a599cbf7548cd452b27a2bafaa58",
+      "size": 6109968,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8eaf1c7904e3a599cbf7548cd452b27a2bafaa58"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v1/talking_heads_blendshapes_internal.wasm.debug.wasm",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v1/talking_heads_blendshapes_internal.wasm.map",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v1/talking_heads_blendshapes_internal.worker.js",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v1/talking_heads_demo.binarypb",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "39db03135c06f0ea5ae650045784947ab48adc46",
+      "size": 2539,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/39db03135c06f0ea5ae650045784947ab48adc46"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v1/talking_heads_microphone_assets.data",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "c56495c6d665d57f2796428dd6903668c0ce583c",
+      "size": 4462789,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c56495c6d665d57f2796428dd6903668c0ce583c"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v1/talking_heads_microphone_assets.js",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "7811132379a1cebd1ad527c117893bf8f6268c95",
+      "size": 8295,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7811132379a1cebd1ad527c117893bf8f6268c95"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v2",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "b0607d422b0aec405bf3b335fee5dca1e4f38638",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/b0607d422b0aec405bf3b335fee5dca1e4f38638"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v2/talking_heads_v2_blendshapes_internal.data",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v2/talking_heads_v2_blendshapes_internal.fetch.js",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v2/talking_heads_v2_blendshapes_internal.html",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v2/talking_heads_v2_blendshapes_internal.js",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "8ab0e94986d447b5ab12549d8bbec18f7e087774",
+      "size": 205911,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8ab0e94986d447b5ab12549d8bbec18f7e087774"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v2/talking_heads_v2_blendshapes_internal.mem",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v2/talking_heads_v2_blendshapes_internal.wasm",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "88d5e701a558506ba3553091228d47c02202c82d",
+      "size": 6110135,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/88d5e701a558506ba3553091228d47c02202c82d"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v2/talking_heads_v2_blendshapes_internal.wasm.debug.wasm",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v2/talking_heads_v2_blendshapes_internal.wasm.map",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v2/talking_heads_v2_blendshapes_internal.worker.js",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v2/talking_heads_v2_demo.binarypb",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "af65b74d65040daca4e0976176c9e1b2c53c79c4",
+      "size": 4908,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/af65b74d65040daca4e0976176c9e1b2c53c79c4"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v2/talking_heads_v2_microphone_assets.data",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "52f10fedd7a26a2583e7ff9b1c98bde02deebb13",
+      "size": 4504964,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/52f10fedd7a26a2583e7ff9b1c98bde02deebb13"
+    },
+    {
+      "path": "demos/palm/web/talking-character/public/talking_head_v2/talking_heads_v2_microphone_assets.js",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "3a3e81c2a5fa78e17e8e9b9125d3f4374d372721",
+      "size": 8310,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3a3e81c2a5fa78e17e8e9b9125d3f4374d372721"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "8180050b154f355bbc7e20b3b18943db884368ea",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/8180050b154f355bbc7e20b3b18943db884368ea"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/App.css",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "11a5f63f0bb686d772182058719b69871afe9001",
+      "size": 1160,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/11a5f63f0bb686d772182058719b69871afe9001"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/App.test.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e0c336105a2905bb171cc2c92ebb9b5de96fc280",
+      "size": 873,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e0c336105a2905bb171cc2c92ebb9b5de96fc280"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/App.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3fc42795cfb8be9412b74d6074a457072505db9f",
+      "size": 845,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3fc42795cfb8be9412b74d6074a457072505db9f"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/apis",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "06a68e6ad27fada0a462ebd7e23e6042fb9e5b8f",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/06a68e6ad27fada0a462ebd7e23e6042fb9e5b8f"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/apis/avatarImage.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "31b0cd69f3d6dfd02b75ba08ac245b89252cab84",
+      "size": 2087,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/31b0cd69f3d6dfd02b75ba08ac245b89252cab84"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/apis/languageModel.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a51cf25b85c97a257196c43594ef5083c18b42b1",
+      "size": 4355,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a51cf25b85c97a257196c43594ef5083c18b42b1"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/apis/mediapipe_audio_blendshapes.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5f1a13b1d0cb5087195192804929e6544b18ba3a",
+      "size": 2243,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5f1a13b1d0cb5087195192804929e6544b18ba3a"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/apis/network.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fd17fc422f67c50384f78184fa2d854d6d8da550",
+      "size": 1219,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fd17fc422f67c50384f78184fa2d854d6d8da550"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/apis/speechRecognition.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d8d797a80ba2f6eda596bbfc3d47d7c60a005b55",
+      "size": 7181,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d8d797a80ba2f6eda596bbfc3d47d7c60a005b55"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/apis/talkingHead.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0fa7cc6c6289a5c6ecdccce6ca6eae8c5720ddc1",
+      "size": 6294,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0fa7cc6c6289a5c6ecdccce6ca6eae8c5720ddc1"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/apis/textToSpeech.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "714c8b7a40163bba96824a08ef5751262d993b0d",
+      "size": 8147,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/714c8b7a40163bba96824a08ef5751262d993b0d"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/apis/voices.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fe86b48786d9400eaf2804ab4b0dc45bb238d86c",
+      "size": 15935,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fe86b48786d9400eaf2804ab4b0dc45bb238d86c"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/components",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "efc21c9212855bfeeef57306b6d451e45a253b36",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/efc21c9212855bfeeef57306b6d451e45a253b36"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/components/Layout",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "ff8c3a7d78e4dee0224bad0ceeb62122f7f6c9f7",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/ff8c3a7d78e4dee0224bad0ceeb62122f7f6c9f7"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/components/Layout/index.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b2e2c58db1c93832e12902f03c74bc3c65958d5f",
+      "size": 961,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b2e2c58db1c93832e12902f03c74bc3c65958d5f"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/components/ThreeJS",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "4f614261833593a5fa6c329b6ad46c461747e885",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/4f614261833593a5fa6c329b6ad46c461747e885"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/components/ThreeJS/Doggo07.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7775ab0f4c6fe8bd711b9ae912a85ade40cced4b",
+      "size": 3455,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7775ab0f4c6fe8bd711b9ae912a85ade40cced4b"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/components/ThreeJS/ZEPETO_TORSO_3.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c54e5bef5e42b8cd32fbd7876da75727f6a86cb1",
+      "size": 3734,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c54e5bef5e42b8cd32fbd7876da75727f6a86cb1"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/components/ThreeJS/index.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e818c4b24ea6a0ce3d75a4cc5103a2fb804a2c49",
+      "size": 710,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e818c4b24ea6a0ce3d75a4cc5103a2fb804a2c49"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/context",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "bde3e56f7bd7df2bb5473b845711a49622100419",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/bde3e56f7bd7df2bb5473b845711a49622100419"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/context/config.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "26e310fea253a31bc30ec45cd843b6b5d7eb7894",
+      "size": 5084,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/26e310fea253a31bc30ec45cd843b6b5d7eb7894"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/context/constants.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d3e6aee64e536bc8a1ee8fd2e67e00aa118eca6b",
+      "size": 969,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d3e6aee64e536bc8a1ee8fd2e67e00aa118eca6b"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/index.css",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "27175345bb8b233c8e8b5cb24108ccb11cd7f786",
+      "size": 2068,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/27175345bb8b233c8e8b5cb24108ccb11cd7f786"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/index.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "06638fb2640909fc1d3918f41a89fc9d11f82b77",
+      "size": 1426,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/06638fb2640909fc1d3918f41a89fc9d11f82b77"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/logo.svg",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9dfc1c058cebbef8b891c5062be6f31033d7d186",
+      "size": 2632,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9dfc1c058cebbef8b891c5062be6f31033d7d186"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/pages",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "e5bb61058bbbdd82f10c120ed1d6a5391b5c036a",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/e5bb61058bbbdd82f10c120ed1d6a5391b5c036a"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/pages/character.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "585a5836de6477b417317da1aa66d788e0609ee7",
+      "size": 9009,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/585a5836de6477b417317da1aa66d788e0609ee7"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/pages/personality.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "475879c05e7fa5091e826b0e98074054eca4de36",
+      "size": 13468,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/475879c05e7fa5091e826b0e98074054eca4de36"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/pages/styles.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "273c4650b9d5bc0a2bb6bbd98094eb026e102b4b",
+      "size": 1349,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/273c4650b9d5bc0a2bb6bbd98094eb026e102b4b"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/react-app-env.d.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9ba8839538e807f25bbc0f8a098a1f823ce45e2b",
+      "size": 636,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9ba8839538e807f25bbc0f8a098a1f823ce45e2b"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/reportWebVitals.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "61f73886dcce2bf90d63e57e8dd1e97302528dd0",
+      "size": 977,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/61f73886dcce2bf90d63e57e8dd1e97302528dd0"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/routes",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "18d782227d8e1b2f953dc9f500e231aa29fa5300",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/18d782227d8e1b2f953dc9f500e231aa29fa5300"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/routes/index.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3908cb5657454c7ea80c101f4eec74c2cc156247",
+      "size": 965,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3908cb5657454c7ea80c101f4eec74c2cc156247"
+    },
+    {
+      "path": "demos/palm/web/talking-character/src/setupTests.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "adc63ebf2ea1f82b36d5a6c73c5e7fae4c4a2496",
+      "size": 837,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/adc63ebf2ea1f82b36d5a6c73c5e7fae4c4a2496"
+    },
+    {
+      "path": "demos/palm/web/talking-character/third_party",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "03bae5a99c7518e333064526e179e6ca1a050c84",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/03bae5a99c7518e333064526e179e6ca1a050c84"
+    },
+    {
+      "path": "demos/palm/web/talking-character/third_party/LICENSE",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0e03e3911e0ac02c72ed527b34efe250f0fb9bef",
+      "size": 12331,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0e03e3911e0ac02c72ed527b34efe250f0fb9bef"
+    },
+    {
+      "path": "demos/palm/web/talking-character/third_party/METADATA",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "43a36612c24410e42101ac5471f1f067ca7cfc85",
+      "size": 330,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/43a36612c24410e42101ac5471f1f067ca7cfc85"
+    },
+    {
+      "path": "demos/palm/web/talking-character/third_party/mediapipe",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "6da1efb4488323d312a8c4d4984358e34e59da67",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/6da1efb4488323d312a8c4d4984358e34e59da67"
+    },
+    {
+      "path": "demos/palm/web/talking-character/third_party/mediapipe/web",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "e7a2f581b9d428acaf65c5eafc1f58a878ab68b1",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/e7a2f581b9d428acaf65c5eafc1f58a878ab68b1"
+    },
+    {
+      "path": "demos/palm/web/talking-character/third_party/mediapipe/web/graph_runner",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "a2f271bf28f7a89c4068aa46178459691977ee0e",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/a2f271bf28f7a89c4068aa46178459691977ee0e"
+    },
+    {
+      "path": "demos/palm/web/talking-character/third_party/mediapipe/web/graph_runner/graph_runner.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5e846ac905942d3995598b3648a8b8a14db7e336",
+      "size": 54430,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5e846ac905942d3995598b3648a8b8a14db7e336"
+    },
+    {
+      "path": "demos/palm/web/talking-character/third_party/mediapipe/web/graph_runner/platform_utils.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ccf1d8c064342c441d2d1845459117a6324f7b08",
+      "size": 957,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ccf1d8c064342c441d2d1845459117a6324f7b08"
+    },
+    {
+      "path": "demos/palm/web/talking-character/tsconfig.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7894005dc51fadf6c2c4c226e1f64716c2907bdb",
+      "size": 626,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7894005dc51fadf6c2c4c226e1f64716c2907bdb"
+    },
+    {
+      "path": "demos/palm/web/textfx",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "006e719cfe8b784ad3db8b8df5ffdf28e0b09ac9",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/006e719cfe8b784ad3db8b8df5ffdf28e0b09ac9"
+    },
+    {
+      "path": "demos/palm/web/textfx/.eslintignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "763301fc0025d020fbc9fb3a0781097e8e036d9c",
+      "size": 19,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/763301fc0025d020fbc9fb3a0781097e8e036d9c"
+    },
+    {
+      "path": "demos/palm/web/textfx/.eslintrc.cjs",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b36ea75d2a12eac22b38cf3c4213339294cd33a7",
+      "size": 1462,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b36ea75d2a12eac22b38cf3c4213339294cd33a7"
+    },
+    {
+      "path": "demos/palm/web/textfx/.gcloudignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "be08419a8cecf7c9cb3c10e87cfe4b8300652f23",
+      "size": 73,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/be08419a8cecf7c9cb3c10e87cfe4b8300652f23"
+    },
+    {
+      "path": "demos/palm/web/textfx/.gitignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4a61e03d41d474854aa9d00b626b65d31ce1046c",
+      "size": 289,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4a61e03d41d474854aa9d00b626b65d31ce1046c"
+    },
+    {
+      "path": "demos/palm/web/textfx/.prettierrc",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b03568e36cbf3b440818179f0953a531faba8de8",
+      "size": 181,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b03568e36cbf3b440818179f0953a531faba8de8"
+    },
+    {
+      "path": "demos/palm/web/textfx/CONTRIBUTING.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "37ae0a447173aa160503302b2a55d10b7bc10eee",
+      "size": 1129,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/37ae0a447173aa160503302b2a55d10b7bc10eee"
+    },
+    {
+      "path": "demos/palm/web/textfx/LICENSE",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "05877b3909d6ae76146afc4a773d06cc3d091a38",
+      "size": 10692,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/05877b3909d6ae76146afc4a773d06cc3d091a38"
+    },
+    {
+      "path": "demos/palm/web/textfx/README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "30a4297980c0806050f1afa66107c3a79914f3d4",
+      "size": 5862,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/30a4297980c0806050f1afa66107c3a79914f3d4"
+    },
+    {
+      "path": "demos/palm/web/textfx/app.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5cba007b2a537c75e1e5c6f122c1d2a215ad66c0",
+      "size": 741,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5cba007b2a537c75e1e5c6f122c1d2a215ad66c0"
+    },
+    {
+      "path": "demos/palm/web/textfx/dev.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "72bbe6e154e5682f569533cbfee43c2eb23b38fd",
+      "size": 755,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/72bbe6e154e5682f569533cbfee43c2eb23b38fd"
+    },
+    {
+      "path": "demos/palm/web/textfx/index.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4d706e49b4b1be2d4cc6b4ba79968af766edcd1e",
+      "size": 2234,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4d706e49b4b1be2d4cc6b4ba79968af766edcd1e"
+    },
+    {
+      "path": "demos/palm/web/textfx/package-lock.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c1223be4b4206ac3d01198c690797c571fa6d4ea",
+      "size": 890413,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c1223be4b4206ac3d01198c690797c571fa6d4ea"
+    },
+    {
+      "path": "demos/palm/web/textfx/package.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "979c358a31fc0612ecab8d8aaa31b8657df901b6",
+      "size": 1461,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/979c358a31fc0612ecab8d8aaa31b8657df901b6"
+    },
+    {
+      "path": "demos/palm/web/textfx/public",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "1011d5f43b9b3d1a97bb0db0d8b2d4bace4ab3a4",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/1011d5f43b9b3d1a97bb0db0d8b2d4bace4ab3a4"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/android-chrome-144x144.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "457caca1107b83b1fd3e8976cb127618358132ac",
+      "size": 7640,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/457caca1107b83b1fd3e8976cb127618358132ac"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/apple-touch-icon.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1b937a5dd1176a977dff1314ffc6eba545a3794f",
+      "size": 8175,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1b937a5dd1176a977dff1314ffc6eba545a3794f"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/assets",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "c96b68393d9a147113ac37d9dbecfb55e0db8040",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/c96b68393d9a147113ac37d9dbecfb55e0db8040"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/assets/landing",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "d363cdc01b78be985e2a1c4cc8ba93f6483e06cd",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/d363cdc01b78be985e2a1c4cc8ba93f6483e06cd"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/assets/landing/lotties",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "cab885a236042a8756bd24d5ba6825de94fbbcce",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/cab885a236042a8756bd24d5ba6825de94fbbcce"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/assets/landing/lotties/acronym_hero_animation_lottie.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8b568d4443f68bedc737a4a473aa16c4112f4194",
+      "size": 76323,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8b568d4443f68bedc737a4a473aa16c4112f4194"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/assets/landing/lotties/alliteration_hero_animation_lottie.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8e77654ef1449dd0384ba2bc4a2764deb131f6e9",
+      "size": 164580,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8e77654ef1449dd0384ba2bc4a2764deb131f6e9"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/assets/landing/lotties/chain_hero_animation_lottie.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9a16ca6ef79274e58d19a8e45fd63eb7ee13730b",
+      "size": 103672,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9a16ca6ef79274e58d19a8e45fd63eb7ee13730b"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/assets/landing/lotties/explode_hero_animation_lottie.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "385a6371da275f8fb12efcb84e85bd386d43dfeb",
+      "size": 121046,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/385a6371da275f8fb12efcb84e85bd386d43dfeb"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/assets/landing/lotties/fuse_hero_animation_lottie.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ea8b76408e22960df9e72d4b388536559ea73b2c",
+      "size": 140787,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ea8b76408e22960df9e72d4b388536559ea73b2c"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/assets/landing/lotties/pov_hero_animation_lottie.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "114df3c374d00f0a5a76521f5cd790e6c72848fe",
+      "size": 117489,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/114df3c374d00f0a5a76521f5cd790e6c72848fe"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/assets/landing/lotties/scene_hero_animation_lottie.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "634baa19dc11c0f46347a76464bae395105d10cb",
+      "size": 153028,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/634baa19dc11c0f46347a76464bae395105d10cb"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/assets/landing/lotties/simile_hero_animation_lottie.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4bc4d3f5dc1288e31d624d096a35c1cf285bea11",
+      "size": 109387,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4bc4d3f5dc1288e31d624d096a35c1cf285bea11"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/assets/landing/lotties/unexpect_hero_animation_lottie.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2ae8ee9ea166f7dd110576e915dbe251ab1fc571",
+      "size": 122817,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2ae8ee9ea166f7dd110576e915dbe251ab1fc571"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/assets/landing/lotties/unfold_hero_animation_lottie.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c35f9ca1c52ce3a13d7001bf1d8b31b0d4b95bf2",
+      "size": 90487,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c35f9ca1c52ce3a13d7001bf1d8b31b0d4b95bf2"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/assets/loading.gif",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a9197b9bed9992280a1126006a1b2be47c12914f",
+      "size": 4846274,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a9197b9bed9992280a1126006a1b2be47c12914f"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/browserconfig.xml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c8b8295ed8e35089ca9816485ba76443001b14ed",
+      "size": 817,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c8b8295ed8e35089ca9816485ba76443001b14ed"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/favicon-16x16.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5fb4d76f5034542c2651d2310d123df5c55a035d",
+      "size": 1971,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5fb4d76f5034542c2651d2310d123df5c55a035d"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/favicon-32x32.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4dcb369f289a64593496500bab2e30bf54f097a3",
+      "size": 308,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4dcb369f289a64593496500bab2e30bf54f097a3"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/favicon.ico",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "32f25c3513733070cf7ec67842b59391199275b8",
+      "size": 766,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/32f25c3513733070cf7ec67842b59391199275b8"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/mstile-150x150.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f3f59a6c6277269333eff8eb4eac8d4c66dc89fc",
+      "size": 7592,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f3f59a6c6277269333eff8eb4eac8d4c66dc89fc"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/safari-pinned-tab.svg",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "932ae5b24ef46fba6ea9cee1a3a5a95a9cc2d74b",
+      "size": 1867,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/932ae5b24ef46fba6ea9cee1a3a5a95a9cc2d74b"
+    },
+    {
+      "path": "demos/palm/web/textfx/public/site.webmanifest",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8af025f70d5bfbaa259814452dd7701bdae71abf",
+      "size": 291,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8af025f70d5bfbaa259814452dd7701bdae71abf"
+    },
+    {
+      "path": "demos/palm/web/textfx/src",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "583a81629aad2095ac242b10e1591c3862fd8aed",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/583a81629aad2095ac242b10e1591c3862fd8aed"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/App.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "91b994c8fbc54056723d6bc75531f53813cd6dd0",
+      "size": 2603,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/91b994c8fbc54056723d6bc75531f53813cd6dd0"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/assets",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "90180f51b16ae6ca64b974b9b0eeba268be36a3d",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/90180f51b16ae6ca64b974b9b0eeba268be36a3d"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/assets/images",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "7e66c9437edc9806b164a5997c3c80423f90aacb",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/7e66c9437edc9806b164a5997c3c80423f90aacb"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/assets/images/landing-right-col-background.jpg",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "cc04fac6dfc630c556dfbbb0f7115211b3cdaa4e",
+      "size": 2766354,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/cc04fac6dfc630c556dfbbb0f7115211b3cdaa4e"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/assets/images/landing-video-poster.jpg",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "694fd181d504be6beccd9d9d20b53829ce0531ec",
+      "size": 1496339,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/694fd181d504be6beccd9d9d20b53829ce0531ec"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/assets/images/welcome",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "74c14e271ad3b488c9c70b3494b53dfe60f84b65",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/74c14e271ad3b488c9c70b3494b53dfe60f84b65"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/assets/images/welcome/welcome-step-1.jpg",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "136d03114db0ad445989d236fa5b8e75662c15cf",
+      "size": 42477,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/136d03114db0ad445989d236fa5b8e75662c15cf"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/assets/images/welcome/welcome-step-2.jpg",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "820cc5bdebeee59348b3f89627cbd0262af2daee",
+      "size": 44352,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/820cc5bdebeee59348b3f89627cbd0262af2daee"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/assets/images/welcome/welcome-step-3.jpg",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "02e88edb934e6602e3806dca24f418176bf57a44",
+      "size": 20181,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/02e88edb934e6602e3806dca24f418176bf57a44"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/assets/landing_right_col_animation_lottie.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b3aa43faf9f74410dec80d0fe6cf52a058007d0d",
+      "size": 819646,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b3aa43faf9f74410dec80d0fe6cf52a058007d0d"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/assets/lupe_signature_animation_lottie.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ae3dc9d4b3768cc627a5884d4af527041d5c0825",
+      "size": 52646,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ae3dc9d4b3768cc627a5884d4af527041d5c0825"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "6072983a57b6f358c752bd3daf704dc81205c04a",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/6072983a57b6f358c752bd3daf704dc81205c04a"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "2aa4d4981ffdebc8b1c5f41b66672b5c5852c350",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/2aa4d4981ffdebc8b1c5f41b66672b5c5852c350"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/button",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "35dc347fc4bba4fdf1f3797b4dc6b24b0590f43d",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/35dc347fc4bba4fdf1f3797b4dc6b24b0590f43d"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/button/button.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7be97ad3b6c27b493f3af18c7533a2bbeb81bf44",
+      "size": 2612,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7be97ad3b6c27b493f3af18c7533a2bbeb81bf44"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/button/button.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "16346677fd35612eb2efd72f223ef70fda6f7b11",
+      "size": 1705,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/16346677fd35612eb2efd72f223ef70fda6f7b11"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/checkbox",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "591183acf10ee2c4797856f3b07f7a1af70cf31b",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/591183acf10ee2c4797856f3b07f7a1af70cf31b"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/checkbox/checkbox.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fb266ca9ed5977ec71fa65f78da9cff9173de4cc",
+      "size": 1270,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fb266ca9ed5977ec71fa65f78da9cff9173de4cc"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/checkbox/checkbox.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ff670ccc2fe0cfef813c404c4468a6ff6bac07c1",
+      "size": 936,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ff670ccc2fe0cfef813c404c4468a6ff6bac07c1"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/filterButton",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "6759edebaecc90fe37a03d91a0540ca175a85dab",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/6759edebaecc90fe37a03d91a0540ca175a85dab"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/filterButton/filterButton.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f58c34021ea0dad5e8dd2a35c22f791a05e630b0",
+      "size": 2027,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f58c34021ea0dad5e8dd2a35c22f791a05e630b0"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/filterButton/filterButton.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "abf12b1b03e6646aad87aca82f4ffed379e3d474",
+      "size": 2129,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/abf12b1b03e6646aad87aca82f4ffed379e3d474"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/filterList",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "a27870d7b7a2332c0eba1169b1de9adb4a368fd4",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/a27870d7b7a2332c0eba1169b1de9adb4a368fd4"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/filterList/filterList.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bdbf09f334f21e36f0967dd44b8ddf53145e46b1",
+      "size": 1511,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bdbf09f334f21e36f0967dd44b8ddf53145e46b1"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/filterList/filterList.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8dc4779959fda6a8d06123249c074f44ce9c2a90",
+      "size": 2707,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8dc4779959fda6a8d06123249c074f44ce9c2a90"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/hamburger",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "f7cdc9bbd7cc64481a3db2e7375562cdf4d3e1b3",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/f7cdc9bbd7cc64481a3db2e7375562cdf4d3e1b3"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/hamburger/hamburger.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "88fa2be937b9df1e105b6ba8da9f7d3c331e889c",
+      "size": 3867,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/88fa2be937b9df1e105b6ba8da9f7d3c331e889c"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/hamburger/hamburger.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b80e901974fa191f460e0d22ed8fe5752bdb3822",
+      "size": 1405,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b80e901974fa191f460e0d22ed8fe5752bdb3822"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "751e501b10f1fd449126149db99fac97474bb1a0",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/751e501b10f1fd449126149db99fac97474bb1a0"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "f5dc6083ae250d200a362e92fda6dcfecc92016a",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/f5dc6083ae250d200a362e92fda6dcfecc92016a"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/acronym.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "838c303a29ced4e0e8f0d6faa9fd42fe73ee1099",
+      "size": 3290,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/838c303a29ced4e0e8f0d6faa9fd42fe73ee1099"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/all.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "61eae08a0a98f684d0aee6e588a61b71b157e670",
+      "size": 1783,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/61eae08a0a98f684d0aee6e588a61b71b157e670"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/alliteration.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "04b1d048282992775f210266b31adcccc08f1a73",
+      "size": 1657,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/04b1d048282992775f210266b31adcccc08f1a73"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/arrow.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "cb11c3f9a077651569a06b42764326038e9dd659",
+      "size": 942,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/cb11c3f9a077651569a06b42764326038e9dd659"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/arrowDown.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6b7a2812298938f515107a2fc7f7e0374ede6122",
+      "size": 1227,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6b7a2812298938f515107a2fc7f7e0374ede6122"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/back.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8639935d72aa7d521dd0c7c5417e220a297c7e4a",
+      "size": 1127,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8639935d72aa7d521dd0c7c5417e220a297c7e4a"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/chain.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4fe387fe6a13d7374c09c13d5bf2f2422ca15d89",
+      "size": 1810,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4fe387fe6a13d7374c09c13d5bf2f2422ca15d89"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/close.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "89e56956bdcb532cd8c1f28c9ba3c94002ff030b",
+      "size": 1187,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/89e56956bdcb532cd8c1f28c9ba3c94002ff030b"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/collapseArrow.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7e4e47e9d1ab860b6631be18ed51a6f74cae1346",
+      "size": 1185,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7e4e47e9d1ab860b6631be18ed51a6f74cae1346"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/copy.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bb921708e904a808fc60f428003b1ea8f7cabe5f",
+      "size": 1455,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bb921708e904a808fc60f428003b1ea8f7cabe5f"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/delete.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "159c466853352c0551a5ca7dd695528e88deda6d",
+      "size": 1207,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/159c466853352c0551a5ca7dd695528e88deda6d"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/download.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7d30781e8f752139e81b5add5b96adbc3438dc9d",
+      "size": 1320,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7d30781e8f752139e81b5add5b96adbc3438dc9d"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/drag.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b648bbb8b343ce9ee85e2cd1603148c2a4fa9d42",
+      "size": 2548,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b648bbb8b343ce9ee85e2cd1603148c2a4fa9d42"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/dropdown.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "972c3dc91fcf6e15d9eff40d248adad7b70ad14e",
+      "size": 897,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/972c3dc91fcf6e15d9eff40d248adad7b70ad14e"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/explode.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "daec891130b95323438870972cdfc0d6ac0d127f",
+      "size": 1395,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/daec891130b95323438870972cdfc0d6ac0d127f"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/external.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2de0264c17cc4164ad2c5e69d865cdca6660c7d7",
+      "size": 1293,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2de0264c17cc4164ad2c5e69d865cdca6660c7d7"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/fuse.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5659db365a2d3f36ed0ad20192f72216bad9bd68",
+      "size": 3348,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5659db365a2d3f36ed0ad20192f72216bad9bd68"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/info.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6e0326303689337a92632801ebb75cba26237d91",
+      "size": 2249,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6e0326303689337a92632801ebb75cba26237d91"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/logo.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "206987423bd2850c2b5f8c40e38459e83f3aa9ac",
+      "size": 291318,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/206987423bd2850c2b5f8c40e38459e83f3aa9ac"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/logoLight.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5a6edb79ac7f08d3b287db275a5155d812885b87",
+      "size": 243081,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5a6edb79ac7f08d3b287db275a5155d812885b87"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/mic.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a0e4b52c8ad214797da38c72aedca514835ba212",
+      "size": 2115,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a0e4b52c8ad214797da38c72aedca514835ba212"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/micListening.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "78c102e6cf1827ae1009f16deca81fcbd44c19e1",
+      "size": 2195,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/78c102e6cf1827ae1009f16deca81fcbd44c19e1"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/micWaiting.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ce6eece31606f524a49bc04054803d6d695941ba",
+      "size": 2129,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ce6eece31606f524a49bc04054803d6d695941ba"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/pin.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1952dc037cf889044c2f89fa284c09d21c5a9654",
+      "size": 1295,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1952dc037cf889044c2f89fa284c09d21c5a9654"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/pinSolid.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "10259aa6656538719d0ece74117fbdb2c14e3449",
+      "size": 1062,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/10259aa6656538719d0ece74117fbdb2c14e3449"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/play.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fc9f28652ceffef3a0d00807f3691f91afcf7d3b",
+      "size": 1836,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fc9f28652ceffef3a0d00807f3691f91afcf7d3b"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/pov.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a933ae2b72d41ad1b6c446d2fbb2fd4add5e4c38",
+      "size": 3842,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a933ae2b72d41ad1b6c446d2fbb2fd4add5e4c38"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/refresh.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1a33f79a2a7d8cc6919efb3c6c58f4839ff3e362",
+      "size": 1482,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1a33f79a2a7d8cc6919efb3c6c58f4839ff3e362"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/save.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c76c8bf1f6d1d417960ac21ad83fbe1d89406da5",
+      "size": 1035,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c76c8bf1f6d1d417960ac21ad83fbe1d89406da5"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/saved.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0e2d24901cd16d3dab05c8c75a0104c5cda87a40",
+      "size": 952,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0e2d24901cd16d3dab05c8c75a0104c5cda87a40"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/scene.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fb68b5d4a13ed1833ae4815a93b08acf946f8c85",
+      "size": 1445,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fb68b5d4a13ed1833ae4815a93b08acf946f8c85"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/simile.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "528cc3de14156601752299716ad157bb30d6fc78",
+      "size": 2256,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/528cc3de14156601752299716ad157bb30d6fc78"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/swiperArrow.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9576df475a5af8449297fda02b635218f42fe10b",
+      "size": 994,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9576df475a5af8449297fda02b635218f42fe10b"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/unexpect.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1dc07e3f6f5f18d684febd9e8e826331806a7df0",
+      "size": 1832,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1dc07e3f6f5f18d684febd9e8e826331806a7df0"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/unfold.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "aeb705635180b63720520b02e014d771be6ddba7",
+      "size": 1748,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/aeb705635180b63720520b02e014d771be6ddba7"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon-set/unpin.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2269a7c75696d4d1275a80a0bed6f4fed1a369e3",
+      "size": 1405,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2269a7c75696d4d1275a80a0bed6f4fed1a369e3"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8d48fabf46df727bf64b1c1ca7e1554965922220",
+      "size": 643,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8d48fabf46df727bf64b1c1ca7e1554965922220"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/icon/icon.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "03d812105b1042adff13cb4c4ed9fda20d7bb071",
+      "size": 3077,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/03d812105b1042adff13cb4c4ed9fda20d7bb071"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/input",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "053b8e715e3a1bab6a6c6124564ccdc7e3dd9351",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/053b8e715e3a1bab6a6c6124564ccdc7e3dd9351"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/input/input.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "599e4164475bf8eab54bbab165c3fb8586080d50",
+      "size": 947,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/599e4164475bf8eab54bbab165c3fb8586080d50"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/input/input.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d82a9de4087b95d2a2ec4872bfa5af5962851796",
+      "size": 1061,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d82a9de4087b95d2a2ec4872bfa5af5962851796"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/macroButtons",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "707048a65e6c091d8379abf802eda61eb763f953",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/707048a65e6c091d8379abf802eda61eb763f953"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/macroButtons/macroButtons.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a22418ca87f1d7b62f7249c8252a5ce30cbd5aba",
+      "size": 3480,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a22418ca87f1d7b62f7249c8252a5ce30cbd5aba"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/macroButtons/macroButtons.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3629bab720ac45d660dfb673367eb537cfeec4bd",
+      "size": 6046,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3629bab720ac45d660dfb673367eb537cfeec4bd"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/macroDescription",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "05d2537845cc084e3b6f9e1c1b11d7f5c5994786",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/05d2537845cc084e3b6f9e1c1b11d7f5c5994786"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/macroDescription/macroDescription.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fc4ccc964bcbc7b9505b017ad824fecf090a98ed",
+      "size": 4184,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fc4ccc964bcbc7b9505b017ad824fecf090a98ed"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/macroDescription/macroDescription.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0bf9814b12730b58efa1b79623651d2650a54634",
+      "size": 5260,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0bf9814b12730b58efa1b79623651d2650a54634"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/macroInput",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "ddeef8e234f75dce7a0b9650213abfb7b587dd0f",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/ddeef8e234f75dce7a0b9650213abfb7b587dd0f"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/macroInput/macroInput.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4627dd05383e2c3b3de8580a11114f3f2113cc6e",
+      "size": 3674,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4627dd05383e2c3b3de8580a11114f3f2113cc6e"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/macroInput/macroInput.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1958b91d746fea82d086aa04fc9038ea01af2ea2",
+      "size": 11417,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1958b91d746fea82d086aa04fc9038ea01af2ea2"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/numberToggle",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "18bb844bc6e6f05bd6cbb21c799f4ff916a390ca",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/18bb844bc6e6f05bd6cbb21c799f4ff916a390ca"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/numberToggle/numberToggle.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8dfa8c83eb7d12246a77d8bdd3c5f036ed2e9863",
+      "size": 1099,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8dfa8c83eb7d12246a77d8bdd3c5f036ed2e9863"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/numberToggle/numberToggle.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "133d388ea8b1592eb3730ecd468d386329ac3609",
+      "size": 2312,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/133d388ea8b1592eb3730ecd468d386329ac3609"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/outputCard",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "6dc476fc9e0981cc504a15ba1a705359e54feaa1",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/6dc476fc9e0981cc504a15ba1a705359e54feaa1"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/outputCard/outputCard.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "db77781f2f2de3ce3fa707e1a4147c3bc26a9e3b",
+      "size": 9252,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/db77781f2f2de3ce3fa707e1a4147c3bc26a9e3b"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/outputCard/outputCard.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "82a103f4a0129950fa1bcd736645e5fed59dd079",
+      "size": 15247,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/82a103f4a0129950fa1bcd736645e5fed59dd079"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/outputSection",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "1d09ac6f0592ee87a91b5dae28f252e7b8901d2f",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/1d09ac6f0592ee87a91b5dae28f252e7b8901d2f"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/outputSection/outputSection.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e00c57f07fad4ca2f7a00352aa7c39624a809704",
+      "size": 2796,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e00c57f07fad4ca2f7a00352aa7c39624a809704"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/outputSection/outputSection.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5073f17b5f589ddc4796774801593407782e5576",
+      "size": 4224,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5073f17b5f589ddc4796774801593407782e5576"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/pinnedCards",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "14165cf01a727dce52c5552651d644f857d1918c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/14165cf01a727dce52c5552651d644f857d1918c"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/pinnedCards/pinnedCard.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5d1f342256422c10433287dbb144f1aa18b086e6",
+      "size": 5963,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5d1f342256422c10433287dbb144f1aa18b086e6"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/pinnedCards/pinnedCards.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ad44665d09424ad262340bc36bf7a34955967b89",
+      "size": 5605,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ad44665d09424ad262340bc36bf7a34955967b89"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/pinnedCards/pinnedCards.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "193de278fc3c4d8b31d05c3414c6d8e4624aa901",
+      "size": 4502,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/193de278fc3c4d8b31d05c3414c6d8e4624aa901"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/popup",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "4430f7a0d6d7b673184c999495783d485b848dfe",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/4430f7a0d6d7b673184c999495783d485b848dfe"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/popup/popup.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d04dd77306b350372ea459f58201b0b68f79ea0f",
+      "size": 1641,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d04dd77306b350372ea459f58201b0b68f79ea0f"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/popup/popup.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "19cec2aee64d7ee9e46466f5cbc94d3117e4224c",
+      "size": 2152,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/19cec2aee64d7ee9e46466f5cbc94d3117e4224c"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/portal",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "0247980376fbb12a9eb0b25e5a4b5d18609e8843",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/0247980376fbb12a9eb0b25e5a4b5d18609e8843"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/portal/portal.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "302e129845e080276e88b7a193a2d6199ee225e7",
+      "size": 1073,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/302e129845e080276e88b7a193a2d6199ee225e7"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/savedFilter",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "dd10f5b5a5408436674cb709a6dddf5d861d8eda",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/dd10f5b5a5408436674cb709a6dddf5d861d8eda"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/savedFilter/savedFilter.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "73f04328e93715b092c57fde3e6abe99e7e167c9",
+      "size": 1344,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/73f04328e93715b092c57fde3e6abe99e7e167c9"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/savedFilter/savedFilter.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "52fa303762d908fa59336f55120e15df65ba643a",
+      "size": 1260,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/52fa303762d908fa59336f55120e15df65ba643a"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/siteNav",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "ff023dbcd3ca627d2f5da736b25b762d1b65db16",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/ff023dbcd3ca627d2f5da736b25b762d1b65db16"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/siteNav/siteNav.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0699f801af3fa5426b86eb3288cf0c1cde9e1031",
+      "size": 2526,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0699f801af3fa5426b86eb3288cf0c1cde9e1031"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/siteNav/siteNav.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b00636babac82dc631932b924b203680fb7bbbda",
+      "size": 2802,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b00636babac82dc631932b924b203680fb7bbbda"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/speechToText",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "bd87f41d7be46a9623129c01ae5230b2fb84f457",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/bd87f41d7be46a9623129c01ae5230b2fb84f457"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/speechToText/speechToText.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f889363091a56263a270b29a311395aa10bb4930",
+      "size": 663,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f889363091a56263a270b29a311395aa10bb4930"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/speechToText/speechToText.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "81f8f71ce8487eb1ba1cc32826e87e0e1533fef9",
+      "size": 2823,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/81f8f71ce8487eb1ba1cc32826e87e0e1533fef9"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/viewAllToggle",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "b290f20493547e9fea384e400bc65bd33031ecb7",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/b290f20493547e9fea384e400bc65bd33031ecb7"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/viewAllToggle/viewAllToggle.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0ef5b8ba22d467a0d29a73b41f5961f3bdd8be83",
+      "size": 1045,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0ef5b8ba22d467a0d29a73b41f5961f3bdd8be83"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/viewAllToggle/viewAllToggle.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b1fbf8d5e9f8c5a755cc2612c656f8d69bb955ed",
+      "size": 1409,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b1fbf8d5e9f8c5a755cc2612c656f8d69bb955ed"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/youtubePlayer",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "464f2b2041a831359489b4b06181646189198842",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/464f2b2041a831359489b4b06181646189198842"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/youtubePlayer/youtubePlayer.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e6cee683224cefa0b2d33cee1faf11663fc3dc84",
+      "size": 1650,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e6cee683224cefa0b2d33cee1faf11663fc3dc84"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/generic/youtubePlayer/youtubePlayer.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0cf0f98aa68e564f8eaddb6e6d2595d6f0be4779",
+      "size": 3824,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0cf0f98aa68e564f8eaddb6e6d2595d6f0be4779"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "1422b0f63da0780d134d611aa1e764cb6c09f995",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/1422b0f63da0780d134d611aa1e764cb6c09f995"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/about",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "cfde69fd49011e8f46617e482a37c97c705fc147",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/cfde69fd49011e8f46617e482a37c97c705fc147"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/about/about.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f11942f90ea08351074aa3911756b652743b5b0b",
+      "size": 1593,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f11942f90ea08351074aa3911756b652743b5b0b"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/about/about.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b3b3fd5b000c21f5cfad8396938cacb5574f5f52",
+      "size": 7403,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b3b3fd5b000c21f5cfad8396938cacb5574f5f52"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/landing",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "9a463d83426bccfa2b562bbd76af22c71cdbf446",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/9a463d83426bccfa2b562bbd76af22c71cdbf446"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/landing/googleLogo.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4eb00b6e300df70cc334d9dae4df0b7844a094d6",
+      "size": 3832,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4eb00b6e300df70cc334d9dae4df0b7844a094d6"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/landing/labsSessionsLogo.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "67b57b58271d8163371ea24ae3b9e64ffb823c17",
+      "size": 13005,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/67b57b58271d8163371ea24ae3b9e64ffb823c17"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/landing/landing.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bd770558bba9b53129b0b2e9646d18410c407845",
+      "size": 10862,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bd770558bba9b53129b0b2e9646d18410c407845"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/landing/landing.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fb3da0b247ec748478dfcdf381cbc73f0b48cda2",
+      "size": 10484,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fb3da0b247ec748478dfcdf381cbc73f0b48cda2"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/landing/landingLogo.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c779bc2dcaf44cc71645436e2c97af4e212a7c66",
+      "size": 295114,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c779bc2dcaf44cc71645436e2c97af4e212a7c66"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/landing/lupeLogo.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "55a36fc12e93dee4d5e43b62ec23f8a4778b316a",
+      "size": 6546,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/55a36fc12e93dee4d5e43b62ec23f8a4778b316a"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/mainScreen",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "4e63998af00d8f26d43ca60c0b89d90057825fc1",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/4e63998af00d8f26d43ca60c0b89d90057825fc1"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/mainScreen/mainScreen.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7de398d90f086e86c2e0201974904aef33beaef5",
+      "size": 4117,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7de398d90f086e86c2e0201974904aef33beaef5"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/mainScreen/mainScreen.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "396dbb6ea1c72f89cb41d7bb23229eb136aa9586",
+      "size": 5920,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/396dbb6ea1c72f89cb41d7bb23229eb136aa9586"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/promptData",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "cb2f326aa6be369f408d611e2c86e53dad6d45dc",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/cb2f326aa6be369f408d611e2c86e53dad6d45dc"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/promptData/promptData.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8ea35c32b56fdf65b06e44197901febf0951c0b3",
+      "size": 3725,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8ea35c32b56fdf65b06e44197901febf0951c0b3"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/promptData/promptData.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "83fe38d3fbed18148831afdccc89105dd73f7694",
+      "size": 4072,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/83fe38d3fbed18148831afdccc89105dd73f7694"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/welcome",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "1cd707e7f57ab687fbaa7c116477baed9baf0b03",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/1cd707e7f57ab687fbaa7c116477baed9baf0b03"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/welcome/screen1.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f0547478940b81d42c5917fefd4fba99a9170f0a",
+      "size": 5369,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f0547478940b81d42c5917fefd4fba99a9170f0a"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/welcome/screen2.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a001bc557255a4f1989e343385ee3e20e0e93784",
+      "size": 2518,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a001bc557255a4f1989e343385ee3e20e0e93784"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/welcome/welcome.module.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3901f4b5de7a64f54711709a73be5d79c6b4bd13",
+      "size": 3088,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3901f4b5de7a64f54711709a73be5d79c6b4bd13"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/components/layouts/welcome/welcome.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e4a9a8054d98407be93d95a55814f4513611bbc0",
+      "size": 1717,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e4a9a8054d98407be93d95a55814f4513611bbc0"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/constants.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fe4a14e652858d9ab39c92137f7cca6125c53ea9",
+      "size": 24935,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fe4a14e652858d9ab39c92137f7cca6125c53ea9"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/hooks",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "7c24bd4bce8a8836072f2ab80a3423ec1aa9fcd7",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/7c24bd4bce8a8836072f2ab80a3423ec1aa9fcd7"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/hooks/useAnimationFrame.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5dc89fcfdd2dbb18568c870e6f4d798d7480b303",
+      "size": 1703,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5dc89fcfdd2dbb18568c870e6f4d798d7480b303"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/hooks/useIsMobile.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bc78c5408d371157eae83e1c1ee55d80dfc324a1",
+      "size": 1844,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bc78c5408d371157eae83e1c1ee55d80dfc324a1"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/hooks/useOnClickOutside.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7c1c570905df4ba1339ead6081104249a848a05b",
+      "size": 1251,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7c1c570905df4ba1339ead6081104249a848a05b"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/hooks/useOnScreen.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6e2fd04486b4d5a53baa3758afbbaeeecac5a98a",
+      "size": 1097,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6e2fd04486b4d5a53baa3758afbbaeeecac5a98a"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/hooks/useSticky.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5579c1772e20ef868687721dbc1878bb2027bfcd",
+      "size": 1161,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5579c1772e20ef868687721dbc1878bb2027bfcd"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/hooks/useWindowSize.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "aebe2fd4931bcc5f4fc1cd562cbb244b526cc48f",
+      "size": 1457,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/aebe2fd4931bcc5f4fc1cd562cbb244b526cc48f"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/lib",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "f1c60d6ebc45e6c425e012cb70063562cbf29818",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/f1c60d6ebc45e6c425e012cb70063562cbf29818"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/lib/adaptPromptDataFormat.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "676bc1b4e7029d850cda584677ef143de39fb293",
+      "size": 1827,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/676bc1b4e7029d850cda584677ef143de39fb293"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/lib/api.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4af742569f00d1edd2bf73da41b81897569e68e6",
+      "size": 2161,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4af742569f00d1edd2bf73da41b81897569e68e6"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/lib/firebase.config.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8ddbafe9451ea14929b454d5878ba36055b7b45e",
+      "size": 2062,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8ddbafe9451ea14929b454d5878ba36055b7b45e"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/lib/formatDownload.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "37293114dd86c8f62ccb53e477d7564df30f93f8",
+      "size": 5159,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/37293114dd86c8f62ccb53e477d7564df30f93f8"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/lib/macros.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b578eba1a426fc3639de8c15fe1f4d3da52a79bd",
+      "size": 7743,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b578eba1a426fc3639de8c15fe1f4d3da52a79bd"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/lib/parse.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b900a75739f7155c33e2015a4c9aeee8a82e49ed",
+      "size": 1291,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b900a75739f7155c33e2015a4c9aeee8a82e49ed"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/lib/postprocess.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "809d1c0c6edcc400e1728debf672165ed1dfcb6f",
+      "size": 8552,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/809d1c0c6edcc400e1728debf672165ed1dfcb6f"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/lib/priming.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8d6d6a9c6ed29263410d0d0a01cae34f76a74b46",
+      "size": 32511,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8d6d6a9c6ed29263410d0d0a01cae34f76a74b46"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/lib/utils.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "61f9a11d22014cb14098de2fab67c37427d218ad",
+      "size": 1018,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/61f9a11d22014cb14098de2fab67c37427d218ad"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/main.tsx",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9516e42f516c0c46675427f98dda8e694e1c0bd3",
+      "size": 792,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9516e42f516c0c46675427f98dda8e694e1c0bd3"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/store.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6d711f15bcd660d1b90b4215d42ff2ed2993e17d",
+      "size": 6085,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6d711f15bcd660d1b90b4215d42ff2ed2993e17d"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/styles",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "6d6bba820d5116eb012293b38a3895366869df31",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/6d6bba820d5116eb012293b38a3895366869df31"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/styles/app.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "229c0c7e49c8ae003d7ac957bda7bafec25b8b73",
+      "size": 805,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/229c0c7e49c8ae003d7ac957bda7bafec25b8b73"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/styles/base.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "39311285bd05605734642d6bb33c924e94bcf1a9",
+      "size": 1322,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/39311285bd05605734642d6bb33c924e94bcf1a9"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/styles/tooltip.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a7d39c13de144264b6cab5afa314245c90e5d433",
+      "size": 761,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a7d39c13de144264b6cab5afa314245c90e5d433"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/styles/typography.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7b61884b7ea805056a2680eb7c4b7e6578835e38",
+      "size": 895,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7b61884b7ea805056a2680eb7c4b7e6578835e38"
+    },
+    {
+      "path": "demos/palm/web/textfx/src/styles/variables.scss",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bc3df718fd4e96ac8a7f4a7cc9979f4ba68bb360",
+      "size": 1260,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bc3df718fd4e96ac8a7f4a7cc9979f4ba68bb360"
+    },
+    {
+      "path": "demos/palm/web/textfx/staging.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "81b676dbc6d7c5f81786bb1cf3dbf4786f13af3d",
+      "size": 759,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/81b676dbc6d7c5f81786bb1cf3dbf4786f13af3d"
+    },
+    {
+      "path": "demos/palm/web/textfx/tsconfig.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "82a7de729fefd6afd161b87cd2cd2420b96dea26",
+      "size": 709,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/82a7de729fefd6afd161b87cd2cd2420b96dea26"
+    },
+    {
+      "path": "demos/palm/web/textfx/types",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "94fb3cbe9c7cac4eab1516bb9a534588d705689b",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/94fb3cbe9c7cac4eab1516bb9a534588d705689b"
+    },
+    {
+      "path": "demos/palm/web/textfx/types/index.d.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ee787cb1b64317452e0ff446e5e14d002ee6f6db",
+      "size": 627,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ee787cb1b64317452e0ff446e5e14d002ee6f6db"
+    },
+    {
+      "path": "demos/palm/web/textfx/vite.config.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "892c433565e80bfda6465287aaada076dd3db7fb",
+      "size": 855,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/892c433565e80bfda6465287aaada076dd3db7fb"
+    },
+    {
+      "path": "demos/palm/web/travel-planner",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "8758027781677083cf9aaa7a623181068d969d73",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/8758027781677083cf9aaa7a623181068d969d73"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/.env",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "eb50c1de6d6e14cfe74ece3f3b1f4a1f06267bb3",
+      "size": 70,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/eb50c1de6d6e14cfe74ece3f3b1f4a1f06267bb3"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/.eslintignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "78282dc9bd5962287e07787c94d50eb68ab7fc78",
+      "size": 130,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/78282dc9bd5962287e07787c94d50eb68ab7fc78"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/.eslintrc",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "457c7d08fe66fa0888453d4e6ae7bb7c1307e6a3",
+      "size": 1813,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/457c7d08fe66fa0888453d4e6ae7bb7c1307e6a3"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/.gcloudignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f4b4ef500f9bfacb4f1c3701d51964a72766231c",
+      "size": 135,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f4b4ef500f9bfacb4f1c3701d51964a72766231c"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/.gitignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d4734d12fa3baf8b6eddad4bda8c8d00fe050576",
+      "size": 281,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d4734d12fa3baf8b6eddad4bda8c8d00fe050576"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/.prettierignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f0c8f397091d76af479bd518f6611757b2450fe9",
+      "size": 50,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f0c8f397091d76af479bd518f6611757b2450fe9"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/.prettierrc",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6f5526c7ebe3adfaa5050c45149b86d8c4faa71a",
+      "size": 90,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6f5526c7ebe3adfaa5050c45149b86d8c4faa71a"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/CODE_OF_CONDUCT.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8ba5767edd40f8b731481b517d99ca01af04bdf2",
+      "size": 4502,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8ba5767edd40f8b731481b517d99ca01af04bdf2"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/CONTRIBUTING",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9d7656bec31111b1919d19231868a7b5f8daece4",
+      "size": 1102,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9d7656bec31111b1919d19231868a7b5f8daece4"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/LICENSE",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7a4a3ea2424c09fbe48d455aed1eaa94d9124835",
+      "size": 11357,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7a4a3ea2424c09fbe48d455aed1eaa94d9124835"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/app.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "cc1d597037584c8acc5c6cf79c6ccb0a1482f4c0",
+      "size": 802,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/cc1d597037584c8acc5c6cf79c6ccb0a1482f4c0"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/config-overrides.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "edafdfeb1c4a80fc4bb3e0474fd38e3a1b71f4ef",
+      "size": 1132,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/edafdfeb1c4a80fc4bb3e0474fd38e3a1b71f4ef"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/docs",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "cebb3d38a3163f519f82ed197aa7ab95b105d657",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/cebb3d38a3163f519f82ed197aa7ab95b105d657"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/docs/llm_prompt_design_diagram.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "75801d4a43235fe99d2f7f39af561254640984d4",
+      "size": 83440,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/75801d4a43235fe99d2f7f39af561254640984d4"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/docs/wanderlust_demo.gif",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "670e48c377782dc31a75a35808aae43b98262a8d",
+      "size": 1302156,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/670e48c377782dc31a75a35808aae43b98262a8d"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/docs/wanderlust_demo.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "be7dbd4d8c45ade8e890abd91f7f4d7fe120017b",
+      "size": 2242676,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/be7dbd4d8c45ade8e890abd91f7f4d7fe120017b"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/docs/wanderlust_header.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f079b5f7c5341923fce2bc1cb9fa72c376c2da2b",
+      "size": 246028,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f079b5f7c5341923fce2bc1cb9fa72c376c2da2b"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/index.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f5012c16fe3ecea64d5a5cd95e86c71020e9c00f",
+      "size": 1352,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f5012c16fe3ecea64d5a5cd95e86c71020e9c00f"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/jsconfig.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a0f1aca809451aca36fa8b742a277370264c59b3",
+      "size": 178,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a0f1aca809451aca36fa8b742a277370264c59b3"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/package-lock.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "290c93b4eccdf7ecbd9df09078af3d6ec9bd18ae",
+      "size": 1265443,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/290c93b4eccdf7ecbd9df09078af3d6ec9bd18ae"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/package.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ba6ef4a1cf7f339c4242f042142d3af53fe3a8f5",
+      "size": 1115,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ba6ef4a1cf7f339c4242f042142d3af53fe3a8f5"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/public",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "67d60e747eb47ae8fbe66db99cebbe8e1cc476db",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/67d60e747eb47ae8fbe66db99cebbe8e1cc476db"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/public/icon.svg",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "91dd6f816427c34cff9fa03983925f128da9dda9",
+      "size": 4553,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/91dd6f816427c34cff9fa03983925f128da9dda9"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/public/onboarding.jpg",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "383b774b0108ca6fe062d381f3a967712909d31b",
+      "size": 89520,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/383b774b0108ca6fe062d381f3a967712909d31b"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/public/💡.svg",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a1aa6b6803e83274a4e44a8825b3550b7cdfcb0e",
+      "size": 4339,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a1aa6b6803e83274a4e44a8825b3550b7cdfcb0e"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/readme.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ce505a2b0b92077dad616af2a3f9ba6aaa7808c7",
+      "size": 13991,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ce505a2b0b92077dad616af2a3f9ba6aaa7808c7"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "33344cf4d6912cffd3147b76ad66f795522eebeb",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/33344cf4d6912cffd3147b76ad66f795522eebeb"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/App.css",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "07a212462feb192ab5e6f2d518ad2651013a592b",
+      "size": 688,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/07a212462feb192ab5e6f2d518ad2651013a592b"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/App.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bdf100f90b0370588895bd367ff2189b59103cd9",
+      "size": 722,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bdf100f90b0370588895bd367ff2189b59103cd9"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/apis",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "526a4bf322fbe36be89db5798bb20aed886f673f",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/526a4bf322fbe36be89db5798bb20aed886f673f"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/apis/LLMCaller.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4bc9a2506a26e1f847e54eff74e98c1e88e5b106",
+      "size": 1619,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4bc9a2506a26e1f847e54eff74e98c1e88e5b106"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/apis/googleCaller.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2894e2b594d4106860a30a7348fc3c0a67101ad5",
+      "size": 1179,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2894e2b594d4106860a30a7348fc3c0a67101ad5"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/apis/placeCaller.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "31e2777444f956fc0cd9c8827aa24bb90c698794",
+      "size": 4010,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/31e2777444f956fc0cd9c8827aa24bb90c698794"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/assets",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "b179a383ba675938dccd469e05b948dc496bbffa",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/b179a383ba675938dccd469e05b948dc496bbffa"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/assets/icons",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "397ecb920a881a8558be4bdcdecb9dbdf5c74e30",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/397ecb920a881a8558be4bdcdecb9dbdf5c74e30"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/assets/icons/🏖️.svg",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "94a2b80277ab20584c7c69b726dad3b3c077adb9",
+      "size": 34226,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/94a2b80277ab20584c7c69b726dad3b3c077adb9"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/assets/lotties",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "41cd15cb18f4188ed0142560692737fb0e9d70b3",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/41cd15cb18f4188ed0142560692737fb0e9d70b3"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/assets/lotties/itinerary_loading_03.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a8c207cc99dc7484e054275c0ab70371c00352e9",
+      "size": 32508,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a8c207cc99dc7484e054275c0ab70371c00352e9"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/assets/react.svg",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6c87de9bb3358469122cc991d5cf578927246184",
+      "size": 4126,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6c87de9bb3358469122cc991d5cf578927246184"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/components",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "670a568f55c45b74530c6304f18c2f388005a69a",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/670a568f55c45b74530c6304f18c2f388005a69a"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/components/ChatInput.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "66cf38bfe10bdb09802507ff1ef27ecffeda4b39",
+      "size": 2475,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/66cf38bfe10bdb09802507ff1ef27ecffeda4b39"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/components/DayList.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fb4227c814c140c5870cc2e207e2f54a2e1e3f72",
+      "size": 5024,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fb4227c814c140c5870cc2e207e2f54a2e1e3f72"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/components/Dialogue.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "40df5fdac4b3f820d7044e987f49f639fb9b487e",
+      "size": 1136,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/40df5fdac4b3f820d7044e987f49f639fb9b487e"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/components/GoogleLogin.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "10a6e3cf64703754292ae087bc5793097eda6ced",
+      "size": 1442,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/10a6e3cf64703754292ae087bc5793097eda6ced"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/components/Header.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3af3e843c671015e6de32c83c98363abf69037d4",
+      "size": 1760,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3af3e843c671015e6de32c83c98363abf69037d4"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/components/Layout.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0148c4a1d333790e1544bcdbd6cc4691c0abcbb9",
+      "size": 782,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0148c4a1d333790e1544bcdbd6cc4691c0abcbb9"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/components/MainLayout.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2da64332fd4a621ffa6a4ca3e0d4a41c558b22df",
+      "size": 1021,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2da64332fd4a621ffa6a4ca3e0d4a41c558b22df"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/components/MapCard.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8565cfc0d5e1f4a96a542df869a4d2a015d63176",
+      "size": 2497,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8565cfc0d5e1f4a96a542df869a4d2a015d63176"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/components/PlaceCard.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2d4831d09c23a3e2e5c1a792e9281e9b59eb28ac",
+      "size": 7523,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2d4831d09c23a3e2e5c1a792e9281e9b59eb28ac"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/components/PlaceView.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d779d6b142311b7c1e251fb9c4c6776956397da9",
+      "size": 6593,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d779d6b142311b7c1e251fb9c4c6776956397da9"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/components/PredefineMessage.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "63c9135b31dc4450b29488b05ad81e4d919f3c23",
+      "size": 5811,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/63c9135b31dc4450b29488b05ad81e4d919f3c23"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/fonts",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "065df133ea8ef0ddd3d367c2a679fa84d9bf955c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/065df133ea8ef0ddd3d367c2a679fa84d9bf955c"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/fonts/GoogleSans",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "740e6a6483c69be504ed9ea37ddf96ce08100087",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/740e6a6483c69be504ed9ea37ddf96ce08100087"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/fonts/GoogleSans/GoogleSans-Bold.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "80497666ec8ca0abb81ce5bd9ce649896555753e",
+      "size": 117916,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/80497666ec8ca0abb81ce5bd9ce649896555753e"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/fonts/GoogleSans/GoogleSans-BoldItalic.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e940d022ecbcfe05b53085f48a871ce39509fa30",
+      "size": 121080,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e940d022ecbcfe05b53085f48a871ce39509fa30"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/fonts/GoogleSans/GoogleSans-Italic.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bfb1a2cd2c63a5dd176fe273c06a19184ce556fb",
+      "size": 121280,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bfb1a2cd2c63a5dd176fe273c06a19184ce556fb"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/fonts/GoogleSans/GoogleSans-Medium.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1543660daf312c87535cb387f57da10c2e626626",
+      "size": 118508,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1543660daf312c87535cb387f57da10c2e626626"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/fonts/GoogleSans/GoogleSans-MediumItalic.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7c1667bbfbcfb996e5a59e725602158537da20b6",
+      "size": 121216,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7c1667bbfbcfb996e5a59e725602158537da20b6"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/fonts/GoogleSans/GoogleSans-Regular.ttf",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ab605f9e2e3c347708a810435ba3a7debc52e1df",
+      "size": 119984,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ab605f9e2e3c347708a810435ba3a7debc52e1df"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/guards",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "17948effda244cf2edca27db3678b689a845c79b",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/17948effda244cf2edca27db3678b689a845c79b"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/guards/AuthGuard.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "53cb96ad8e8d5979c7d5cb1e3481a82829ffab92",
+      "size": 1240,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/53cb96ad8e8d5979c7d5cb1e3481a82829ffab92"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/guards/GuestGuard.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "74d4bdfce7da316543276baf4bfae6b415c7d466",
+      "size": 1068,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/74d4bdfce7da316543276baf4bfae6b415c7d466"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/hooks",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "21033b7900ae967ae4d42e2043b68bbc810b070c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/21033b7900ae967ae4d42e2043b68bbc810b070c"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/hooks/useInterval.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9de045ecb698223ce10bb116fd98bc81f636aa06",
+      "size": 1179,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9de045ecb698223ce10bb116fd98bc81f636aa06"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/index.css",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fc824e71411c7596994d283af6db8d4e55a7f0e4",
+      "size": 1722,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fc824e71411c7596994d283af6db8d4e55a7f0e4"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/main.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7e73e19edaf1ebece80a1f35ad10fd8c172f0d79",
+      "size": 971,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7e73e19edaf1ebece80a1f35ad10fd8c172f0d79"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/pages",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "049b0dce68cbd0b814dd59abff591e5f24c8e96e",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/049b0dce68cbd0b814dd59abff591e5f24c8e96e"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/pages/index.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "086b70193325c876cd0674cbc2534899ae69f197",
+      "size": 19290,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/086b70193325c876cd0674cbc2534899ae69f197"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/pages/onboarding.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5a7865d3ae84b3fa87d6c5e4b418827d3f0e3f2d",
+      "size": 3205,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5a7865d3ae84b3fa87d6c5e4b418827d3f0e3f2d"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/routes",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "02d66ec4456b115965e315c540f34a16206691f6",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/02d66ec4456b115965e315c540f34a16206691f6"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/routes/index.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "304fea7f015ebb7d05fd6176cb0bea89fa35605d",
+      "size": 970,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/304fea7f015ebb7d05fd6176cb0bea89fa35605d"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/utils",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "bbc1a16365322d00bdeadca649af5d7526ab0838",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/bbc1a16365322d00bdeadca649af5d7526ab0838"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/utils/fetchImage.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e28baa9fe628a50908ddda887dd16c01f9604828",
+      "size": 925,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e28baa9fe628a50908ddda887dd16c01f9604828"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/utils/gtag.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "332905d51c24522f886b3a4de6f2a6b654863f26",
+      "size": 706,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/332905d51c24522f886b3a4de6f2a6b654863f26"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/utils/iframeUtils.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "15a1889919818412b69a2ce9644ec7aed78ccbaf",
+      "size": 736,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/15a1889919818412b69a2ce9644ec7aed78ccbaf"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/utils/llmTextParser.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1687425b840181a4d86dad697aaf605c9fc2a7cd",
+      "size": 1707,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1687425b840181a4d86dad697aaf605c9fc2a7cd"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/utils/loadScript.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "81ecf8dd466de923aedcdb37a2ad92d2d997cfd6",
+      "size": 942,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/81ecf8dd466de923aedcdb37a2ad92d2d997cfd6"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/utils/markPlaces.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "cf6781bb62690b1115a8bde0f842db0fa9a886df",
+      "size": 1216,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/cf6781bb62690b1115a8bde0f842db0fa9a886df"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/utils/prompt.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d8a6b2ac39bfe8e9f7bba0caf54e0cd0ca1245c5",
+      "size": 761,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d8a6b2ac39bfe8e9f7bba0caf54e0cd0ca1245c5"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/utils/rawParser.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8eca52279720d9ffcf38be423314539ede52dd5c",
+      "size": 2602,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8eca52279720d9ffcf38be423314539ede52dd5c"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/src/utils/sleep.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "59974cb977685ae45ec78b270279a49d226c4dd5",
+      "size": 689,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/59974cb977685ae45ec78b270279a49d226c4dd5"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/vite.config.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4a49cec3660f11be8aac69e9bb60f84ec948fe47",
+      "size": 1411,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4a49cec3660f11be8aac69e9bb60f84ec948fe47"
+    },
+    {
+      "path": "demos/palm/web/travel-planner/yarn.lock",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bf02a6022424f0f19fe60ea5b7b51dbf3e330677",
+      "size": 309920,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bf02a6022424f0f19fe60ea5b7b51dbf3e330677"
+    },
+    {
+      "path": "examples",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "5f2b23ca9e8b0f1b6b2dae8c1b46873b5b95e9ff",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/5f2b23ca9e8b0f1b6b2dae8c1b46873b5b95e9ff"
+    },
+    {
+      "path": "examples/gemini",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "ec0a3da832276d060b960b8e40fc51e772085a1e",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/ec0a3da832276d060b960b8e40fc51e772085a1e"
+    },
+    {
+      "path": "examples/gemini/javascript",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "4911dde44d3fe5129ce066205d9d1c56d5c33d56",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/4911dde44d3fe5129ce066205d9d1c56d5c33d56"
+    },
+    {
+      "path": "examples/gemini/javascript/langchain_quickstart_node",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "73bcb00ead4c026e8c03a308df74a5dfd415b9dd",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/73bcb00ead4c026e8c03a308df74a5dfd415b9dd"
+    },
+    {
+      "path": "examples/gemini/javascript/langchain_quickstart_node/.gitignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9c6e766ce2fec7070ca3017806edfcc6fb973af8",
+      "size": 10,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9c6e766ce2fec7070ca3017806edfcc6fb973af8"
+    },
+    {
+      "path": "examples/gemini/javascript/langchain_quickstart_node/README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0f1b1c61814fc5f5bc0acfd65d41eee37fc6e634",
+      "size": 2117,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0f1b1c61814fc5f5bc0acfd65d41eee37fc6e634"
+    },
+    {
+      "path": "examples/gemini/javascript/langchain_quickstart_node/main.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c8f43b84a05615d4370542ac41da10f070ec0b60",
+      "size": 2635,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c8f43b84a05615d4370542ac41da10f070ec0b60"
+    },
+    {
+      "path": "examples/gemini/javascript/langchain_quickstart_node/package-lock.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ab1231027c6ff63854517ff2a8ec5eb7fb7ee378",
+      "size": 19226,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ab1231027c6ff63854517ff2a8ec5eb7fb7ee378"
+    },
+    {
+      "path": "examples/gemini/javascript/langchain_quickstart_node/package.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "85cc2abf58bcaa78b650892ff642032646f3dca4",
+      "size": 326,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/85cc2abf58bcaa78b650892ff642032646f3dca4"
+    },
+    {
+      "path": "examples/gemini/node",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "6d40d8c3ea21be5319e955e4db039a973af41478",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/6d40d8c3ea21be5319e955e4db039a973af41478"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "d4f6abf9a2140882237d2b7cf4d0f1f55b2b413c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/d4f6abf9a2140882237d2b7cf4d0f1f55b2b413c"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/.eslintrc.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f9b22b793c2998a2d5b65850b80b8a459bab32f4",
+      "size": 516,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f9b22b793c2998a2d5b65850b80b8a459bab32f4"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/.gitignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0b60dfa12fb992ff3c1555855471510558356a46",
+      "size": 43,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0b60dfa12fb992ff3c1555855471510558356a46"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/.vscode",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "89d6546175c5823466f3fbd429e9dd75cff8afe1",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/89d6546175c5823466f3fbd429e9dd75cff8afe1"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/.vscode/extensions.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3ac9aeb61e496888ca93a841e732dc9a752184a4",
+      "size": 169,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3ac9aeb61e496888ca93a841e732dc9a752184a4"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/.vscode/launch.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "670d6e66ced4912e36e6905aeb898a8501c27afd",
+      "size": 928,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/670d6e66ced4912e36e6905aeb898a8501c27afd"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/.vscode/settings.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "30bf8c2d3f11630391958c9635172e63ee1a2122",
+      "size": 444,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/30bf8c2d3f11630391958c9635172e63ee1a2122"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/.vscode/tasks.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3b17e53b62cc6ffaacd997adeb1915422fb6858f",
+      "size": 366,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3b17e53b62cc6ffaacd997adeb1915422fb6858f"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/.vscodeignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "389996760c6238122bee7c4edf1584c194f77a57",
+      "size": 133,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/389996760c6238122bee7c4edf1584c194f77a57"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/CHANGELOG.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "57be26dc92644685d6a8fe7ddae425f6e7d7c8e7",
+      "size": 265,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/57be26dc92644685d6a8fe7ddae425f6e7d7c8e7"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/CONTRIBUTING.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ea7316938a478db4dc9d8de135d814dc5c2feb23",
+      "size": 1066,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ea7316938a478db4dc9d8de135d814dc5c2feb23"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/LICENSE",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f9a86f111ec2e6568b5f6ac1e991176bbd93353c",
+      "size": 11010,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f9a86f111ec2e6568b5f6ac1e991176bbd93353c"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "34c786c73b1045eb70cd7406bccfc12117fa122c",
+      "size": 5149,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/34c786c73b1045eb70cd7406bccfc12117fa122c"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/flutter-theme-agent.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e17151b2335089970d2703c5d1db24f12ccae1db",
+      "size": 369636,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e17151b2335089970d2703c5d1db24f12ccae1db"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/package-lock.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fee5d283edb50b87958d55d42a1cee6269cb2dc9",
+      "size": 85523,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fee5d283edb50b87958d55d42a1cee6269cb2dc9"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/package.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "301f22d6648a44dae7c05ec9608e3fd1dfe0ed3d",
+      "size": 2334,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/301f22d6648a44dae7c05ec9608e3fd1dfe0ed3d"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/src",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "84327e133277bd6395c3c2cb8c7e76ec33491bc7",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/84327e133277bd6395c3c2cb8c7e76ec33491bc7"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/src/components",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "471638aa598aadfad92570f493f64774df9f9de1",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/471638aa598aadfad92570f493f64774df9f9de1"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/src/components/buttonstyle.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "848eec325eaa1e75c6face8c57f5c77bcb08c8ee",
+      "size": 7832,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/848eec325eaa1e75c6face8c57f5c77bcb08c8ee"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/src/components/colorscheme.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "970f21fee0d16afc52928796e215843fa2d9a00c",
+      "size": 8163,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/970f21fee0d16afc52928796e215843fa2d9a00c"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/src/components/component.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8ee625372487565cc08cbae897052022d6a040f6",
+      "size": 1074,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8ee625372487565cc08cbae897052022d6a040f6"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/src/components/texttheme.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "011a831561e5c2b3df563ede1f161d36f0cdde6b",
+      "size": 4202,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/011a831561e5c2b3df563ede1f161d36f0cdde6b"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/src/extension.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8ae73e5b38f02752dfd78511e3cb00dfb4a91d96",
+      "size": 1331,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8ae73e5b38f02752dfd78511e3cb00dfb4a91d96"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/src/theme.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fabb455767a7671aef2c4d0a765be5d2df0f991e",
+      "size": 6127,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fabb455767a7671aef2c4d0a765be5d2df0f991e"
+    },
+    {
+      "path": "examples/gemini/node/flutter_theme_agent/tsconfig.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "64006615a61046c1b91fa8e4d10562ea4c1f4797",
+      "size": 538,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/64006615a61046c1b91fa8e4d10562ea4c1f4797"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "05c3a794cb59ea1d615386d6af11e0d62132518c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/05c3a794cb59ea1d615386d6af11e0d62132518c"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/.eslintrc.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f9b22b793c2998a2d5b65850b80b8a459bab32f4",
+      "size": 516,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f9b22b793c2998a2d5b65850b80b8a459bab32f4"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/.gitignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8597d7973dd07ab7fc4495ec74460f099eb3bbd1",
+      "size": 258,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8597d7973dd07ab7fc4495ec74460f099eb3bbd1"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/.vscode",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "7f97705a80ae5ded154482e8377796f9144a3a81",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/7f97705a80ae5ded154482e8377796f9144a3a81"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/.vscode/extensions.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "978d6307f7091c6d76297d1a37fe5f0caaea46e3",
+      "size": 56,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/978d6307f7091c6d76297d1a37fe5f0caaea46e3"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/.vscode/launch.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "670d6e66ced4912e36e6905aeb898a8501c27afd",
+      "size": 928,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/670d6e66ced4912e36e6905aeb898a8501c27afd"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/.vscode/settings.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0429f05ca810b02c79650630a12f60e0e13dd1a1",
+      "size": 428,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0429f05ca810b02c79650630a12f60e0e13dd1a1"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/.vscode/tasks.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3b17e53b62cc6ffaacd997adeb1915422fb6858f",
+      "size": 366,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3b17e53b62cc6ffaacd997adeb1915422fb6858f"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/.vscodeignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "389996760c6238122bee7c4edf1584c194f77a57",
+      "size": 133,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/389996760c6238122bee7c4edf1584c194f77a57"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/CHANGELOG.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2e1028d05764b13cce1c6bd10d50b76e1256714c",
+      "size": 194,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2e1028d05764b13cce1c6bd10d50b76e1256714c"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/CONTRIBUTING.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ea7316938a478db4dc9d8de135d814dc5c2feb23",
+      "size": 1066,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ea7316938a478db4dc9d8de135d814dc5c2feb23"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/LICENSE",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "989e2c59e973a05cfbfe9de678b7f2af777b0713",
+      "size": 11323,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/989e2c59e973a05cfbfe9de678b7f2af777b0713"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7d470397286152c107678e9646b7584780e2c9fe",
+      "size": 4680,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7d470397286152c107678e9646b7584780e2c9fe"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/package-lock.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a65319f8ec80831c6d916cd24439bc468b968765",
+      "size": 85276,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a65319f8ec80831c6d916cd24439bc468b968765"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/package.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a2d8462f7a29bb29847c0186da08c5fabeedac07",
+      "size": 2058,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a2d8462f7a29bb29847c0186da08c5fabeedac07"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/pipet-snippet.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "db9500d108baf3cfdd85d01224bbd43048f3583d",
+      "size": 35790,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/db9500d108baf3cfdd85d01224bbd43048f3583d"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/src",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "d2ec90817170a37c02c5206f046c68f17272c1c2",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/d2ec90817170a37c02c5206f046c68f17272c1c2"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/src/comments.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5dc5174785c47e61e8f7864cc108fe70f1610255",
+      "size": 3848,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5dc5174785c47e61e8f7864cc108fe70f1610255"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/src/extension.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "67b9670783a942dcd5e415470735b109f37df7ee",
+      "size": 990,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/67b9670783a942dcd5e415470735b109f37df7ee"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/src/review.ts",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d2fcc7beaf989ab60cfa0ba1e45a05e4c8b89ea3",
+      "size": 3444,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d2fcc7beaf989ab60cfa0ba1e45a05e4c8b89ea3"
+    },
+    {
+      "path": "examples/gemini/node/pipet-code-agent/tsconfig.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "315af7ec731c1ef626c891437fe29cd7d1e365dc",
+      "size": 537,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/315af7ec731c1ef626c891437fe29cd7d1e365dc"
+    },
+    {
+      "path": "examples/gemini/python",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "a380c33cc82e3dec819c761c0aaa8b1c0599d7c6",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/a380c33cc82e3dec819c761c0aaa8b1c0599d7c6"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "1eb18323fb613b4b6ea6e33ba111adc139f34c66",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/1eb18323fb613b4b6ea6e33ba111adc139f34c66"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/CONTRIBUTING.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8956a61b820b4e6e69be58f329bc53f62557c3f2",
+      "size": 1067,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8956a61b820b4e6e69be58f329bc53f62557c3f2"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/LICENSE",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7a4a3ea2424c09fbe48d455aed1eaa94d9124835",
+      "size": 11357,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7a4a3ea2424c09fbe48d455aed1eaa94d9124835"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "57a7f56534bfe6064049584f8fde64ee2e9d6d49",
+      "size": 19261,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/57a7f56534bfe6064049584f8fde64ee2e9d6d49"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/apps_script",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "995f1c472ee40fbee59812bbfa35912e8a8e9f1b",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/995f1c472ee40fbee59812bbfa35912e8a8e9f1b"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/apps_script/README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d333f36a85a77ecba48673f71c09b3e56286fe12",
+      "size": 6293,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d333f36a85a77ecba48673f71c09b3e56286fe12"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/apps_script/drive_to_markdown.gs",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5bfca82e3463adb6e8f62a58fd9ed252d5922a98",
+      "size": 10195,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5bfca82e3463adb6e8f62a58fd9ed252d5922a98"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/apps_script/exportmd.gs",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "40a4461ffc57f1e721eb3c0d739d679d9ab085b7",
+      "size": 46384,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/40a4461ffc57f1e721eb3c0d739d679d9ab085b7"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/apps_script/gmail_to_markdown.gs",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d8f4b63515bf031126a0a321e6bb5fe29dee38eb",
+      "size": 6349,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d8f4b63515bf031126a0a321e6bb5fe29dee38eb"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/apps_script/helper_functions.gs",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3fbf96866102d35cc0a4337c7afd340b7653b726",
+      "size": 7561,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3fbf96866102d35cc0a4337c7afd340b7653b726"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/apps_script/main.gs",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bc8f962e7fb4b57a4e16c43559e008e54e2c503a",
+      "size": 1034,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bc8f962e7fb4b57a4e16c43559e008e54e2c503a"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/config.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "440d1612b951b658d306b9638aadc0a5325a6029",
+      "size": 2229,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/440d1612b951b658d306b9638aadc0a5325a6029"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "b9c2d521fb78ede7477b686f9796ea50a1afac38",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/b9c2d521fb78ede7477b686f9796ea50a1afac38"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs/chunking-process.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e4c054b921da97f96bb68761919986194014353a",
+      "size": 3393,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e4c054b921da97f96bb68761919986194014353a"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs/cli-reference.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "dad5f30aaa738b09bfa76d811357964a074c6049",
+      "size": 9935,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/dad5f30aaa738b09bfa76d811357964a074c6049"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs/concepts.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3a8652d661da0dc4778ac9783bac1539cf04fcc6",
+      "size": 15550,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3a8652d661da0dc4778ac9783bac1539cf04fcc6"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs/config-reference.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5e9f32493e80a9809cf84731238a3203adc53491",
+      "size": 4121,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5e9f32493e80a9809cf84731238a3203adc53491"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs/create-a-new-task.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fc37193a3f173f4eba5b8f5dd63fec7189fa41fc",
+      "size": 8078,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fc37193a3f173f4eba5b8f5dd63fec7189fa41fc"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs/images",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "fc57ea68a09dd044891f0699f08e60919c2d693f",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/fc57ea68a09dd044891f0699f08e60919c2d693f"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs/images/apps-script-screenshot-01.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e49478e79cb79fe38504992429575147a26c91c1",
+      "size": 234775,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e49478e79cb79fe38504992429575147a26c91c1"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs/images/docs-agent-architecture-01.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "21912a876b9c7914145adb71de5a375d3a274ee9",
+      "size": 137642,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/21912a876b9c7914145adb71de5a375d3a274ee9"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs/images/docs-agent-architecture-02.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9eff8da5f088763ecd365fe2800657ee2a7b2386",
+      "size": 134403,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9eff8da5f088763ecd365fe2800657ee2a7b2386"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs/images/docs-agent-benchmarks-01.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2907ac307b71b998ff8ea5c27d0b3c1e8bd7d848",
+      "size": 44839,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2907ac307b71b998ff8ea5c27d0b3c1e8bd7d848"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs/images/docs-agent-chat-app-screenshot-01.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6efb51c9a2ef98ed28a59a5f14e9c8088df5c1f7",
+      "size": 265045,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6efb51c9a2ef98ed28a59a5f14e9c8088df5c1f7"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs/images/docs-agent-embeddings-01.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "32ac4dc5acbfd40394fa2f87f4a016f41365d472",
+      "size": 100945,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/32ac4dc5acbfd40394fa2f87f4a016f41365d472"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs/images/docs-agent-embeddings-02.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7ff222efdd592a8eec6a8f6dd5880f32ec839dc8",
+      "size": 488676,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7ff222efdd592a8eec6a8f6dd5880f32ec839dc8"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs/images/docs-agent-pre-processing-01.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "98b34c02ddc6603d5337d150393372ec533517fc",
+      "size": 355257,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/98b34c02ddc6603d5337d150393372ec533517fc"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs/images/docs-agent-prompt-structure-01.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "64119ac07cfa5313e029dd5ab81bbfe26493629c",
+      "size": 266254,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/64119ac07cfa5313e029dd5ab81bbfe26493629c"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs/images/docs-agent-ui-screenshot-01.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d680cae39b147a6ead359b07a3fdca11ad5fe3d2",
+      "size": 408671,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d680cae39b147a6ead359b07a3fdca11ad5fe3d2"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs/whats-new.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a0653017e6fab0beb933d7d1da3447f40f1e6966",
+      "size": 4096,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a0653017e6fab0beb933d7d1da3447f40f1e6966"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "982da1268b087264400250e0ff905e9105ae6044",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/982da1268b087264400250e0ff905e9105ae6044"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/agents",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "bebbdbde7a3945103abf4c618f47447de4304131",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/bebbdbde7a3945103abf4c618f47447de4304131"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/agents/__init__.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/agents/docs_agent.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e838edb12bf05bfb9887fdb3b7268a51096f7604",
+      "size": 18443,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e838edb12bf05bfb9887fdb3b7268a51096f7604"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/benchmarks",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "76f2ed4eb589b4402b7f0368db584efc46911e5c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/76f2ed4eb589b4402b7f0368db584efc46911e5c"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/benchmarks/README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "07cb577f02feebebbff18085ac908a93681de350",
+      "size": 6665,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/07cb577f02feebebbff18085ac908a93681de350"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/benchmarks/__init__.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/benchmarks/benchmarks.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a5a6e4c7e1681cefb7e89c266597cc2c0697f010",
+      "size": 4449,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a5a6e4c7e1681cefb7e89c266597cc2c0697f010"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/benchmarks/results.out",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7418b92cc7f7de9b1f9031c9d604c88618ec52da",
+      "size": 681,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7418b92cc7f7de9b1f9031c9d604c88618ec52da"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/benchmarks/run_benchmark_tests.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7baf5657c27827188afea8d1429383ab7b4847af",
+      "size": 7760,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7baf5657c27827188afea8d1429383ab7b4847af"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "0fd2b26353dec86beb1b0015810230cede6ac553",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/0fd2b26353dec86beb1b0015810230cede6ac553"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "015ffd571406e55849947b2fd657aeffebeb3f87",
+      "size": 11159,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/015ffd571406e55849947b2fd657aeffebeb3f87"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/__init__.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "f6879f2070e9efe89ae2bd964c7a4aed1eec67f4",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/f6879f2070e9efe89ae2bd964c7a4aed1eec67f4"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/__init__.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "58c4c46d984d8ec99a1d1b7ede73025eebc6083a",
+      "size": 903,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/58c4c46d984d8ec99a1d1b7ede73025eebc6083a"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/chatui.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e59b4dd2c77d2a0381b1cd5ae440eb3fd4cd56ff",
+      "size": 23702,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e59b4dd2c77d2a0381b1cd5ae440eb3fd4cd56ff"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/static",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "d0f0a839da6e90acb0f732feb5baa9dae8c84be2",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/d0f0a839da6e90acb0f732feb5baa9dae8c84be2"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/static/css",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "aa0130162f626de193fbe78a958b48c1af6788dc",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/aa0130162f626de193fbe78a958b48c1af6788dc"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/static/css/chatbox.css",
+      "mode": "120000",
+      "type": "blob",
+      "sha": "44ad5badf23294e4a2e3b7c90f6ff70597a07048",
+      "size": 42,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/44ad5badf23294e4a2e3b7c90f6ff70597a07048"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/static/css/style-chatui-full.css",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4cdb442e36983145139af823066845cfff99d842",
+      "size": 11533,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4cdb442e36983145139af823066845cfff99d842"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/static/css/style-chatui-widget-pro.css",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b343fb6e17798d1174dc42c801bb8a8b34390bc4",
+      "size": 11728,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b343fb6e17798d1174dc42c801bb8a8b34390bc4"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/static/css/style-chatui-widget.css",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9658ef6a720517a20199b97fec55682924dc2950",
+      "size": 11339,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9658ef6a720517a20199b97fec55682924dc2950"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/static/css/style-chatui.css",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7267c9b22ed227ea04347a503bc30dd2c0bae57d",
+      "size": 10939,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7267c9b22ed227ea04347a503bc30dd2c0bae57d"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/static/css/style-logs.css",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e0e884c0aad140c9d2c3757d1ef596266ca1d601",
+      "size": 701,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e0e884c0aad140c9d2c3757d1ef596266ca1d601"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/static/images",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "7fd5943274b30cdd944423fad352086ce4ecda1c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/7fd5943274b30cdd944423fad352086ce4ecda1c"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/static/images/favicon.png",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "dd83d19ceb4ed5362644b083dda458b2455a8ad6",
+      "size": 608,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/dd83d19ceb4ed5362644b083dda458b2455a8ad6"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/static/javascript",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "69d8004bd344505b3d224a3e09b871cc1a4714c6",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/69d8004bd344505b3d224a3e09b871cc1a4714c6"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/static/javascript/app.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "cd3e9aba9674b11254020b81ef4b899eff3a9942",
+      "size": 12654,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/cd3e9aba9674b11254020b81ef4b899eff3a9942"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "9f2ecec13e716f65fd8427252afc22dc24612210",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/9f2ecec13e716f65fd8427252afc22dc24612210"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/admin",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "b5698b82adefd993a0f38aebb1f85a72421b5536",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/b5698b82adefd993a0f38aebb1f85a72421b5536"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/admin/debugs.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "76ab6130e1504f1ae75592b8f9058ba7e8e1eede",
+      "size": 809,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/76ab6130e1504f1ae75592b8f9058ba7e8e1eede"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/admin/logs.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "77f84f1365c485909a40e08a8b44d7ed7d631162",
+      "size": 868,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/77f84f1365c485909a40e08a8b44d7ed7d631162"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui-experimental",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "d8f485e2ec6bd33502a4e0c3a09615baf98825b9",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/d8f485e2ec6bd33502a4e0c3a09615baf98825b9"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui-experimental/base.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9449841828a373941deb474f0fbd236330f67d86",
+      "size": 838,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9449841828a373941deb474f0fbd236330f67d86"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui-experimental/index.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "97376ac8aeb36d1a81f01e89a521f9f7051de719",
+      "size": 541,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/97376ac8aeb36d1a81f01e89a521f9f7051de719"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui-experimental/result.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "778bfc9358ef701cba48519ddeee8b07908ba084",
+      "size": 4611,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/778bfc9358ef701cba48519ddeee8b07908ba084"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui-full",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "64c2a2d356522d35f378edae3a1ea52717f6b92c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/64c2a2d356522d35f378edae3a1ea52717f6b92c"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui-full/base.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "643e779c7a17b4f147c2fc7969177b5a8083b4f0",
+      "size": 897,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/643e779c7a17b4f147c2fc7969177b5a8083b4f0"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui-full/index.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5b57140e49484f9e3b7739f161e4b981ad22d960",
+      "size": 506,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5b57140e49484f9e3b7739f161e4b981ad22d960"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui-full/result.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5888b2d9d5ce9764af3a0063f1495d389dedbadf",
+      "size": 7192,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5888b2d9d5ce9764af3a0063f1495d389dedbadf"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui-widget-pro",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "396ddf582665af4d3f8cd0a796b3343ffa5e34bf",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/396ddf582665af4d3f8cd0a796b3343ffa5e34bf"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui-widget-pro/base.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ec22387df1c5ac11ced2f308538883163e5dcb5d",
+      "size": 905,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ec22387df1c5ac11ced2f308538883163e5dcb5d"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui-widget-pro/index.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6c084fb06586a2e9cd761517cb6b0645715a0ca2",
+      "size": 518,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6c084fb06586a2e9cd761517cb6b0645715a0ca2"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui-widget-pro/result.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a2c3550e679b09619bf2d8e2c116515dadcc9ae0",
+      "size": 7256,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a2c3550e679b09619bf2d8e2c116515dadcc9ae0"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui-widget",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "72db20983521fb5adb06b487a0bfedf278c38c40",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/72db20983521fb5adb06b487a0bfedf278c38c40"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui-widget/base.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "720260ca59fdaeba51e17a21796fd9e5f352fea7",
+      "size": 883,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/720260ca59fdaeba51e17a21796fd9e5f352fea7"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui-widget/index.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5a6119bd74d22e36b82880b5c008c4ae9f64327e",
+      "size": 512,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5a6119bd74d22e36b82880b5c008c4ae9f64327e"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui-widget/result.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3f6cc60b93933b33cc344d34a8ab428e779b164e",
+      "size": 7326,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3f6cc60b93933b33cc344d34a8ab428e779b164e"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "794a310d28258aa9266b04a28626538945925601",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/794a310d28258aa9266b04a28626538945925601"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui/base.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "87cece3e4470ddfa3ada11c12673eab10abed7bb",
+      "size": 888,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/87cece3e4470ddfa3ada11c12673eab10abed7bb"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui/index.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "042f18d02145c1c4b8ca3b21adfcb251593283bb",
+      "size": 496,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/042f18d02145c1c4b8ca3b21adfcb251593283bb"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/chatbot/templates/chatui/result.html",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3dd10d06d10f657aa4ffcb56be2b45dd9bff7cd8",
+      "size": 6421,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3dd10d06d10f657aa4ffcb56be2b45dd9bff7cd8"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/cli",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "d07e6e54246c6db0ee0a6627187ecd5f02a00793",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/d07e6e54246c6db0ee0a6627187ecd5f02a00793"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/cli/__init__.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/cli/cli.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "97de6d07e94328e54ffbe58d208c97123a9ecffd",
+      "size": 1428,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/97de6d07e94328e54ffbe58d208c97123a9ecffd"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/cli/cli_admin.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6c8800425317f6da0e18a2740d2fb1b38d0b1e83",
+      "size": 14659,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6c8800425317f6da0e18a2740d2fb1b38d0b1e83"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/cli/cli_common.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "596dbf41d96a0f0cd7fc3ee7aa2e33edcce2ec74",
+      "size": 2126,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/596dbf41d96a0f0cd7fc3ee7aa2e33edcce2ec74"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/cli/cli_helpme.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "30bbdb963d0474ea15295dc998e25cd6487b67a6",
+      "size": 36184,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/30bbdb963d0474ea15295dc998e25cd6487b67a6"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/cli/cli_posix.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1b10e80976aa68cd76adee8ad8b767188f590efa",
+      "size": 3232,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1b10e80976aa68cd76adee8ad8b767188f590efa"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/cli/cli_runtask.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6a52494980060b2e89bc0f2329d8956d9bb2f46e",
+      "size": 38046,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6a52494980060b2e89bc0f2329d8956d9bb2f46e"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/cli/cli_script.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7f678de7fc691776697c131c410410ffda08d29a",
+      "size": 5552,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7f678de7fc691776697c131c410410ffda08d29a"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/cli/cli_show_session.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9a49c0e69c2a5566d098e946d268972adc4cbd5a",
+      "size": 1946,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9a49c0e69c2a5566d098e946d268972adc4cbd5a"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/cli/cli_tellme.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "155c008419d79f546aded6c8f2e42e0eb4a7e7c9",
+      "size": 3773,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/155c008419d79f546aded6c8f2e42e0eb4a7e7c9"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/cli/cli_tools.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d750a6a52a007c22034cbc3cebc373be9b676508",
+      "size": 13726,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d750a6a52a007c22034cbc3cebc373be9b676508"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/hello_world.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "385f9b1dcf07c964ae7fd0d9cad128cd0800cdb6",
+      "size": 2680,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/385f9b1dcf07c964ae7fd0d9cad128cd0800cdb6"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/interfaces/run_console.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2f33fbb4a6a3250b5916daa0c38c7b04064e423a",
+      "size": 17861,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2f33fbb4a6a3250b5916daa0c38c7b04064e423a"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/memory",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "37a1653c59001b86f0379c1257c2d61d55cb1fb9",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/37a1653c59001b86f0379c1257c2d61d55cb1fb9"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/memory/__init__.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/memory/logging.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "889d529b5c2317c86a1212e38dbe7e1e07f5dcf1",
+      "size": 12529,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/889d529b5c2317c86a1212e38dbe7e1e07f5dcf1"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/models",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "318322cffdd5cc4e985fc15e425898a25206d227",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/318322cffdd5cc4e985fc15e425898a25206d227"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/models/__init__.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/models/aqa.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e87b7aef998253679c8f44e2d60f42b788cc3f4a",
+      "size": 878,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e87b7aef998253679c8f44e2d60f42b788cc3f4a"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/models/aqa_models.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "372b2a0dbf3579d9622ecfdb1b98bada25d61fe9",
+      "size": 8168,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/372b2a0dbf3579d9622ecfdb1b98bada25d61fe9"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/models/base.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b93debfc91730fb19a5eeb8a2fbd4364904e2e00",
+      "size": 3937,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b93debfc91730fb19a5eeb8a2fbd4364904e2e00"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/models/google_genai.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0f7693a9afcca0819103994c857f70540676d613",
+      "size": 19215,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0f7693a9afcca0819103994c857f70540676d613"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/models/llm.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "391a1fc6a1aff71b466deb07f44b972578961675",
+      "size": 2041,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/391a1fc6a1aff71b466deb07f44b972578961675"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/models/tokenCount.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8561e5966455aee3076366db778f62dd89bf67ba",
+      "size": 5135,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8561e5966455aee3076366db778f62dd89bf67ba"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/models/tools",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "cba23f1b259d711742c4cb2716b45f9223ff7a1a",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/cba23f1b259d711742c4cb2716b45f9223ff7a1a"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/models/tools/__init__.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/models/tools/base.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "84d21ecc6ca2183bb4470fb22dad79dfb434f0ba",
+      "size": 1353,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/84d21ecc6ca2183bb4470fb22dad79dfb434f0ba"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/models/tools/mcp_client.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8a4a52f053db8d9771a2d790176e2cb7193dddf8",
+      "size": 11057,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8a4a52f053db8d9771a2d790176e2cb7193dddf8"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/models/tools/tool_manager.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "aa50d203a8496d6d794b020ce3fc35be71239178",
+      "size": 33707,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/aa50d203a8496d6d794b020ce3fc35be71239178"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/models/tools/tools.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6a5f9ad775e23cceb9aed1237998808d11372cb3",
+      "size": 2728,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6a5f9ad775e23cceb9aed1237998808d11372cb3"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/postprocess",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "9c6169885aefc1ac6c8a44117bb84f8c61f8e1c4",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/9c6169885aefc1ac6c8a44117bb84f8c61f8e1c4"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/postprocess/__init__.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/postprocess/docs_retriever.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d71e8374e10af42f7c5719da7b49c77c890757b6",
+      "size": 15893,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d71e8374e10af42f7c5719da7b49c77c890757b6"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/preprocess",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "24895368f3a631c4ca0d3d76d391c08bc61b675d",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/24895368f3a631c4ca0d3d76d391c08bc61b675d"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/preprocess/README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0cb807fd8358f5d6e2bec7595333bce8e928483d",
+      "size": 6110,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0cb807fd8358f5d6e2bec7595333bce8e928483d"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/preprocess/__init__.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/preprocess/extract_image_path.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2d813c1e86c6e2050e974388925655ac3d6370a7",
+      "size": 6202,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2d813c1e86c6e2050e974388925655ac3d6370a7"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/preprocess/files_to_plain_text.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f8926aee81af7c5d247d3ba8135b102f270da861",
+      "size": 31570,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f8926aee81af7c5d247d3ba8135b102f270da861"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/preprocess/populate_vector_database.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "34ba8ab6623832f860d264816b256cd7e1fa1598",
+      "size": 28389,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/34ba8ab6623832f860d264816b256cd7e1fa1598"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/preprocess/splitters",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "fa2831cd41cda8f01a3759770b4e993a5c4e8448",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/fa2831cd41cda8f01a3759770b4e993a5c4e8448"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/preprocess/splitters/__init__.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/preprocess/splitters/fidl_splitter.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "321168cb0eb68189bba136777c957e203cbd1570",
+      "size": 4581,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/321168cb0eb68189bba136777c957e203cbd1570"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/preprocess/splitters/html_splitter.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "952564cac82ea3759e5bf47ab4430517fd74f6a6",
+      "size": 1677,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/952564cac82ea3759e5bf47ab4430517fd74f6a6"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/preprocess/splitters/markdown_splitter.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ab5c43959b70a29557c8b13faa76fe7c4073f7d7",
+      "size": 24809,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ab5c43959b70a29557c8b13faa76fe7c4073f7d7"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/storage",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "5b1a8f36047bed49eea7ae91142daffbe5c3c24c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/5b1a8f36047bed49eea7ae91142daffbe5c3c24c"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/storage/__init__.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/storage/base.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c3e55d12eec53edb76a5cd395662899c1aa87a3d",
+      "size": 2313,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c3e55d12eec53edb76a5cd395662899c1aa87a3d"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/storage/chroma.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ced7a56a2993d9865fc212e178e41903603db60f",
+      "size": 26008,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ced7a56a2993d9865fc212e178e41903603db60f"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/storage/google_semantic_retriever.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2d09d00a707ab189ff9eb0cda9f6a082e0a3cb96",
+      "size": 16201,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2d09d00a707ab189ff9eb0cda9f6a082e0a3cb96"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/storage/rag.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b0326e553e8ddebd3e8f61a179e97d007c82ca6e",
+      "size": 1968,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b0326e553e8ddebd3e8f61a179e97d007c82ca6e"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/tests",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "2e922669b8a66949e0f840c1d4e00b1d5f53a254",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/2e922669b8a66949e0f840c1d4e00b1d5f53a254"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/tests/__init__.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/tests/cli_unit_tests.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9cfb28c488a2510ba7e5d98abf58b9c6cc3eb84a",
+      "size": 220,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9cfb28c488a2510ba7e5d98abf58b9c6cc3eb84a"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/tests/utilities",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "b77ef5e4bebc37b0a493e897b2a557e35fe6347c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/b77ef5e4bebc37b0a493e897b2a557e35fe6347c"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/tests/utilities/__init__.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/tests/utilities/test_helpers.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1d5efad72bbe0dbaee0cee37a21e38aa6621026b",
+      "size": 23410,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1d5efad72bbe0dbaee0cee37a21e38aa6621026b"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/utilities",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "d11e1f2c48a878e27926b8ddd6b6736cf48b4473",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/d11e1f2c48a878e27926b8ddd6b6736cf48b4473"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/utilities/__init__.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/utilities/config.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "277b3fe890bd6aef24f58b5feedd9acbb05ea99d",
+      "size": 32082,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/277b3fe890bd6aef24f58b5feedd9acbb05ea99d"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/utilities/helpers.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4bbb08d3dc3a7eba59732938d3279c59092c7caa",
+      "size": 16869,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4bbb08d3dc3a7eba59732938d3279c59092c7caa"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/docs_agent/utilities/tasks.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "beb826e023ef15bb1158bf6ff848a13e2667876d",
+      "size": 15112,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/beb826e023ef15bb1158bf6ff848a13e2667876d"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/poetry.lock",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "30b7b9c8039c6c3cea471b641781069cf0779f56",
+      "size": 415424,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/30b7b9c8039c6c3cea471b641781069cf0779f56"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/pylintrc",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fcb2930cd7bd9f6e7727160255e0640f1323ea4a",
+      "size": 13993,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fcb2930cd7bd9f6e7727160255e0640f1323ea4a"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/pyproject.toml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b417bc30d644b67c96d8d640d3468968e35a7e5d",
+      "size": 1228,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b417bc30d644b67c96d8d640d3468968e35a7e5d"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/scripts",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "c19ad14b65a3853f771522b114c1223ae9b1ddc5",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/c19ad14b65a3853f771522b114c1223ae9b1ddc5"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/scripts/autocomplete.sh",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "82405d541e08c9358bcf5baca1f1b6d124dd5c6d",
+      "size": 1824,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/82405d541e08c9358bcf5baca1f1b6d124dd5c6d"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/scripts/create_file_dictionary.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1476d7b6cce9e0efd3c3c065490ab0839f10995b",
+      "size": 4049,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1476d7b6cce9e0efd3c3c065490ab0839f10995b"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/scripts/extract_image_files.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9a8fe50ef8c63eba88d1f74e88e9528715028c62",
+      "size": 4595,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9a8fe50ef8c63eba88d1f74e88e9528715028c62"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/scripts/extract_replace_image_alt_text.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7b54b8c3cb9e6309fce3c4b021b740a786dc67a2",
+      "size": 12613,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7b54b8c3cb9e6309fce3c4b021b740a786dc67a2"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/scripts/helpme.sh",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "183306c7f977bb3897adeddf26bab5864994120f",
+      "size": 1348,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/183306c7f977bb3897adeddf26bab5864994120f"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/scripts/tellme.sh",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "a51d4855474c604ac000a94ba0c997006feaf7ae",
+      "size": 864,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a51d4855474c604ac000a94ba0c997006feaf7ae"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/scripts/update_files_from_yaml.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "32364fad68005b99636e312ac970bb98f938ee8e",
+      "size": 6825,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/32364fad68005b99636e312ac970bb98f938ee8e"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/tasks",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "26e9919dcd9300a92a1442dcb006857449e1d7b1",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/26e9919dcd9300a92a1442dcb006857449e1d7b1"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/tasks/describe-images-alt-text-no-markdown.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "166f2d1e58991b1d214fe96fb2d743f84306f039",
+      "size": 1154,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/166f2d1e58991b1d214fe96fb2d743f84306f039"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/tasks/describe-images-and-replace.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c14c05a36c8fab1a5b8039db27d9cccec0e63e73",
+      "size": 2596,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c14c05a36c8fab1a5b8039db27d9cccec0e63e73"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/tasks/describe-images-for-alt-text-task.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e1e055af12db5d13fb4fc4479dae5a94a1e7fd36",
+      "size": 1517,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e1e055af12db5d13fb4fc4479dae5a94a1e7fd36"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/tasks/describe-images-from-doc-replace.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "15fc66e65cb61a76968b7e0d5003cac5eddf965c",
+      "size": 998,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/15fc66e65cb61a76968b7e0d5003cac5eddf965c"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/tasks/describe-images-from-doc.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "fb4ba8042719122026a934f19ebc6d2f74b02315",
+      "size": 1866,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/fb4ba8042719122026a934f19ebc6d2f74b02315"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/tasks/extract-workflows-task.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "778c13f7b010283c2ce02ef57433e4896fb7055a",
+      "size": 1030,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/778c13f7b010283c2ce02ef57433e4896fb7055a"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/tasks/help-polish-prompts-task.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e2327baa51bd1e941d8444f048499c1078dee5da",
+      "size": 723,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e2327baa51bd1e941d8444f048499c1078dee5da"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/tasks/index-page-generator-task.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "26a1590952395f65519bd0222a1e5ea5a20ab0ba",
+      "size": 1549,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/26a1590952395f65519bd0222a1e5ea5a20ab0ba"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/tasks/prepare-podcast-from-dir.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d18bf117846edaab74afc1f51c5037860d70cb03",
+      "size": 1030,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d18bf117846edaab74afc1f51c5037860d70cb03"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/tasks/release-notes-task.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "24c9fa1a7e2055a88c7d80819083132b34662c4c",
+      "size": 1105,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/24c9fa1a7e2055a88c7d80819083132b34662c4c"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/tasks/revise-content-structure-task.yaml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bee171e5ebe35b219fe2ebdd221ba08ff56da9a1",
+      "size": 1430,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bee171e5ebe35b219fe2ebdd221ba08ff56da9a1"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/third_party",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "90c447f682d196f719b56b6765c94335344a6b12",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/90c447f682d196f719b56b6765c94335344a6b12"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/third_party/css",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "d14a47d0b4c1a98a84fbe0b7e59d4547d583a6f2",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/d14a47d0b4c1a98a84fbe0b7e59d4547d583a6f2"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/third_party/css/chatbox.css",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e7d562c9871cd7a8622eedd5484178c38a5d2a63",
+      "size": 1559,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e7d562c9871cd7a8622eedd5484178c38a5d2a63"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/third_party/g2docsmd-html",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "29c173bc26a9bf7106469a616e334c5fd90c5a6b",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/29c173bc26a9bf7106469a616e334c5fd90c5a6b"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/third_party/g2docsmd-html/LICENSE",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7a4a3ea2424c09fbe48d455aed1eaa94d9124835",
+      "size": 11357,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7a4a3ea2424c09fbe48d455aed1eaa94d9124835"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/third_party/g2docsmd-html/exportmd.gs",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "aa8afd00f2d2871795fd6161be105305b825efad",
+      "size": 44054,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/aa8afd00f2d2871795fd6161be105305b825efad"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/third_party/g2docsmd-html/patches",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "dcafe575bddddc4a5af7c911174762445ab8317b",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/dcafe575bddddc4a5af7c911174762445ab8317b"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/third_party/g2docsmd-html/patches/001-initial-changes-for-docs-agent.patch",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "af6d3aa935bbcfcbcf2038204fecced50567ba3a",
+      "size": 5486,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/af6d3aa935bbcfcbcf2038204fecced50567ba3a"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/vector_stores",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "d564d0bc3dd917926892c55e3706cc116d5b165e",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/d564d0bc3dd917926892c55e3706cc116d5b165e"
+    },
+    {
+      "path": "examples/gemini/python/docs-agent/vector_stores/.gitkeep",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "size": 0,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    },
+    {
+      "path": "examples/gemini/python/langchain",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "2ffebb4986942e8b3b8c4c5c2212817592cb5ab8",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/2ffebb4986942e8b3b8c4c5c2212817592cb5ab8"
+    },
+    {
+      "path": "examples/gemini/python/langchain/Gemini_LangChain_QA_Chroma_WebLoad.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6d2342a404135b913563ba5b9b720b308e0eaebb",
+      "size": 34283,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6d2342a404135b913563ba5b9b720b308e0eaebb"
+    },
+    {
+      "path": "examples/gemini/python/langchain/Gemini_LangChain_QA_Pinecone_WebLoad.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6090249d633e70b0cf4502f6edc779bb1253d9ea",
+      "size": 33022,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6090249d633e70b0cf4502f6edc779bb1253d9ea"
+    },
+    {
+      "path": "examples/gemini/python/langchain/Gemini_LangChain_Summarization_WebLoad.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "3e789669ebff0f8ae4c3f4ea64772233ffc7eaf3",
+      "size": 16876,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/3e789669ebff0f8ae4c3f4ea64772233ffc7eaf3"
+    },
+    {
+      "path": "examples/gemini/python/llamaindex",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "37ab0de0373e2cf75b25b5f57ce0eff758e6fd77",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/37ab0de0373e2cf75b25b5f57ce0eff758e6fd77"
+    },
+    {
+      "path": "examples/gemini/python/llamaindex/Gemini_LlamaIndex_QA_Chroma_WebPageReader.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7e1dd0250e35688c3b07558ce5c7e4df19102b9d",
+      "size": 25089,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7e1dd0250e35688c3b07558ce5c7e4df19102b9d"
+    },
+    {
+      "path": "examples/gemini/python/vectordb_with_chroma",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "6d1009d87d31f77cb12045f4ea412465cc211bec",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/6d1009d87d31f77cb12045f4ea412465cc211bec"
+    },
+    {
+      "path": "examples/gemini/python/vectordb_with_chroma/vectordb_with_chroma.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "77f84cc5d33c33d8e05e06048acb7e5ed94c08d2",
+      "size": 33731,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/77f84cc5d33c33d8e05e06048acb7e5ed94c08d2"
+    },
+    {
+      "path": "examples/gemini/python/vectordb_with_qdrant",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "78402717e2f6764162d7b99d1e480386b73d6128",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/78402717e2f6764162d7b99d1e480386b73d6128"
+    },
+    {
+      "path": "examples/gemini/python/vectordb_with_qdrant/Qdrant_similarity_search.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5d9ca0ee2f1a950cca303460751d9a6f8b1f50d8",
+      "size": 23938,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5d9ca0ee2f1a950cca303460751d9a6f8b1f50d8"
+    },
+    {
+      "path": "examples/palm",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "a7296c322b3fbe7e9fda0cd9de6ad8de22a85d97",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/a7296c322b3fbe7e9fda0cd9de6ad8de22a85d97"
+    },
+    {
+      "path": "examples/palm/README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "db900c00c3fcda7429aa590bb113de9001eaaf4d",
+      "size": 293,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/db900c00c3fcda7429aa590bb113de9001eaaf4d"
+    },
+    {
+      "path": "examples/palm/java",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "2bcd229a36a798cd3f9844bbc8c1f18a0af05834",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/2bcd229a36a798cd3f9844bbc8c1f18a0af05834"
+    },
+    {
+      "path": "examples/palm/java/DELETEME",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2517fab01e09391fa1d0ba5f33a81eb04b909355",
+      "size": 66,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2517fab01e09391fa1d0ba5f33a81eb04b909355"
+    },
+    {
+      "path": "examples/palm/python",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "91f00a094f79897c5f605a45725ab5b05c4ae685",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/91f00a094f79897c5f605a45725ab5b05c4ae685"
+    },
+    {
+      "path": "examples/palm/python/DELETEME",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2517fab01e09391fa1d0ba5f33a81eb04b909355",
+      "size": 66,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2517fab01e09391fa1d0ba5f33a81eb04b909355"
+    },
+    {
+      "path": "examples/palm/python/google_cloud_functions",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "e0491655fe9916fb59a92b5550b515a83af72040",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/e0491655fe9916fb59a92b5550b515a83af72040"
+    },
+    {
+      "path": "examples/palm/python/google_cloud_functions/main.py",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ae6baae0a182a4be9916529f8337b7df9854f5d3",
+      "size": 1693,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ae6baae0a182a4be9916529f8337b7df9854f5d3"
+    },
+    {
+      "path": "site",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "35b5c04521a323cfd691f2e244c6230471d97287",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/35b5c04521a323cfd691f2e244c6230471d97287"
+    },
+    {
+      "path": "site/en",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "bafb3c1421084c071246838645fc0da183933c71",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/bafb3c1421084c071246838645fc0da183933c71"
+    },
+    {
+      "path": "site/en/README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "19ce53694dcc2560d054615b216d314aa4ab0bc2",
+      "size": 611,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/19ce53694dcc2560d054615b216d314aa4ab0bc2"
+    },
+    {
+      "path": "site/en/docs",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "d46dc9a5d17e93bda156989939953335a1054c93",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/d46dc9a5d17e93bda156989939953335a1054c93"
+    },
+    {
+      "path": "site/en/docs/pdf_parsing_for_semantic_retrieval_systems.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2bac4c6285ba76210bd964384462c7d9703d1c16",
+      "size": 868917,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2bac4c6285ba76210bd964384462c7d9703d1c16"
+    },
+    {
+      "path": "site/en/docs/react_gemini_prompting.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a7a28be370d85b897f77255d37707eaebf3d82e1",
+      "size": 40714,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a7a28be370d85b897f77255d37707eaebf3d82e1"
+    },
+    {
+      "path": "site/en/docs/search_reranking_using_embeddings.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c86c02ccc86b4a04a2494738135c0c5325691dac",
+      "size": 71257,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c86c02ccc86b4a04a2494738135c0c5325691dac"
+    },
+    {
+      "path": "site/en/examples",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "bb414e1e6cfd7f8dcfbeacb99456f532f3565cf1",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/bb414e1e6cfd7f8dcfbeacb99456f532f3565cf1"
+    },
+    {
+      "path": "site/en/examples/chat_calculator.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7e154edd7c401b0c3211145fa5a6f9082e2e4ae8",
+      "size": 28413,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7e154edd7c401b0c3211145fa5a6f9082e2e4ae8"
+    },
+    {
+      "path": "site/en/examples/text_calculator.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "330efa5c0afee598f76b6f7460c0a76a515ed95b",
+      "size": 28638,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/330efa5c0afee598f76b6f7460c0a76a515ed95b"
+    },
+    {
+      "path": "site/en/gemini-api",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "fd6260f7b5da5aef255ef1ba54a82fce3818e2f4",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/fd6260f7b5da5aef255ef1ba54a82fce3818e2f4"
+    },
+    {
+      "path": "site/en/gemini-api/docs",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "955bb856624b1981a9518e1193bbf0d4f78eae83",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/955bb856624b1981a9518e1193bbf0d4f78eae83"
+    },
+    {
+      "path": "site/en/gemini-api/docs/function-calling",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "c01a2e30dca471c8ea7fcda922828b1701c96c0d",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/c01a2e30dca471c8ea7fcda922828b1701c96c0d"
+    },
+    {
+      "path": "site/en/gemini-api/docs/function-calling/python.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f07e3fec3365d045d4d1df01d1ce40a06e25de0b",
+      "size": 31132,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f07e3fec3365d045d4d1df01d1ce40a06e25de0b"
+    },
+    {
+      "path": "site/en/gemini-api/docs/get-started",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "828c8e15015904232eb6fa57129006a737f35b2c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/828c8e15015904232eb6fa57129006a737f35b2c"
+    },
+    {
+      "path": "site/en/gemini-api/docs/get-started/python.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "a9634df683a958b57262cb2c5716c3f8bbf31949",
+      "size": 4262519,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/a9634df683a958b57262cb2c5716c3f8bbf31949"
+    },
+    {
+      "path": "site/en/gemini-api/docs/get-started/rest.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6b00cc14f318268a614a3b66fac3ffbf2639efdc",
+      "size": 517985,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6b00cc14f318268a614a3b66fac3ffbf2639efdc"
+    },
+    {
+      "path": "site/en/gemini-api/docs/model-tuning",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "60762c0ba74acf54dbcba288157aa7421855324f",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/60762c0ba74acf54dbcba288157aa7421855324f"
+    },
+    {
+      "path": "site/en/gemini-api/docs/model-tuning/python.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0aae0196c01576ee8f52c643cc3054c868cfde12",
+      "size": 45744,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0aae0196c01576ee8f52c643cc3054c868cfde12"
+    },
+    {
+      "path": "site/en/gemini-api/docs/model-tuning/rest.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4ae64d7c96dc0b06a1bf99ff10408481729f27d6",
+      "size": 36235,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4ae64d7c96dc0b06a1bf99ff10408481729f27d6"
+    },
+    {
+      "path": "site/en/gemini-api/docs/prompting_with_media.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "5096dbc4296ff7eb020dbeeada5cb393bb02cdae",
+      "size": 21823,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5096dbc4296ff7eb020dbeeada5cb393bb02cdae"
+    },
+    {
+      "path": "site/en/gemini-api/docs/semantic_retrieval.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "637ac31aeeb9b937108b27a81b0c7d2d0dee5f88",
+      "size": 47898,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/637ac31aeeb9b937108b27a81b0c7d2d0dee5f88"
+    },
+    {
+      "path": "site/en/gemini-api/docs/vision.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "aa64486e862bb01efeabf346f850d9528d4a69f3",
+      "size": 30635,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/aa64486e862bb01efeabf346f850d9528d4a69f3"
+    },
+    {
+      "path": "site/en/gemini-api/tutorials",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "13aa32f7ff4502dd5f5c5ac9cc0ff161108457eb",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/13aa32f7ff4502dd5f5c5ac9cc0ff161108457eb"
+    },
+    {
+      "path": "site/en/gemini-api/tutorials/anomaly_detection.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2722b2ac139c14067a1dd673d383ffdbbf590a3f",
+      "size": 757560,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/2722b2ac139c14067a1dd673d383ffdbbf590a3f"
+    },
+    {
+      "path": "site/en/gemini-api/tutorials/clustering_with_embeddings.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "4035164b9d4e0eec03627252180bd4e0b19eb9da",
+      "size": 505796,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/4035164b9d4e0eec03627252180bd4e0b19eb9da"
+    },
+    {
+      "path": "site/en/gemini-api/tutorials/document_search.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "26dacb36b8695625311c7abb54373130133484a5",
+      "size": 68455,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/26dacb36b8695625311c7abb54373130133484a5"
+    },
+    {
+      "path": "site/en/gemini-api/tutorials/extract_structured_data.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ba09f96909cf0d2a754437997c8b239ae797606b",
+      "size": 36442,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ba09f96909cf0d2a754437997c8b239ae797606b"
+    },
+    {
+      "path": "site/en/gemini-api/tutorials/text_classifier_embeddings.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6017fb1644e973403183eae0196a42f64acd80c7",
+      "size": 186236,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6017fb1644e973403183eae0196a42f64acd80c7"
+    },
+    {
+      "path": "site/en/gemma",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "4e60f5b503a87db7fd041728cf5bd4c09a3be215",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/4e60f5b503a87db7fd041728cf5bd4c09a3be215"
+    },
+    {
+      "path": "site/en/gemma/docs",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "d1a0f35e29ed2169fd0f8d7bf46ed785795d610a",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/d1a0f35e29ed2169fd0f8d7bf46ed785795d610a"
+    },
+    {
+      "path": "site/en/gemma/docs/agile_classifiers.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7e865959be9c633eb0494dd7b6b386eb288c424a",
+      "size": 174652,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7e865959be9c633eb0494dd7b6b386eb288c424a"
+    },
+    {
+      "path": "site/en/gemma/docs/capabilities",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "68b8955545ddb934bc4ecc15bbc56e6e966ae52a",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/68b8955545ddb934bc4ecc15bbc56e6e966ae52a"
+    },
+    {
+      "path": "site/en/gemma/docs/capabilities/vision",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "d5cf93c0b4996135b766dd4af94cc752a9c1e8e8",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/d5cf93c0b4996135b766dd4af94cc752a9c1e8e8"
+    },
+    {
+      "path": "site/en/gemma/docs/capabilities/vision/video-understanding.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c636736f61396a4d7019e8cbb2cd179bf6383f1e",
+      "size": 13348,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c636736f61396a4d7019e8cbb2cd179bf6383f1e"
+    },
+    {
+      "path": "site/en/gemma/docs/codegemma",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "b152c0686555f20402d76960b4f5e81e747bd385",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/b152c0686555f20402d76960b4f5e81e747bd385"
+    },
+    {
+      "path": "site/en/gemma/docs/codegemma/code_assist_keras.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f135b3f213af2426368368a1472eaa0f2da8f249",
+      "size": 68177,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f135b3f213af2426368368a1472eaa0f2da8f249"
+    },
+    {
+      "path": "site/en/gemma/docs/codegemma/codegemma_flax_inference.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b4c3901bed03dd2a6aacf6c4ddf59acb8cd597d9",
+      "size": 26058,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b4c3901bed03dd2a6aacf6c4ddf59acb8cd597d9"
+    },
+    {
+      "path": "site/en/gemma/docs/codegemma/keras_quickstart.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e9e3e8b742130278a846d31762c6010096f6e1ea",
+      "size": 33928,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e9e3e8b742130278a846d31762c6010096f6e1ea"
+    },
+    {
+      "path": "site/en/gemma/docs/core",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "1753f869526db7b280361a266e503ddd634798a0",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/1753f869526db7b280361a266e503ddd634798a0"
+    },
+    {
+      "path": "site/en/gemma/docs/core/distributed_tuning.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f66f2c797f53a0d05fce83f2808128f4081ea3c5",
+      "size": 55554,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f66f2c797f53a0d05fce83f2808128f4081ea3c5"
+    },
+    {
+      "path": "site/en/gemma/docs/core/gemma_library.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b999fad330ef6e3fb0872bf1b01ff7f03593823b",
+      "size": 14040,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b999fad330ef6e3fb0872bf1b01ff7f03593823b"
+    },
+    {
+      "path": "site/en/gemma/docs/core/huggingface_inference.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1611af0c032f5edc0ece4fc9f0c0719507bb054f",
+      "size": 24065,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1611af0c032f5edc0ece4fc9f0c0719507bb054f"
+    },
+    {
+      "path": "site/en/gemma/docs/core/huggingface_text_finetune_qlora.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1055210b6ee33766ff8b08fc6788bd95342e8ea4",
+      "size": 29465,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/1055210b6ee33766ff8b08fc6788bd95342e8ea4"
+    },
+    {
+      "path": "site/en/gemma/docs/core/huggingface_text_full_finetune.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d2a88888ea9ac5900e2b43a2afdf1d7bf963665f",
+      "size": 76669,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d2a88888ea9ac5900e2b43a2afdf1d7bf963665f"
+    },
+    {
+      "path": "site/en/gemma/docs/core/keras_inference.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7b42a3a2b5f06319bc9c02170ad55356d30d12d4",
+      "size": 32573,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7b42a3a2b5f06319bc9c02170ad55356d30d12d4"
+    },
+    {
+      "path": "site/en/gemma/docs/core/lora_tuning.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "17bf02f4fb3c4c4283d255748e7d01c93289ea2f",
+      "size": 32977,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/17bf02f4fb3c4c4283d255748e7d01c93289ea2f"
+    },
+    {
+      "path": "site/en/gemma/docs/core/pytorch_gemma.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e82af7873ad947cc5ef4e6a9a1dc7d4dd9f5562f",
+      "size": 22416,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e82af7873ad947cc5ef4e6a9a1dc7d4dd9f5562f"
+    },
+    {
+      "path": "site/en/gemma/docs/embeddinggemma",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "0437895461f4ed037a5df24809da56443e624580",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/0437895461f4ed037a5df24809da56443e624580"
+    },
+    {
+      "path": "site/en/gemma/docs/embeddinggemma/fine-tuning-embeddinggemma-with-sentence-transformers.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "7efa25d45f688cbc8fc3215877a6fb3b241e2f31",
+      "size": 21947,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/7efa25d45f688cbc8fc3215877a6fb3b241e2f31"
+    },
+    {
+      "path": "site/en/gemma/docs/embeddinggemma/inference-embeddinggemma-with-sentence-transformers.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "95cb0a595d01f0463635ca0e7ce095453165d787",
+      "size": 28554,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/95cb0a595d01f0463635ca0e7ce095453165d787"
+    },
+    {
+      "path": "site/en/gemma/docs/functiongemma",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "01d658c19353fb8b390d2c60e7c35d4be76f7ab4",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/01d658c19353fb8b390d2c60e7c35d4be76f7ab4"
+    },
+    {
+      "path": "site/en/gemma/docs/functiongemma/finetuning-with-functiongemma.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "02fa69700802f8edb2cd8d9d8792026172841bfa",
+      "size": 96573,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/02fa69700802f8edb2cd8d9d8792026172841bfa"
+    },
+    {
+      "path": "site/en/gemma/docs/functiongemma/full-function-calling-sequence-with-functiongemma.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e9be2f8d79fe9a8ac58ce10711016965dee965ee",
+      "size": 24069,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e9be2f8d79fe9a8ac58ce10711016965dee965ee"
+    },
+    {
+      "path": "site/en/gemma/docs/functiongemma/function-calling-with-hf.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c2aae65bb7e7226083d3fdb0c01e562f320fb308",
+      "size": 19442,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c2aae65bb7e7226083d3fdb0c01e562f320fb308"
+    },
+    {
+      "path": "site/en/gemma/docs/gemma_chat.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "89ffab4947a34503b348ec6a8f59dc0f6b4a741b",
+      "size": 52155,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/89ffab4947a34503b348ec6a8f59dc0f6b4a741b"
+    },
+    {
+      "path": "site/en/gemma/docs/integrations",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "9bcb825bfff60db6778e2bfa5ef5ad8514d4f1f5",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/9bcb825bfff60db6778e2bfa5ef5ad8514d4f1f5"
+    },
+    {
+      "path": "site/en/gemma/docs/integrations/langchain.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "0b461f78cddd902cdb73c12208ec9504cffb182c",
+      "size": 31800,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/0b461f78cddd902cdb73c12208ec9504cffb182c"
+    },
+    {
+      "path": "site/en/gemma/docs/lit_gemma.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d50bc221cb07efadb128ed22ead58046ecc7b2ea",
+      "size": 17899,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d50bc221cb07efadb128ed22ead58046ecc7b2ea"
+    },
+    {
+      "path": "site/en/gemma/docs/paligemma",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "3228d814d698ce0103f4ea6af5762a8fa0cef452",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/3228d814d698ce0103f4ea6af5762a8fa0cef452"
+    },
+    {
+      "path": "site/en/gemma/docs/paligemma/fine-tuning-paligemma.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c2845eee5dc6e2b33e38a623d4317ad3f98df6fe",
+      "size": 42175,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c2845eee5dc6e2b33e38a623d4317ad3f98df6fe"
+    },
+    {
+      "path": "site/en/gemma/docs/paligemma/inference-with-keras.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ebae4e8f369d9721ded547fd43f031b2b84933df",
+      "size": 26330,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ebae4e8f369d9721ded547fd43f031b2b84933df"
+    },
+    {
+      "path": "site/en/gemma/docs/recurrentgemma",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "57425a37f0b15e74eaed3881d4a5c52b8c6b1a51",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/57425a37f0b15e74eaed3881d4a5c52b8c6b1a51"
+    },
+    {
+      "path": "site/en/gemma/docs/recurrentgemma/recurrentgemma_jax_finetune.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "034121cede55f21da7030910db83a2a65244e1b1",
+      "size": 62617,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/034121cede55f21da7030910db83a2a65244e1b1"
+    },
+    {
+      "path": "site/en/gemma/docs/recurrentgemma/recurrentgemma_jax_inference.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ece899954b441001b31eb119f8fed79581a6c1d9",
+      "size": 23132,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ece899954b441001b31eb119f8fed79581a6c1d9"
+    },
+    {
+      "path": "site/en/palm_docs",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "89d177de506305d975426ebda2df352aae1d56b7",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/89d177de506305d975426ebda2df352aae1d56b7"
+    },
+    {
+      "path": "site/en/palm_docs/chat_node_quickstart.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "93df7c5a16706d0ab398236c43db683ae7b75ee2",
+      "size": 14377,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/93df7c5a16706d0ab398236c43db683ae7b75ee2"
+    },
+    {
+      "path": "site/en/palm_docs/chat_quickstart.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "209601fe62094b155ce4248e302bef63e700d7ce",
+      "size": 38351,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/209601fe62094b155ce4248e302bef63e700d7ce"
+    },
+    {
+      "path": "site/en/palm_docs/curl_quickstart.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ecf9d4baceed121c75507f19caf06ff3f7fb784a",
+      "size": 53189,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/ecf9d4baceed121c75507f19caf06ff3f7fb784a"
+    },
+    {
+      "path": "site/en/palm_docs/embeddings_quickstart.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d59d4aff376c38c1cf86938f725f29a70a4ff723",
+      "size": 20344,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/d59d4aff376c38c1cf86938f725f29a70a4ff723"
+    },
+    {
+      "path": "site/en/palm_docs/notebook_magic.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c699f0d9be9419d898bbfefac40a15ca6862fe01",
+      "size": 256437,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/c699f0d9be9419d898bbfefac40a15ca6862fe01"
+    },
+    {
+      "path": "site/en/palm_docs/text_node_quickstart.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "143bb610885cef414c4d51bd65ee779a0ded4c04",
+      "size": 10560,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/143bb610885cef414c4d51bd65ee779a0ded4c04"
+    },
+    {
+      "path": "site/en/palm_docs/text_quickstart.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "8be9bcd14ce5c7cf47945b0d648ff0ba47940762",
+      "size": 28748,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/8be9bcd14ce5c7cf47945b0d648ff0ba47940762"
+    },
+    {
+      "path": "site/en/palm_docs/tuning_quickstart_python.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "510a9a6dfb584cbfd24d6aafbcd24e36421ad64a",
+      "size": 197777,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/510a9a6dfb584cbfd24d6aafbcd24e36421ad64a"
+    },
+    {
+      "path": "site/en/palm_docs/tuning_quickstart_rest.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9e4d32838d306b32fd8f501526ba705dd25e87c2",
+      "size": 56404,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/9e4d32838d306b32fd8f501526ba705dd25e87c2"
+    },
+    {
+      "path": "site/en/responsible",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "45db054a31249921cee2c3193b3a5ba057a57a8c",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/45db054a31249921cee2c3193b3a5ba057a57a8c"
+    },
+    {
+      "path": "site/en/responsible/docs",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "7bb59b781ab1eb24cf14ec355d7cd8ab64727a62",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/7bb59b781ab1eb24cf14ec355d7cd8ab64727a62"
+    },
+    {
+      "path": "site/en/responsible/docs/safeguards",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "b493b475737582343058e773f171045f2670de92",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/b493b475737582343058e773f171045f2670de92"
+    },
+    {
+      "path": "site/en/responsible/docs/safeguards/shieldgemma2_on_huggingface.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b257364511df6a7752a2c323f461a92fdab56c45",
+      "size": 11183,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/b257364511df6a7752a2c323f461a92fdab56c45"
+    },
+    {
+      "path": "site/en/responsible/docs/safeguards/shieldgemma_on_huggingface.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "308a89634c490c668c674880e4156a6e52245fc0",
+      "size": 20753,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/308a89634c490c668c674880e4156a6e52245fc0"
+    },
+    {
+      "path": "site/en/responsible/docs/safeguards/shieldgemma_on_keras.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "753068ad24b3393c072f2f66176d1121719ebf3c",
+      "size": 22564,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/753068ad24b3393c072f2f66176d1121719ebf3c"
+    },
+    {
+      "path": "site/en/tutorials",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "bee253bb85ec39a0f6cb45faa86823da56ea1a51",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/bee253bb85ec39a0f6cb45faa86823da56ea1a51"
+    },
+    {
+      "path": "site/en/tutorials/quickstart_colab.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "41653c382a37d237f0dd9a682bcbd93ac01729db",
+      "size": 10580,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/41653c382a37d237f0dd9a682bcbd93ac01729db"
+    },
+    {
+      "path": "templates",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "dff48030ece259c9e63bfd31f1afb601f8de0c71",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/dff48030ece259c9e63bfd31f1afb601f8de0c71"
+    },
+    {
+      "path": "templates/aistudio_gemini_prompt_chat.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f05ea511f97607fa4404c484c04ce4c22ce50936",
+      "size": 6354,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/f05ea511f97607fa4404c484c04ce4c22ce50936"
+    },
+    {
+      "path": "templates/aistudio_gemini_prompt_chat_b64.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "901ea3b02dbb1f31eafb47e5e4bd5959e0a5c80a",
+      "size": 6619,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/901ea3b02dbb1f31eafb47e5e4bd5959e0a5c80a"
+    },
+    {
+      "path": "templates/aistudio_gemini_prompt_freeform.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "dc5897e9f9856be89d0f79af52eb39e3855bf346",
+      "size": 7820,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/dc5897e9f9856be89d0f79af52eb39e3855bf346"
+    },
+    {
+      "path": "templates/aistudio_gemini_prompt_freeform_b64.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "bd6c650dd8c115170577af0182de8d8685ee4106",
+      "size": 9151,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/bd6c650dd8c115170577af0182de8d8685ee4106"
+    },
+    {
+      "path": "templates/aistudio_palm_prompt_chat.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "023b35477222d19461944b6325b6871603a76734",
+      "size": 4067,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/023b35477222d19461944b6325b6871603a76734"
+    },
+    {
+      "path": "templates/aistudio_palm_prompt_text.ipynb",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e8d546546cd8d445c1967e4605ed03fafb915f73",
+      "size": 4220,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/e8d546546cd8d445c1967e4605ed03fafb915f73"
+    },
+    {
+      "path": "third_party",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "49aa1101aebb17e47528a222f648f7657b4da1a1",
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/trees/49aa1101aebb17e47528a222f648f7657b4da1a1"
+    },
+    {
+      "path": "third_party/README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "6b58566b8cdbafdb695701c016668a01ec8d1654",
+      "size": 127,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/6b58566b8cdbafdb695701c016668a01ec8d1654"
+    },
+    {
+      "path": "third_party/docs-agent",
+      "mode": "120000",
+      "type": "blob",
+      "sha": "5174a46cb6878313f887601e6f6dc8d512615bc6",
+      "size": 48,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/5174a46cb6878313f887601e6f6dc8d512615bc6"
+    },
+    {
+      "path": "third_party/mood-food",
+      "mode": "120000",
+      "type": "blob",
+      "sha": "85d7f0bb49d8c4dc15552f8e758145e260dae254",
+      "size": 39,
+      "url": "https://api.github.com/repos/google/generative-ai-docs/git/blobs/85d7f0bb49d8c4dc15552f8e758145e260dae254"
+    }
+  ],
+  "truncated": false
+}

--- a/test/quality-gate-e2e.test.ts
+++ b/test/quality-gate-e2e.test.ts
@@ -1,0 +1,131 @@
+/**
+ * End-to-end quality-gate test that verifies the gate-then-rollback behavior:
+ * a scrape that indexes nothing must finish FAILED with errorCode EMPTY_RESULT
+ * and must leave nothing searchable (the staged version is rolled back).
+ *
+ * Modeled on test/vector-search-e2e.test.ts (in-process pipeline + MSW-mocked
+ * OpenAI embeddings). Uses a local fixture directory containing only a
+ * non-indexable file so the crawl finishes with zero stored chunks.
+ */
+
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { config } from "dotenv";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { EventBusService } from "../src/events";
+import { PipelineFactory } from "../src/pipeline/PipelineFactory";
+import { PipelineJobStatus, ScrapeErrorCode, ScrapeOutcome } from "../src/pipeline/types";
+import { createLocalDocumentManagement } from "../src/store";
+import {
+  EmbeddingConfig,
+  type EmbeddingModelConfig,
+} from "../src/store/embeddings/EmbeddingConfig";
+import { ScrapeTool } from "../src/tools/ScrapeTool";
+import { SearchTool } from "../src/tools/SearchTool";
+import { loadConfig } from "../src/utils/config";
+
+// Load environment variables from .env file
+config();
+
+describe("Quality Gate End-to-End Tests", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test harness mirrors vector-search-e2e
+  let docService: any;
+  let scrapeTool: ScrapeTool;
+  let searchTool: SearchTool;
+  // biome-ignore lint/suspicious/noExplicitAny: test harness mirrors vector-search-e2e
+  let pipeline: any;
+  let tempDir: string;
+  const appConfig = loadConfig();
+  let prevOpenAiApiKey: string | undefined;
+  let prevOpenAiApiBase: string | undefined;
+
+  beforeAll(async () => {
+    // Ensure vector search initializes in tests without requiring real credentials.
+    // The OpenAI embeddings endpoint is mocked by test/mock-server.ts.
+    prevOpenAiApiKey = process.env.OPENAI_API_KEY;
+    prevOpenAiApiBase = process.env.OPENAI_API_BASE;
+    process.env.OPENAI_API_KEY = "test-key";
+    delete process.env.OPENAI_API_BASE;
+
+    tempDir = mkdtempSync(path.join(tmpdir(), "quality-gate-e2e-test-"));
+
+    const embeddingConfig: EmbeddingModelConfig = EmbeddingConfig.parseEmbeddingConfig(
+      "openai:text-embedding-3-small",
+    );
+
+    appConfig.app.storePath = tempDir;
+    appConfig.app.embeddingModel = embeddingConfig.modelSpec;
+    appConfig.embeddings.vectorDimension = 1536;
+    appConfig.scraper.security.fileAccess.mode = "allowedRoots";
+    appConfig.scraper.security.fileAccess.allowedRoots = [process.cwd()];
+
+    const eventBus = new EventBusService();
+    docService = await createLocalDocumentManagement(eventBus, appConfig);
+
+    pipeline = await PipelineFactory.createPipeline(docService, eventBus, {
+      appConfig: appConfig,
+    });
+    await pipeline.start();
+
+    scrapeTool = new ScrapeTool(pipeline, appConfig.scraper);
+    searchTool = new SearchTool(docService);
+  }, 30000);
+
+  afterAll(async () => {
+    try {
+      if (pipeline) {
+        await pipeline.stop();
+      }
+      if (docService) {
+        await docService.shutdown();
+      }
+      if (tempDir) {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    } finally {
+      if (prevOpenAiApiKey === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = prevOpenAiApiKey;
+      }
+
+      if (prevOpenAiApiBase === undefined) {
+        delete process.env.OPENAI_API_BASE;
+      } else {
+        process.env.OPENAI_API_BASE = prevOpenAiApiBase;
+      }
+    }
+  });
+
+  it("a scrape that indexes nothing is not searchable and reports EMPTY_RESULT", async () => {
+    const fixtureDir = path.resolve(process.cwd(), "test/fixtures/empty-fixture");
+    const fileUrl = `file://${fixtureDir}`;
+
+    // Enqueue without waiting; a gate failure rejects the completion promise.
+    const result = await scrapeTool.execute({
+      library: "emptylib",
+      version: "1.0.0",
+      url: fileUrl,
+      waitForCompletion: false,
+    });
+    const jobId = (result as { jobId: string }).jobId;
+
+    // The gate failure rejects waitForJobCompletion; swallow it and inspect state.
+    await pipeline.waitForJobCompletion(jobId).catch(() => {});
+
+    const job = await pipeline.getJob(jobId);
+    expect(job?.status).toBe(PipelineJobStatus.FAILED);
+    expect(job?.outcome).toBe(ScrapeOutcome.EMPTY);
+    expect(job?.errorCode).toBe(ScrapeErrorCode.EMPTY_RESULT);
+
+    // Rolled back: nothing should be searchable for this (library, version).
+    const searchResult = await searchTool.execute({
+      library: "emptylib",
+      version: "1.0.0",
+      query: "anything",
+      exactMatch: true,
+    });
+    expect(searchResult.results).toHaveLength(0);
+  }, 60000);
+});


### PR DESCRIPTION
# feat: scrape quality gates — classify outcome and roll back unusable indexes

## Problem

Today a scrape job is marked `completed` as soon as the scraper returns without
throwing (`PipelineManager` success path). There is **no quality gate**: the server
conflates *"the crawl finished"* with *"I indexed usable documentation"*. This produces
three failure modes that all report `completed`, verified against the real
`google/generative-ai-docs` repository:

| # | Failure mode | Verified root cause | Today |
|---|--------------|---------------------|-------|
| FM-1 | Empty / hostile host (SPA, `?hl=` locale redirect) | No locale normalization; a JS-gated or redirect-walled page yields 0 docs with no signal. Redirect cap exists but there is no cyclic-`Location` detection and no locale stripping. | `completed` |
| FM-2 | Wrong content — crawler indexes an irrelevant subtree | A repo-root scrape legitimately includes `demos/` as descendants. Measured: **679 of 1045 tree entries are under `demos/`**, drowning the ~50 real `.md` docs. Path scope can't help (demos *are* descendants of the root). | `completed` (non-empty!) |
| FM-3 | Silent no-op — GitHub `/tree/<branch>/<subPath>` indexes nothing | The GitHub tree API returns **HTTP 200 with the entire tree regardless of subPath**; the subPath is filtered **client-side**. A nonexistent/mistyped/wrong-case subPath matches **0 files** silently → only the wiki link is queued (404) → 0 docs → `completed` in ~0.4s. | `completed` |

Empirical evidence (real repo, not truncated, 1045 entries):

```
/tree/main/docs                     -> 0 files   (dir doesn't exist)
/tree/main/gemini-api/docs          -> 0 files   (wrong path)
/tree/main/Site/en                  -> 0 files   (wrong case)
/tree/main/site/en/gemini-api/docs  -> 8 files   (correct path)
```

## Solution

Promote a `(library, version)` to searchable **only if it passes quality gates**.
Otherwise, discard what was indexed and return a **typed error code with remediation**.

- **Outcome classification** — new `ScrapeOutcome` enum (`indexed | empty | thin |
  degenerate | failed`) computed at job end from counters that already exist.
- **Gate-then-rollback (hard-fail)** — at the single seam where the manager would mark
  `COMPLETED`, a failing verdict calls the existing `removeVersion()` to discard the
  staged docs and marks the job `FAILED` with a typed `errorCode`. No half-indexed
  garbage stays searchable.
- **FM-1** — `localeStrategy` (`pin-en` default): `Accept-Language: en` + strip
  `hl`/`lang`/`locale` query params; cyclic-`Location` detection within the existing
  redirect cap raises `LOCALE_REDIRECT_LOOP`.
- **FM-2** — `denyPaths` (default `demos`/`examples`) trims irrelevant subtrees; an
  **opt-in** relevance gate (`expectTerms`) samples indexed chunks and flags `OFF_TOPIC`,
  plus path/host coherence flags `SCOPE_DRIFT`.
- **FM-3** — a `/tree/` subPath matching zero files raises `GITHUB_SUBPATH_NOT_FOUND`
  whose message lists the repo's real top-level directories.

## Error codes (surfaced in `get_job_info` / `list_jobs`)

`EMPTY_RESULT`, `THIN_RESULT`, `OFF_TOPIC`, `SCOPE_DRIFT`, `LOCALE_REDIRECT_LOOP`,
`GITHUB_SUBPATH_NOT_FOUND`.

## Backward compatibility

All public changes are **additive**:
- New optional `scrape_docs` params: `expectTerms`, `denyPaths`, `localeStrategy`
  (bounded in the zod schema: ≤50 items, ≤200 chars each).
- New optional fields on `ScraperOptions`, `FetchOptions`, `JobInfo`, `PipelineJob`.
- Conservative defaults: only a **0-document** scrape is hard-failed by default; the
  relevance axes (`OFF_TOPIC`/`SCOPE_DRIFT`) are **opt-in** via `expectTerms`.
- Refresh / `clean=false` jobs **skip** the gate, so a transient thin re-index can never
  delete a pre-existing good version.

## Implementation walkthrough (one commit per step)

- **M1** — `ScrapeOutcome`/`ScrapeErrorCode`/`JobOutcomeMetrics` types; pure
  `evaluateOutcome()` classifier; `getVersionMetrics()` store accessor.
- **M2** — `applyQualityGate()` seam in `PipelineManager` + gate-then-rollback; E2E
  asserting a failed gate leaves the store empty.
- **M3** — real GitHub tree fixture; `GITHUB_SUBPATH_NOT_FOUND` guard; locale
  normalization + `LOCALE_REDIRECT_LOOP`.
- **M4** — `denyPaths` in GitHub + web crawl; `relevanceGate` (`toScopeKey` ref-agnostic
  scope, `expectTerms` sampling); wiring into the gate (opt-in).
- **M5** — expose `outcome`/`errorCode` in job tools; plumb new params through
  `scrape_docs`; docs.

## Tests

New deterministic coverage (no network): `outcomeGate.test.ts`, `relevanceGate.test.ts`,
`quality-gate-e2e.test.ts`, plus additions to `PipelineManager`, `HttpFetcher`,
`GitHubScraperStrategy`, `DocumentManagementService`, `GetJobInfoTool`, `ScrapeTool` tests.
FM-2/FM-3 use a committed snapshot of the real `google/generative-ai-docs` tree.
`npm test`, `npm run lint`, `npm run typecheck` all green (pre-existing locale-dependent
`cli-e2e` and an environment-dependent `vector-persistence` case excluded — failing
identically on `main`).

## Out of scope (intentionally deferred)

- `discover_source(library)` tool.
- A real staging-version with pointer swap (this PR uses gate-then-rollback).
- Typed signal + pagination for truncated GitHub trees (still `logger.warn`).
