### PR TITLE
fix(scraper): make browser fetcher robust to non-navigable urls and idle hangs

### DIFF
--- a/src/scraper/fetcher/BrowserFetcher.test.ts
+++ b/src/scraper/fetcher/BrowserFetcher.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { loadConfig } from "../../utils/config";
+import { ScraperError } from "../../utils/errors";
 import { MARKDOWN_PREFERRED_ACCEPT } from "./headers";
 
 vi.mock("playwright", () => ({
@@ -11,144 +12,90 @@ vi.mock("playwright", () => ({
 import { chromium } from "playwright";
 import { BrowserFetcher } from "./BrowserFetcher";
 
+/**
+ * Builds a mocked Playwright page/context/browser tree. `pageOverrides` lets a
+ * test replace individual page methods (e.g. a rejecting `goto`).
+ */
+function mockBrowser(pageOverrides: Record<string, unknown> = {}) {
+  const page = {
+    setViewportSize: vi.fn().mockResolvedValue(undefined),
+    setExtraHTTPHeaders: vi.fn().mockResolvedValue(undefined),
+    route: vi.fn().mockResolvedValue(undefined),
+    unroute: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    waitForLoadState: vi.fn().mockResolvedValue(undefined),
+    goto: vi.fn().mockResolvedValue({
+      status: () => 200,
+      headers: () => ({ "content-type": "text/html" }),
+    }),
+    url: vi.fn().mockReturnValue("https://example.com"),
+    content: vi.fn().mockResolvedValue("<html><body>ok</body></html>"),
+    request: { get: vi.fn() },
+    ...pageOverrides,
+  };
+  const context = {
+    newPage: vi.fn().mockResolvedValue(page),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  const browser = {
+    newContext: vi.fn().mockResolvedValue(context),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  vi.mocked(chromium.launch).mockResolvedValue(browser as never);
+  return { page, context, browser };
+}
+
 describe("BrowserFetcher", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("uses broad invalid TLS override for the browser context", async () => {
-    const setViewportSize = vi.fn().mockResolvedValue(undefined);
-    const setExtraHTTPHeaders = vi.fn().mockResolvedValue(undefined);
-    const route = vi.fn().mockResolvedValue(undefined);
-    const unroute = vi.fn().mockResolvedValue(undefined);
-    const closePage = vi.fn().mockResolvedValue(undefined);
-    const page = {
-      setViewportSize,
-      setExtraHTTPHeaders,
-      route,
-      unroute,
-      close: closePage,
-      goto: vi.fn().mockResolvedValue({
-        status: () => 200,
-        headers: () => ({ "content-type": "text/html" }),
-      }),
-      url: vi.fn().mockReturnValue("https://example.com"),
-      content: vi.fn().mockResolvedValue("<html><body>ok</body></html>"),
-    };
-    const closeContext = vi.fn().mockResolvedValue(undefined);
-    const newContext = vi.fn().mockResolvedValue({
-      newPage: vi.fn().mockResolvedValue(page),
-      close: closeContext,
-    });
-    const browser = {
-      newContext,
-      close: vi.fn().mockResolvedValue(undefined),
-    };
-    vi.mocked(chromium.launch).mockResolvedValue(browser as never);
-
+    const { browser } = mockBrowser();
     const config = loadConfig().scraper;
     config.security.network.allowInvalidTls = true;
     const fetcher = new BrowserFetcher(config);
 
     await fetcher.fetch("http://example.com");
 
-    expect(newContext).toHaveBeenCalledWith(
+    expect(browser.newContext).toHaveBeenCalledWith(
       expect.objectContaining({ ignoreHTTPSErrors: true }),
     );
   });
 
   it("restores fingerprint headers and desktop viewport", async () => {
-    const setViewportSize = vi.fn().mockResolvedValue(undefined);
-    const setExtraHTTPHeaders = vi.fn().mockResolvedValue(undefined);
-    const page = {
-      setViewportSize,
-      setExtraHTTPHeaders,
-      route: vi.fn().mockResolvedValue(undefined),
-      unroute: vi.fn().mockResolvedValue(undefined),
-      close: vi.fn().mockResolvedValue(undefined),
-      goto: vi.fn().mockResolvedValue({
-        status: () => 200,
-        headers: () => ({ "content-type": "text/html" }),
-      }),
-      url: vi.fn().mockReturnValue("https://example.com"),
-      content: vi.fn().mockResolvedValue("<html><body>ok</body></html>"),
-    };
-    const browser = {
-      newContext: vi.fn().mockResolvedValue({
-        newPage: vi.fn().mockResolvedValue(page),
-        close: vi.fn().mockResolvedValue(undefined),
-      }),
-      close: vi.fn().mockResolvedValue(undefined),
-    };
-    vi.mocked(chromium.launch).mockResolvedValue(browser as never);
-
+    const { page } = mockBrowser();
     const fetcher = new BrowserFetcher(loadConfig().scraper);
     await fetcher.fetch("https://example.com", { headers: { "X-Test": "1" } });
 
-    expect(setViewportSize).toHaveBeenCalledWith({ width: 1920, height: 1080 });
-    expect(setExtraHTTPHeaders).toHaveBeenCalledWith(
+    expect(page.setViewportSize).toHaveBeenCalledWith({ width: 1920, height: 1080 });
+    expect(page.setExtraHTTPHeaders).toHaveBeenCalledWith(
       expect.objectContaining({ "X-Test": "1", Accept: MARKDOWN_PREFERRED_ACCEPT }),
     );
   });
 
   it("preserves caller-supplied Accept headers", async () => {
-    const setExtraHTTPHeaders = vi.fn().mockResolvedValue(undefined);
-    const page = {
-      setViewportSize: vi.fn().mockResolvedValue(undefined),
-      setExtraHTTPHeaders,
-      route: vi.fn().mockResolvedValue(undefined),
-      unroute: vi.fn().mockResolvedValue(undefined),
-      close: vi.fn().mockResolvedValue(undefined),
-      goto: vi.fn().mockResolvedValue({
-        status: () => 200,
-        headers: () => ({ "content-type": "text/html" }),
-      }),
-      url: vi.fn().mockReturnValue("https://example.com"),
-      content: vi.fn().mockResolvedValue("<html><body>ok</body></html>"),
-    };
-    const browser = {
-      newContext: vi.fn().mockResolvedValue({
-        newPage: vi.fn().mockResolvedValue(page),
-        close: vi.fn().mockResolvedValue(undefined),
-      }),
-      close: vi.fn().mockResolvedValue(undefined),
-    };
-    vi.mocked(chromium.launch).mockResolvedValue(browser as never);
-
+    const { page } = mockBrowser();
     const fetcher = new BrowserFetcher(loadConfig().scraper);
     await fetcher.fetch("https://example.com", { headers: { accept: "text/html" } });
 
-    expect(setExtraHTTPHeaders).toHaveBeenCalledWith(
+    expect(page.setExtraHTTPHeaders).toHaveBeenCalledWith(
       expect.objectContaining({ accept: "text/html" }),
     );
-    expect(setExtraHTTPHeaders).toHaveBeenCalledWith(
+    expect(page.setExtraHTTPHeaders).toHaveBeenCalledWith(
       expect.not.objectContaining({ Accept: MARKDOWN_PREFERRED_ACCEPT }),
     );
   });
 
   it("returns raw response body for Markdown responses instead of rendered HTML", async () => {
-    const page = {
-      setViewportSize: vi.fn().mockResolvedValue(undefined),
-      setExtraHTTPHeaders: vi.fn().mockResolvedValue(undefined),
-      route: vi.fn().mockResolvedValue(undefined),
-      unroute: vi.fn().mockResolvedValue(undefined),
-      close: vi.fn().mockResolvedValue(undefined),
+    const { page } = mockBrowser({
       goto: vi.fn().mockResolvedValue({
         status: () => 200,
         headers: () => ({ "content-type": "text/markdown; charset=utf-8" }),
         body: vi.fn().mockResolvedValue(Buffer.from("# Markdown body")),
       }),
       url: vi.fn().mockReturnValue("https://example.com/readme.md"),
-      content: vi.fn().mockResolvedValue("<html><body># Markdown body</body></html>"),
-    };
-    const browser = {
-      newContext: vi.fn().mockResolvedValue({
-        newPage: vi.fn().mockResolvedValue(page),
-        close: vi.fn().mockResolvedValue(undefined),
-      }),
-      close: vi.fn().mockResolvedValue(undefined),
-    };
-    vi.mocked(chromium.launch).mockResolvedValue(browser as never);
+    });
 
     const fetcher = new BrowserFetcher(loadConfig().scraper);
     const result = await fetcher.fetch("https://example.com/readme.md");
@@ -156,5 +103,56 @@ describe("BrowserFetcher", () => {
     expect(page.content).not.toHaveBeenCalled();
     expect(result.mimeType).toBe("text/markdown");
     expect(result.content.toString()).toBe("# Markdown body");
+  });
+
+  it("falls back to the request API when goto rejects on a non-navigable resource", async () => {
+    // First goto (the .md) rejects as non-navigable; the origin goto (to clear
+    // any challenge) resolves; then the request API returns the markdown bytes.
+    const goto = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error(
+          "page.goto: net::ERR_INVALID_ARGUMENT at https://x/automation/index.md",
+        ),
+      )
+      .mockResolvedValue({ status: () => 200, headers: () => ({}) });
+    const requestGet = vi.fn().mockResolvedValue({
+      ok: () => true,
+      status: () => 200,
+      headers: () => ({ "content-type": "text/markdown" }),
+      body: vi.fn().mockResolvedValue(Buffer.from("# from request api")),
+    });
+    const { page } = mockBrowser({ goto, request: { get: requestGet } });
+
+    const fetcher = new BrowserFetcher(loadConfig().scraper);
+    const result = await fetcher.fetch("https://example.com/automation/index.md");
+
+    expect(requestGet).toHaveBeenCalledWith(
+      "https://example.com/automation/index.md",
+      expect.any(Object),
+    );
+    expect(goto).toHaveBeenCalledWith("https://example.com", expect.any(Object));
+    expect(page.content).not.toHaveBeenCalled();
+    expect(result.mimeType).toBe("text/markdown");
+    expect(result.content.toString()).toBe("# from request api");
+  });
+
+  it("throws a retryable ScraperError when the request-API fallback is still blocked", async () => {
+    const goto = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("page.goto: net::ERR_ABORTED"))
+      .mockResolvedValue({ status: () => 200, headers: () => ({}) });
+    const requestGet = vi.fn().mockResolvedValue({
+      ok: () => false,
+      status: () => 403,
+      headers: () => ({ "content-type": "text/html" }),
+      body: vi.fn().mockResolvedValue(Buffer.from("Just a moment...")),
+    });
+    mockBrowser({ goto, request: { get: requestGet } });
+
+    const fetcher = new BrowserFetcher(loadConfig().scraper);
+    await expect(
+      fetcher.fetch("https://example.com/automation/index.md"),
+    ).rejects.toBeInstanceOf(ScraperError);
   });
 });

--- a/src/scraper/fetcher/BrowserFetcher.ts
+++ b/src/scraper/fetcher/BrowserFetcher.ts
@@ -83,12 +83,32 @@ export class BrowserFetcher implements ContentFetcher {
       // Set timeout
       const timeout = options?.timeout || this.defaultTimeoutMs;
 
-      // Navigate to the page and wait for it to load
+      // Navigate to the page. Gate on "load" rather than "networkidle": many
+      // sites keep background connections open indefinitely (analytics,
+      // Cloudflare telemetry, websockets), so "networkidle" never settles and
+      // page.goto times out even though the document is already available.
       logger.debug(`Navigating to ${source} with browser...`);
-      const response = await page.goto(source, {
-        waitUntil: "networkidle",
-        timeout,
-      });
+      let response: Awaited<ReturnType<typeof page.goto>>;
+      try {
+        response = await page.goto(source, { waitUntil: "load", timeout });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        // Non-navigable resources (Markdown, JSON, plain text, ...) make the
+        // browser begin a download, so page.goto rejects with
+        // ERR_INVALID_ARGUMENT / ERR_ABORTED. Fetch those through the context's
+        // request API instead (see fetchViaRequest): it shares cookies — so any
+        // anti-bot clearance carries over — but does not try to render them.
+        if (/ERR_INVALID_ARGUMENT|ERR_ABORTED/i.test(message)) {
+          return await this.fetchViaRequest(page, source, options, timeout);
+        }
+        throw error;
+      }
+
+      // Best-effort: give the network a moment to settle (e.g. so a JS
+      // challenge can finish) but never fail the fetch if it never goes idle.
+      await page
+        .waitForLoadState("networkidle", { timeout: Math.min(timeout, 5_000) })
+        .catch(() => undefined);
 
       if (!response) {
         throw new ScraperError(`Failed to navigate to ${source}`, false);
@@ -149,6 +169,72 @@ export class BrowserFetcher implements ContentFetcher {
       await page?.close().catch(() => undefined);
       await browserContext?.close().catch(() => undefined);
     }
+  }
+
+  /**
+   * Fetches a resource the browser cannot navigate to (Markdown, JSON, plain
+   * text, ...). Loads the origin first so any JS/anti-bot challenge is solved
+   * and clearance cookies are set on the shared context, then retrieves the
+   * resource bytes via the context's request API (which reuses those cookies
+   * but does not attempt to render the response as a document).
+   *
+   * @param page - The page whose context (and cookies) the request reuses.
+   * @param source - The non-navigable resource URL to fetch.
+   * @param options - The original fetch options (headers, redirect policy).
+   * @param timeout - Navigation/request timeout in milliseconds.
+   * @returns The fetched raw content.
+   */
+  private async fetchViaRequest(
+    page: Page,
+    source: string,
+    options: FetchOptions | undefined,
+    timeout: number,
+  ): Promise<RawContent> {
+    const origin = new URL(source).origin;
+    logger.debug(
+      `Resource ${source} is not browser-navigable; clearing ${origin} then fetching via request API`,
+    );
+    // Visit a navigable page on the same origin so the browser can solve any JS
+    // challenge and set clearance cookies; ignore failures since the request
+    // below still returns a definitive status.
+    await page
+      .goto(origin, { waitUntil: "load", timeout })
+      .then(() =>
+        page
+          .waitForLoadState("networkidle", { timeout: Math.min(timeout, 5_000) })
+          .catch(() => undefined),
+      )
+      .catch(() => undefined);
+
+    const response = await page.request.get(source, {
+      headers: options?.headers,
+      maxRedirects: options?.followRedirects === false ? 0 : undefined,
+      timeout,
+    });
+
+    const finalUrl = source;
+    await this.accessPolicy.assertNetworkUrlAllowed(finalUrl);
+
+    if (!response.ok()) {
+      throw new ScraperError(
+        `Browser request for ${source} returned status ${response.status()}`,
+        true,
+      );
+    }
+
+    const contentType = response.headers()["content-type"] || "application/octet-stream";
+    const { mimeType, charset } = MimeTypeUtils.parseContentType(contentType);
+    const content = Buffer.from(await response.body());
+
+    return {
+      content,
+      mimeType,
+      charset,
+      encoding: undefined,
+      source: finalUrl,
+      etag: response.headers().etag,
+      status: FetchStatus.SUCCESS,
+    } satisfies RawContent;
   }
 
   public static async launchBrowser(): Promise<Browser> {


### PR DESCRIPTION
Fixes #441.

## Summary

Makes `BrowserFetcher` robust to the two failure modes described in #441:

- **`networkidle` → `load`.** `page.goto` now gates on `"load"` and waits for `networkidle` only on a best-effort basis (with a short timeout, swallowed on failure), matching what `HtmlPlaywrightMiddleware` already does. Sites that never go network-idle (Cloudflare telemetry, analytics, websockets) no longer time out the navigation.
- **Non-navigable resources fall back to the request API.** When `page.goto` rejects with `ERR_INVALID_ARGUMENT` / `ERR_ABORTED` (Markdown/JSON/plain-text resources the browser tries to download), the fetcher loads the origin first (so any JS/anti-bot challenge is solved and clearance cookies are set on the context) and then retrieves the bytes via `page.request.get`, which reuses those cookies but does not try to render the response. A still-blocked fetch surfaces as a **retryable** `ScraperError` rather than crashing the job.

## Why

The `llms.txt` feature seeds Markdown (`.md`) URL variants at depth 0. Behind a Cloudflare Managed Challenge these get routed to the browser fallback, where `page.goto` on a Markdown URL throws `ERR_INVALID_ARGUMENT`; since depth-0 failures are fatal in `BaseScraperStrategy`, one such seed aborts the whole scrape. The `networkidle` gate independently caused navigation timeouts on the same class of sites.

## Changes

- `src/scraper/fetcher/BrowserFetcher.ts` — `load` gate + best-effort networkidle; new `fetchViaRequest()` fallback for non-navigable URLs.
- `src/scraper/fetcher/BrowserFetcher.test.ts` — refactored mocks into a `mockBrowser()` helper; added tests for the request-API fallback (success path) and for a still-blocked fallback raising a `ScraperError`.

## Testing

- `npx vitest run src/scraper/fetcher/BrowserFetcher.test.ts` — passes (incl. new cases).
- `npx tsc --noEmit` and `biome check` — clean.
- Verified end-to-end against a Cloudflare-challenged Read-the-Docs site (`docs.vyos.io`): the scrape that previously aborted in ~30s now completes the full tree with no `ERR_INVALID_ARGUMENT` or `networkidle` timeouts; pages that genuinely can't be cleared fail individually (non-fatal) instead of killing the job.

## Notes

The depth-0-seed-fatal behavior in `BaseScraperStrategy` (any single `llms.txt` seed failure aborting the whole job) is a related but separate issue; this PR makes the browser path degrade gracefully so it no longer triggers that path, but the underlying strategy behavior is left for a follow-up.
