### PR TITLE
fix(web): preserve complete remote worker endpoint

### DIFF
--- a/src/web/routes/index.test.tsx
+++ b/src/web/routes/index.test.tsx
@@ -1,0 +1,23 @@
+import Fastify from "fastify";
+import { describe, expect, it } from "vitest";
+import { registerIndexRoute } from "./index";
+
+describe("registerIndexRoute", () => {
+  it.each([
+    "http://worker:8080/api",
+    "http://worker:8080/api/",
+  ])("renders the complete remote worker endpoint for %s", async (serverUrl) => {
+    const server = Fastify();
+    registerIndexRoute(server, serverUrl);
+
+    const response = await server.inject({ method: "GET", url: "/" });
+    await server.close();
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toContain(
+      'window.__EVENT_CLIENT_CONFIG__ = {"useRemoteWorker":true,' +
+        '"trpcUrl":"http://worker:8080/api"};',
+    );
+    expect(response.body).not.toContain("/api/api");
+  });
+});

--- a/src/web/routes/index.test.tsx
+++ b/src/web/routes/index.test.tsx
@@ -10,14 +10,33 @@ describe("registerIndexRoute", () => {
     const server = Fastify();
     registerIndexRoute(server, serverUrl);
 
-    const response = await server.inject({ method: "GET", url: "/" });
-    await server.close();
+    try {
+      const response = await server.inject({ method: "GET", url: "/" });
 
-    expect(response.statusCode).toBe(200);
-    expect(response.body).toContain(
-      'window.__EVENT_CLIENT_CONFIG__ = {"useRemoteWorker":true,' +
-        '"trpcUrl":"http://worker:8080/api"};',
-    );
-    expect(response.body).not.toContain("/api/api");
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toContain(
+        'window.__EVENT_CLIENT_CONFIG__ = {"useRemoteWorker":true,' +
+          '"trpcUrl":"http://worker:8080/api"};',
+      );
+      expect(response.body).not.toContain("/api/api");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("omits the remote worker endpoint when it is empty", async () => {
+    const server = Fastify();
+    registerIndexRoute(server, "");
+
+    try {
+      const response = await server.inject({ method: "GET", url: "/" });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toContain(
+        'window.__EVENT_CLIENT_CONFIG__ = {"useRemoteWorker":false};',
+      );
+    } finally {
+      await server.close();
+    }
   });
 });

--- a/src/web/routes/index.tsx
+++ b/src/web/routes/index.tsx
@@ -16,7 +16,7 @@ export function registerIndexRoute(
 
     // Determine if we're using a remote worker
     const useRemoteWorker = Boolean(externalWorkerUrl);
-    const trpcUrl = externalWorkerUrl ? `${externalWorkerUrl}/api` : undefined;
+    const trpcUrl = externalWorkerUrl?.replace(/\/$/, "");
 
     // Use the Layout component and define the main content within it
     return (

--- a/src/web/routes/index.tsx
+++ b/src/web/routes/index.tsx
@@ -16,7 +16,9 @@ export function registerIndexRoute(
 
     // Determine if we're using a remote worker
     const useRemoteWorker = Boolean(externalWorkerUrl);
-    const trpcUrl = externalWorkerUrl?.replace(/\/$/, "");
+    const trpcUrl = externalWorkerUrl
+      ? externalWorkerUrl.replace(/\/$/, "")
+      : undefined;
 
     // Use the Layout component and define the main content within it
     return (


### PR DESCRIPTION
The documented `--server-url` contract expects the complete tRPC endpoint, including `/api`. The web UI appended another `/api`, so distributed deployments configured with a valid endpoint rendered `/api/api` in the browser configuration.

This passes the supplied endpoint through directly while matching the existing client normalization for a trailing slash. Regression coverage checks both `http://worker:8080/api` and `http://worker:8080/api/`.