### PR TITLE
fix(ci): strip inline comments from docker metadata tags block

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,13 +163,21 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
-          # Use the version from the semantic-release output
+          # Use the version from the semantic-release output.
+          # NOTE: this is a YAML literal block scalar (`|`), so `#` here is NOT a YAML
+          # comment - it would be passed to the action as literal text and break tag
+          # parsing. Keep these lines free of inline comments.
+          #   type=raw,value=<version>              e.g. 2.4.3
+          #   type=semver,pattern={{version}}        e.g. 2.4.3
+          #   type=semver,pattern=v{{major}}.{{minor}}  e.g. v2.4
+          #   type=semver,pattern=v{{major}}         e.g. v2
+          #   type=raw,value=latest,enable=true      always tag latest on main branch release
           tags: |
-            type=raw,value=${{ needs.release.outputs.new_release_version }} # e.g., v1.4.1
-            type=semver,pattern={{version}},value=${{ needs.release.outputs.new_release_version }} # e.g., 1.4.1
-            type=semver,pattern=v{{major}}.{{minor}},value=${{ needs.release.outputs.new_release_version }} # e.g., v1.4
-            type=semver,pattern=v{{major}},value=${{ needs.release.outputs.new_release_version }} # e.g., v1
-            type=raw,value=latest,enable=true # Always tag latest on main branch release
+            type=raw,value=${{ needs.release.outputs.new_release_version }}
+            type=semver,pattern={{version}},value=${{ needs.release.outputs.new_release_version }}
+            type=semver,pattern=v{{major}}.{{minor}},value=${{ needs.release.outputs.new_release_version }}
+            type=semver,pattern=v{{major}},value=${{ needs.release.outputs.new_release_version }}
+            type=raw,value=latest,enable=true
 
       - name: Build and push Docker image
         id: push


### PR DESCRIPTION
## Summary
- The Docker publish job of the [Release workflow](https://github.com/arabold/docs-mcp-server/actions/runs/29924292713/job/88937627436) was failing at the "Extract Docker metadata" step.
- Root cause: the `tags:` input to `docker/metadata-action` uses a YAML literal block scalar (`|`), where `#` is **not** a YAML comment but literal text. The trailing `# e.g., ...` comments on each tag line were being sent to the action verbatim, corrupting the `enable`/`value` attributes it parses (e.g. `enable=true # Always tag latest on main branch release` fails strict boolean parsing).
- This bug was latent for a while but only became a hard failure after the `docker/metadata-action@v5 -> v6` bump ([7087ebb](https://github.com/arabold/docs-mcp-server/commit/7087ebb)), which validates the `enable` attribute more strictly.
- Fix: move the explanatory comments to real YAML comment lines above the block instead of inline within it.

## Side effect to be aware of
Because the job failed before the push step ran, the `v2.4.3` Docker image was never published to GHCR — `ghcr.io/arabold/docs-mcp-server:latest` still points at `2.4.2`. This PR only fixes the workflow going forward; publishing the missing `2.4.3` image is a separate follow-up.

## Test plan
- [x] Validated the modified YAML parses correctly (`js-yaml`)
- [ ] Confirm the "Build and Push Docker Image to GHCR" job succeeds on the next release run