### PR TITLE
fix(store): materialize vector search CTE to fix API wedge on large DBs (#454)

### DIFF
--- a/src/store/DocumentStore.ts
+++ b/src/store/DocumentStore.ts
@@ -2033,7 +2033,7 @@ export class DocumentStore {
         const vectorSearchK = overfetchLimit * this.vectorSearchMultiplier;
 
         const stmt = this.db.prepare(`
-          WITH vec_distances AS NOT MATERIALIZED (
+          WITH vec_distances AS MATERIALIZED (
             SELECT
               dv.rowid as id,
               dv.distance as vec_distance


### PR DESCRIPTION
## Summary

Fixes #454 — on large databases the server answers briefly after startup, then all tRPC/API routes (`/api/ping`, `getJobs`, `listLibraries`, search) stop responding within minutes, sometimes pegging CPU at 60–85% with no log output. Rolling back to 2.4.2 fixed it.

**Root cause:** a query-planner regression. The hybrid search statement declares its vector‑KNN CTE as `NOT MATERIALIZED`. Because the outer query is `FROM documents d … LEFT JOIN vec_distances`, that hint makes SQLite **re-run the KNN inline for every row of a full `documents` scan** instead of computing it once — so search cost becomes O(total documents in the DB). Since `better-sqlite3` is synchronous, a single slow search **blocks the entire event loop**, which is why unrelated endpoints hang and CPU pegs with no logs (static assets keep serving because they don't touch the query). Introduced in `2b4e886` (partition-key migration), first shipped in 2.4.4.

**Fix:** one line — `WITH vec_distances AS NOT MATERIALIZED (…)` → `AS MATERIALIZED (…)`. The KNN is computed once and joined. Results are identical; this is purely an execution-strategy change.

## Reproduction & evidence

Synthesized a 2.8 GB / 70‑partition / 68k‑vector database (matching the reporter's scale) and drove it through the HTTP API:

| | `NOT MATERIALIZED` (2.4.4) | `MATERIALIZED` (this PR) |
|---|---|---|
| Search query (SQL, `EXPLAIN` A/B) | **37,005 ms** | **144 ms** |
| Search end-to-end via API | ~40 s | ~0.5 s |
| `/api/ping` while a search runs | hangs ~40 s | 0.15 s (loop free) |

`EXPLAIN QUERY PLAN` confirms the mechanism: the slow plan inlines the vec-table scan into the 68k‑row `SCAN d`; the fast plan begins with `MATERIALIZE vec_distances` (computed once).

## Side effects / drawbacks

- **Behavior:** none. Result rows are identical in both plans (verified). This only changes how SQLite executes the query.
- **Memory:** negligible — materializes ≤ `vectorSearchK` (~150) rows of `{id, distance}`.
- **Small DBs:** no regression — the materialization overhead is sub-millisecond; on tiny datasets both plans are already fast.
- **Not fixed here (follow-up):** even with `MATERIALIZED`, the outer query still does one full `SCAN documents` per search (≈144 ms at 68k chunks; scales ~linearly with total DB size). This is not a wedge, but a future optimization could drive the outer query from the vec+FTS candidate set (~200 ids) instead of the whole table. Filed as a follow-up rather than blocking this fix.

## Testing

- `npx vitest run src/store/DocumentStore.test.ts test/vector-search-e2e.test.ts` → **76 passed** (search correctness unchanged).
- `npm run typecheck` clean.
- End-to-end verified against the 2.8 GB DB: search 40 s → ~0.5 s, server stays responsive during searches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
