### PR TITLE
docs: correct multi-worker scaling claims in deployment docs

### DIFF
--- a/docs/concepts/pipeline-architecture.md
+++ b/docs/concepts/pipeline-architecture.md
@@ -276,10 +276,10 @@ Increase worker concurrency within its single process:
 
 The worker is a single process that owns the in-memory job queue and the SQLite-backed document store — it does not scale horizontally. What scales horizontally is the coordinator tier:
 
-- Run multiple `web`/`mcp` coordinator replicas, each pointed at the same worker's `--server-url`
+- Run multiple `web`/`mcp` coordinator replicas, each started with `--server-url` pointing at the same worker
 - Coordinators are stateless; both document reads (`DocumentManagementClient`) and job dispatch (`PipelineClient`) proxy to the one worker over tRPC
 - Load balance across coordinator replicas, not worker replicas
 
 ### Deployment Modes Are Exclusive
 
-A deployment runs with either an embedded worker (`enableWorker: true`, standalone mode) or a single external worker (`--server-url`, distributed mode) — not both at once.
+A deployment runs with either an embedded worker (`enableWorker: true`, standalone mode) or a single external worker started separately and reached via the coordinator's `--server-url` flag (distributed mode) — not both at once.

--- a/docs/concepts/pipeline-architecture.md
+++ b/docs/concepts/pipeline-architecture.md
@@ -266,26 +266,20 @@ Job execution metrics:
 
 ### Vertical Scaling
 
-Increase worker concurrency within single process:
+Increase worker concurrency within its single process:
 
-- Higher concurrency limits
+- Higher `maxConcurrency` limits
 - More memory allocation
 - Faster storage backend
 
-### Horizontal Scaling
+### Horizontal Scaling (Coordinators Only)
 
-Distribute workers across processes:
+The worker is a single process that owns the in-memory job queue and the SQLite-backed document store — it does not scale horizontally. What scales horizontally is the coordinator tier:
 
-- External worker deployment
-- Load balancer coordination
-- Independent worker scaling
-- Database connection pooling
+- Run multiple `web`/`mcp` coordinator replicas, each pointed at the same worker's `--server-url`
+- Coordinators are stateless; both document reads (`DocumentManagementClient`) and job dispatch (`PipelineClient`) proxy to the one worker over tRPC
+- Load balance across coordinator replicas, not worker replicas
 
-### Hybrid Deployment
+### Deployment Modes Are Exclusive
 
-Combine embedded and external workers:
-
-- Coordinator with embedded workers
-- Additional external workers for peak load
-- Flexible resource allocation
-- Cost-optimized scaling
+A deployment runs with either an embedded worker (`enableWorker: true`, standalone mode) or a single external worker (`--server-url`, distributed mode) — not both at once.

--- a/docs/infrastructure/deployment-modes.md
+++ b/docs/infrastructure/deployment-modes.md
@@ -35,15 +35,15 @@ Separate coordinator and worker processes for scaling. The coordinator handles i
 
 ### Architecture
 
-- **Coordinator**: Runs MCP server, web interface, and API
-- **Workers**: Execute document processing jobs
-- **Communication**: Coordinator uses the API (tRPC over HTTP) to talk to workers
+- **Coordinator**: Runs MCP server, web interface, and API; stateless, so multiple replicas can run at once
+- **Worker**: A single process that executes document processing jobs and owns the SQLite-backed document store
+- **Communication**: Coordinators use the API (tRPC over HTTP) to talk to the worker
 
 ### Use Cases
 
 - High-volume processing
 - Container orchestration (Kubernetes, Docker Swarm)
-- Horizontal scaling requirements
+- Scaling coordinator (web/MCP) replicas independently of the worker
 - Resource isolation
 
 ### Worker Management
