### PR TITLE
refactor(web): remove unused event client config from rendered pages

### DIFF
--- a/src/app/AppServer.test.ts
+++ b/src/app/AppServer.test.ts
@@ -274,7 +274,6 @@ describe("AppServer Behavior Tests", () => {
         mockPipeline,
         eventBus,
         appConfig,
-        undefined,
       );
       expect(mockWorkerService.registerWorkerService).toHaveBeenCalledWith(mockPipeline);
       expect(mockMcpService.registerMcpService).not.toHaveBeenCalled();
@@ -368,7 +367,6 @@ describe("AppServer Behavior Tests", () => {
         mockPipeline,
         eventBus,
         appConfig,
-        undefined,
       );
       expect(mockMcpService.registerMcpService).toHaveBeenCalledWith(
         mockFastify,

--- a/src/app/AppServer.ts
+++ b/src/app/AppServer.ts
@@ -392,7 +392,6 @@ export class AppServer {
       this.pipeline,
       this.eventBus,
       this.appConfig,
-      this.serverConfig.externalWorkerUrl,
     );
 
     logger.debug("Web interface service enabled");

--- a/src/services/webService.ts
+++ b/src/services/webService.ts
@@ -37,7 +37,6 @@ export async function registerWebService(
   pipeline: IPipeline,
   eventBus: EventBusService,
   appConfig: AppConfig,
-  externalWorkerUrl?: string,
 ): Promise<void> {
   // Note: Web interface uses direct event tracking without session management
   // This approach provides meaningful analytics without the complexity of per-request sessions
@@ -54,7 +53,7 @@ export async function registerWebService(
   const clearCompletedJobsTool = new ClearCompletedJobsTool(pipeline);
 
   // Register all web routes
-  registerIndexRoute(server, externalWorkerUrl);
+  registerIndexRoute(server);
   registerLibrariesRoutes(server, listLibrariesTool, removeTool, refreshVersionTool);
   registerLibraryDetailRoutes(
     server,

--- a/src/web/EventClient.ts
+++ b/src/web/EventClient.ts
@@ -24,6 +24,10 @@ export class EventClient {
 
   /**
    * Start the SSE connection.
+   *
+   * The endpoint is relative to the coordinator serving this page. In
+   * distributed deployments RemoteEventProxy bridges the worker's events onto
+   * the coordinator's event bus, so the browser never needs the worker URL.
    */
   connect(): void {
     if (this.eventSource) {

--- a/src/web/components/Layout.tsx
+++ b/src/web/components/Layout.tsx
@@ -14,24 +14,14 @@ interface LayoutProps extends PropsWithChildren {
   title: string;
   /** Optional version string to display next to the title. */
   version?: string;
-  /** Event client configuration for real-time updates */
-  eventClientConfig?: {
-    useRemoteWorker: boolean;
-    trpcUrl?: string;
-  };
 }
 
 /**
  * Base HTML layout component for all pages.
  * Includes common head elements, header, and scripts.
- * @param props - Component props including title, version, children, and eventClientConfig.
+ * @param props - Component props including title, version, and children.
  */
-const Layout = ({
-  title,
-  version,
-  children,
-  eventClientConfig,
-}: LayoutProps) => {
+const Layout = ({ title, version, children }: LayoutProps) => {
   // Use provided version prop, or fall back to build-time injected version
   const versionString = version || __APP_VERSION__;
   const versionInitializer = `versionUpdate({ currentVersion: ${
@@ -281,11 +271,6 @@ const Layout = ({
         <div class="container max-w-2xl mx-auto px-4 py-6">
           <main>{children}</main>
         </div>
-
-        {/* Event client configuration */}
-        <script>
-          {`window.__EVENT_CLIENT_CONFIG__ = ${JSON.stringify(eventClientConfig)};`}
-        </script>
 
         {/* Bundled JS (includes Flowbite, HTMX, AlpineJS, and initialization) */}
         <script type="module" src="/assets/main.js"></script>

--- a/src/web/routes/index.test.tsx
+++ b/src/web/routes/index.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { registerIndexRoute } from "./index";
 
 describe("registerIndexRoute", () => {
-  it("serves the page shell with the containers HTMX hydrates", async () => {
+  it("renders the dashboard shell with the containers HTMX hydrates", async () => {
     const server = Fastify();
     registerIndexRoute(server);
 
@@ -15,22 +15,6 @@ describe("registerIndexRoute", () => {
       expect(response.body).toContain('hx-get="/web/stats"');
       expect(response.body).toContain('hx-get="/web/jobs"');
       expect(response.body).toContain('hx-get="/web/libraries"');
-    } finally {
-      await server.close();
-    }
-  });
-
-  it("does not embed worker connection details in the page", async () => {
-    const server = Fastify();
-    registerIndexRoute(server);
-
-    try {
-      const response = await server.inject({ method: "GET", url: "/" });
-
-      // The browser reaches real-time updates through this coordinator's SSE
-      // endpoint, which RemoteEventProxy feeds from the worker. It never talks
-      // to the worker directly, so the worker URL must not leak into the page.
-      expect(response.body).not.toContain("__EVENT_CLIENT_CONFIG__");
     } finally {
       await server.close();
     }

--- a/src/web/routes/index.test.tsx
+++ b/src/web/routes/index.test.tsx
@@ -3,38 +3,34 @@ import { describe, expect, it } from "vitest";
 import { registerIndexRoute } from "./index";
 
 describe("registerIndexRoute", () => {
-  it.each([
-    "http://worker:8080/api",
-    "http://worker:8080/api/",
-  ])("renders the complete remote worker endpoint for %s", async (serverUrl) => {
+  it("serves the page shell with the containers HTMX hydrates", async () => {
     const server = Fastify();
-    registerIndexRoute(server, serverUrl);
+    registerIndexRoute(server);
 
     try {
       const response = await server.inject({ method: "GET", url: "/" });
 
       expect(response.statusCode).toBe(200);
-      expect(response.body).toContain(
-        'window.__EVENT_CLIENT_CONFIG__ = {"useRemoteWorker":true,' +
-          '"trpcUrl":"http://worker:8080/api"};',
-      );
-      expect(response.body).not.toContain("/api/api");
+      expect(response.headers["content-type"]).toContain("text/html");
+      expect(response.body).toContain('hx-get="/web/stats"');
+      expect(response.body).toContain('hx-get="/web/jobs"');
+      expect(response.body).toContain('hx-get="/web/libraries"');
     } finally {
       await server.close();
     }
   });
 
-  it("omits the remote worker endpoint when it is empty", async () => {
+  it("does not embed worker connection details in the page", async () => {
     const server = Fastify();
-    registerIndexRoute(server, "");
+    registerIndexRoute(server);
 
     try {
       const response = await server.inject({ method: "GET", url: "/" });
 
-      expect(response.statusCode).toBe(200);
-      expect(response.body).toContain(
-        'window.__EVENT_CLIENT_CONFIG__ = {"useRemoteWorker":false};',
-      );
+      // The browser reaches real-time updates through this coordinator's SSE
+      // endpoint, which RemoteEventProxy feeds from the worker. It never talks
+      // to the worker directly, so the worker URL must not leak into the page.
+      expect(response.body).not.toContain("__EVENT_CLIENT_CONFIG__");
     } finally {
       await server.close();
     }

--- a/src/web/routes/index.tsx
+++ b/src/web/routes/index.tsx
@@ -5,32 +5,16 @@ import Layout from "../components/Layout";
 /**
  * Registers the root route that serves the main HTML page.
  * @param server - The Fastify instance.
- * @param externalWorkerUrl - Optional URL for external worker service.
  */
-export function registerIndexRoute(
-  server: FastifyInstance,
-  externalWorkerUrl?: string
-) {
+export function registerIndexRoute(server: FastifyInstance) {
   server.get("/", async (_, reply) => {
     reply.type("text/html");
-
-    // Determine if we're using a remote worker
-    const useRemoteWorker = Boolean(externalWorkerUrl);
-    const trpcUrl = externalWorkerUrl
-      ? externalWorkerUrl.replace(/\/$/, "")
-      : undefined;
 
     // Use the Layout component and define the main content within it
     return (
       "<!DOCTYPE html>" +
       (
-        <Layout
-          title="MCP Docs"
-          eventClientConfig={{
-            useRemoteWorker,
-            trpcUrl,
-          }}
-        >
+        <Layout title="MCP Docs">
           {/* Analytics Section */}
           <div
             id="analytics-stats"


### PR DESCRIPTION
Follow-up to #460.

Every rendered page embedded a `window.__EVENT_CLIENT_CONFIG__` global carrying `useRemoteWorker` and `trpcUrl`. Nothing ever read it.

The browser receives real-time updates over this coordinator's SSE endpoint at `/web/events`, which `RemoteEventProxy` feeds from the worker. It never talks to the worker directly, so it has no use for the worker URL — `EventClient` takes no configuration and hardcodes that relative endpoint.

Because the value was written but never read, it drifted unnoticed and rendered a malformed `/api/api` endpoint until #460 corrected it. This removes the global and the parameter threading behind it, so the class of bug goes away rather than just the instance.

## Changes

- Drop the `<script>` block that injected the global, and the `eventClientConfig` prop from `Layout`.
- Drop `externalWorkerUrl` from `registerIndexRoute` and `registerWebService`, and the argument `AppServer` passed in.
- Note on `EventClient.connect` why the SSE endpoint is coordinator-relative, where someone tempted to make it configurable will read it.
- Retarget the index route test at what the route now guarantees: it renders the dashboard shell, served as HTML, with the containers HTMX hydrates.

`externalWorkerUrl` **stays** on `AppServerConfig` — `RemoteEventProxy` and pipeline creation still depend on it. Only the branch that carried it into the web route is gone.

## On the test

An earlier revision of this PR also asserted the page does *not* contain `__EVENT_CLIENT_CONFIG__`. That test was vacuous: it only checked for the absence of a string, so a `500` from a broken `Layout` satisfied it too. Breaking `Layout` so every page errored confirmed it — that assertion stayed green while the shell test failed. It has been merged away rather than patched with status assertions, which would only have duplicated the remaining test.

This file is the only coverage that renders a web page at all (`AppServer.test.ts` asserts wiring against a mocked `registerWebService`), so the surviving test is worth having. Each of its assertions was mutation-checked to catch a distinct regression:

| Mutation | Caught by |
|---|---|
| drop `reply.type("text/html")` | content-type assertion |
| mistype an `hx-get` path | container assertions |
| throw during `Layout` render | status code assertion |

## Verification

- `npm run typecheck` and `npm run lint` clean.
- Full suite: 131 files, 1875 tests passing.
- Inspected the rendered page directly to confirm the tail is intact and the config block is gone: `</main></div><script type="module" src="/assets/main.js"></script></body></html>`.

No behavior change. Net -37 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)