@@ -133,18 +133,21 @@ services:
     command: ["worker", "--port", "8080"]
 ```
 
-## Load Balancing
+## Scaling
 
-### Multiple Workers
+### Coordinators Scale Horizontally
 
-Use a load balancer (or DNS) in front of multiple worker instances. The coordinator is configured with a single `--server-url` that points to the balancer.
+Coordinator (`web`/`mcp`) processes are stateless: both document reads and job dispatch proxy to the worker over tRPC. Run multiple coordinator replicas behind a load balancer (or DNS), each configured with the same worker's `--server-url`.
+
+### The Worker Does Not Scale Horizontally
+
+The worker owns the in-memory job queue and the SQLite-backed document store. There is no supported way to run multiple worker replicas against shared state today: a second worker has no visibility into jobs queued on the first, and SQLite's WAL-based locking model is designed for concurrent processes on one host's local filesystem, not multiple hosts sharing a file over a network volume. Scale the worker vertically instead.
 
 ### Health Checks
 
-Expose a lightweight `/health` endpoint or container healthcheck for load balancers and monitoring.
+Expose a lightweight `/health` endpoint or container healthcheck for coordinator and worker monitoring.
 
 ### Scaling Strategies
 
-- Horizontal: Add more worker containers
-- Vertical: Increase worker resource allocation
-- Hybrid: Combine both strategies based on workload
+- Horizontal: Add more coordinator (`web`/`mcp`) replicas in front of the one worker
+- Vertical: Increase worker concurrency (`maxConcurrency`) and resource allocation

--- a/docs/infrastructure/deployment-modes.md
+++ b/docs/infrastructure/deployment-modes.md
@@ -31,7 +31,7 @@ Services can be selectively enabled via AppServerConfig:
 
 ## Distributed Mode
 
-Separate coordinator and worker processes for scaling. The coordinator handles interfaces while workers process jobs.
+Separate coordinator and worker processes for scaling. The coordinator handles interfaces while the worker processes jobs.
 
 ### Architecture
 
@@ -48,7 +48,7 @@ Separate coordinator and worker processes for scaling. The coordinator handles i
 
 ### Worker Management
 
-Workers may expose a simple `/health` or container-level healthcheck for monitoring. Coordinators communicate with workers via Pipeline RPC.
+The worker may expose a simple `/health` or container-level healthcheck for monitoring. Coordinators communicate with the worker via Pipeline RPC.
 
 ## Protocol Auto-Detection
 
@@ -98,9 +98,9 @@ Job recovery behavior depends on deployment mode:
 
 ### Distributed Mode
 
-- Workers handle their own job recovery
+- The worker handles its own job recovery
 - Coordinators do not recover jobs to avoid conflicts
-- Each worker maintains independent job state
+- The worker maintains its own job state, independent of any coordinator
 
 ### CLI Commands
 
@@ -137,7 +137,7 @@ services:
 
 ### Coordinators Scale Horizontally
 
-Coordinator (`web`/`mcp`) processes are stateless: both document reads and job dispatch proxy to the worker over tRPC. Run multiple coordinator replicas behind a load balancer (or DNS), each configured with the same worker's `--server-url`.
+Coordinator (`web`/`mcp`) processes are stateless: both document reads and job dispatch proxy to the worker over tRPC. Run multiple coordinator replicas behind a load balancer (or DNS), each started with `--server-url` pointing at the same worker.
 
 ### The Worker Does Not Scale Horizontally
 


### PR DESCRIPTION
## Summary

- `deployment-modes.md` and `pipeline-architecture.md` claimed you can load-balance across multiple worker replicas, or run embedded + external workers together ("hybrid deployment"). Neither is implemented, and it directly contradicted `ARCHITECTURE.md`'s "shared worker" language.
- Verified against the code: `PipelineManager`'s job queue is in-process memory (`PipelineManager.ts`), only one worker process owns the SQLite-backed document store at a time, and `enableWorker`/`--server-url` are mutually exclusive (`mcp.ts`, `web.ts`, `worker.ts`) — so a coordinator always talks to exactly one worker.
- Rewrote the scaling sections in both docs to reflect what's actually true: the stateless `web`/`mcp` coordinator tier scales horizontally behind a load balancer; the worker does not (scale it vertically via `maxConcurrency` instead), in part because SQLite's WAL locking assumes one host's local filesystem, not multiple hosts sharing a file over a network volume.

## Test plan

- [x] `npm ci` (Node 22) + `npx biome check` on the two changed files — both are excluded from Biome's markdown checks, so no formatting drift
- [x] Pre-commit hook (`lint-staged`) ran clean
- [x] Manually cross-checked every claim in the reworded sections against `PipelineManager.ts`, `PipelineFactory.ts`, `mcp.ts`, `web.ts`, `worker.ts`, and `AppServer.ts`

Fixes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)