### PR TITLE
fix(scraper): explain why local file access was blocked

### DIFF
--- a/docs/infrastructure/security.md
+++ b/docs/infrastructure/security.md
@@ -100,7 +100,8 @@ Traversal defaults:
 Important semantics:
 
 - `allowedRoots: []` in `allowedRoots` mode means no user-requested local file access is allowed.
-- `$DOCUMENTS`, `$DOWNLOADS`, and `$DESKTOP` are convenience tokens — they probe for `<home>/<Folder>` and grant no access if the directory is missing on the current platform or account.
+- `$DOCUMENTS`, `$DOWNLOADS`, and `$DESKTOP` are convenience tokens — they probe for `<home>/<Folder>` and grant no access if the directory is missing on the current platform or account. Each unresolved root is warned about, and an allowlist that grants nothing is reported as such, so a policy that blocks everything is never silent.
+- Rejections name the rule that blocked the path and link to the configuration documentation. Filesystem paths are logged rather than included in the error, since the error reaches MCP clients and the web UI; unresolvable configured paths are counted rather than named, because a missing path still describes an intended layout. Root tokens such as `$DOCUMENTS` are named in the error, since they are runtime state rather than host detail.
 - `$HOME` and `$CWD` resolve to a concrete path even when unusual; `$HOME` in particular exposes dotfile-bearing directories.
 - Hidden paths remain blocked even when explicitly requested unless `includeHidden` is enabled.
 

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -255,6 +255,20 @@ Supported tokens in `allowedRoots`:
 
 The default `[$DOCUMENTS]` root is aimed at trusted local use. For shared services, containers, or internet-exposed deployments, narrow `allowedRoots` to an application-owned directory or switch `mode` to `disabled`.
 
+Headless hosts and containers frequently have no `<home>/Documents`, which makes the default `[$DOCUMENTS]` resolve to nothing and blocks all `file://` indexing. That case is reported with the entries that failed to resolve:
+
+```
+Local file access is limited to configured roots, but none of its entries are available on this system ($DOCUMENTS did not resolve), so file:///srv/docs/ cannot be indexed. See https://github.com/arabold/docs-mcp-server/blob/main/docs/setup/configuration.md to configure the allowed roots.
+```
+
+Set `allowedRoots` to the folder you want to index:
+
+```bash
+export DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_ALLOWED_ROOTS=/srv/docs
+```
+
+Every blocked path reports which rule rejected it and links back to this page, rather than naming individual settings. Filesystem paths stay out of the error and are logged at warn level instead, because the error also reaches MCP clients and the web UI — configured paths that do not resolve are counted rather than named, since even a missing path describes the layout an operator intended. Root tokens such as `$DOCUMENTS` are named in the error: they are runtime state rather than host detail, and warn-level logs are suppressed on the non-interactive runs where this problem is most common.
+
 Internally managed temporary archive files created during accepted web archive scraping remain allowed even when they sit outside user-configured roots. That exception is limited to the downloaded archive artifact and its virtual members.
 
 ### Security Examples

--- a/src/utils/accessPolicy.test.ts
+++ b/src/utils/accessPolicy.test.ts
@@ -1,5 +1,13 @@
 import { vol } from "memfs";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockedFunction,
+  vi,
+} from "vitest";
 import type { AppConfig } from "./config";
 import { defaults as configDefaults } from "./config";
 import { AccessPolicyError } from "./errors";
@@ -13,6 +21,7 @@ vi.mock("node:dns/promises", () => ({
 
 import os from "node:os";
 import { expandConfiguredRoot, ScraperAccessPolicy } from "./accessPolicy";
+import { logger } from "./logger";
 
 type SecurityOverrides = {
   network?: Partial<AppConfig["scraper"]["security"]["network"]>;
@@ -502,6 +511,193 @@ describe("temp-archive bypass scoping", () => {
     await expect(
       policy.resolveFileAccess("file:///tmp/dl/docs.zip/.hidden/notes.md", ["/tmp/dl"]),
     ).rejects.toBeInstanceOf(AccessPolicyError);
+  });
+});
+
+describe("file access diagnostics", () => {
+  // `test/setup-env.ts` auto-mocks the logger, so `logger.warn` is a single
+  // shared mock whose call history outlives each test. Re-resolve and clear it
+  // per test rather than spying: caching the reference or layering a spy makes
+  // assertions depend on which mock instance the property currently holds.
+  let warn: MockedFunction<typeof logger.warn>;
+
+  beforeEach(() => {
+    vol.reset();
+    warn = vi.mocked(logger.warn);
+    warn.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("names the unresolved root token and points at the docs", async () => {
+    // The token goes in the error itself, not just a log line: WARN output is
+    // suppressed on non-TTY runs (containers, MCP stdio), which is exactly
+    // where an unresolvable $DOCUMENTS default bites. It is runtime state, not
+    // a config key, so no rename can invalidate it.
+    vi.spyOn(os, "homedir").mockReturnValue("/home/tester");
+    vol.fromJSON({ "/srv/docs/readme.md": "hello" });
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        fileAccess: { mode: "allowedRoots", allowedRoots: ["$DOCUMENTS"] },
+      }),
+    );
+
+    await expect(policy.resolveFileAccess("file:///srv/docs/readme.md")).rejects.toThrow(
+      /\$DOCUMENTS did not resolve.*configuration\.md/s,
+    );
+  });
+
+  it("never echoes a configured literal path, only tokens", async () => {
+    // Literal roots always expand (`path.resolve`), so a mixed config keeps the
+    // allowlist non-empty and the rejection is out-of-root. Either way the
+    // configured path must not travel back to an MCP or web caller.
+    vi.spyOn(os, "homedir").mockReturnValue("/home/tester");
+    vol.fromJSON({ "/srv/docs/readme.md": "hello" });
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        fileAccess: {
+          mode: "allowedRoots",
+          allowedRoots: ["$DOCUMENTS", "/mnt/acme-secrets/docs"],
+        },
+      }),
+    );
+
+    await expect(
+      policy.resolveFileAccess("file:///srv/docs/readme.md"),
+    ).rejects.not.toThrow(/acme-secrets/);
+  });
+
+  it("reports an empty allowlist distinctly from unresolvable entries", async () => {
+    vol.fromJSON({ "/srv/docs/readme.md": "hello" });
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        fileAccess: { mode: "allowedRoots", allowedRoots: [] },
+      }),
+    );
+
+    await expect(policy.resolveFileAccess("file:///srv/docs/readme.md")).rejects.toThrow(
+      /no roots are configured/,
+    );
+  });
+
+  it("warns once per unresolvable configured root", async () => {
+    vi.spyOn(os, "homedir").mockReturnValue("/home/tester");
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        fileAccess: { mode: "allowedRoots", allowedRoots: ["$DOCUMENTS", "$DOWNLOADS"] },
+      }),
+    );
+
+    await expect(
+      policy.resolveFileAccess("file:///srv/docs/readme.md"),
+    ).rejects.toBeInstanceOf(AccessPolicyError);
+    await expect(
+      policy.resolveFileAccess("file:///srv/docs/other.md"),
+    ).rejects.toBeInstanceOf(AccessPolicyError);
+
+    const unresolvedWarnings = warn.mock.calls
+      .map(([message]) => message)
+      .filter((message) => message.includes("Ignoring allowed file root"));
+    expect(unresolvedWarnings).toHaveLength(2);
+    expect(unresolvedWarnings.join("\n")).toContain("$DOCUMENTS");
+    expect(unresolvedWarnings.join("\n")).toContain("$DOWNLOADS");
+  });
+
+  it("warns that all local file access is blocked when the allowlist grants nothing", async () => {
+    vi.spyOn(os, "homedir").mockReturnValue("/home/tester");
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        fileAccess: { mode: "allowedRoots", allowedRoots: ["$DOCUMENTS"] },
+      }),
+    );
+
+    await expect(
+      policy.resolveFileAccess("file:///srv/docs/readme.md"),
+    ).rejects.toBeInstanceOf(AccessPolicyError);
+
+    expect(
+      warn.mock.calls.some(([message]) =>
+        message.includes("all file:// indexing is blocked"),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps allowed root paths out of the out-of-root error but logs them", async () => {
+    vol.fromJSON({
+      "/srv/allowed/readme.md": "hello",
+      "/srv/other/secret.md": "secret",
+    });
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        fileAccess: { mode: "allowedRoots", allowedRoots: ["/srv/allowed"] },
+      }),
+    );
+
+    await expect(policy.resolveFileAccess("file:///srv/other/secret.md")).rejects.toThrow(
+      /outside the configured allowed roots/,
+    );
+    await expect(
+      policy.resolveFileAccess("file:///srv/other/secret.md"),
+    ).rejects.not.toThrow(/\/srv\/allowed/);
+    expect(warn.mock.calls.some(([message]) => message.includes("/srv/allowed"))).toBe(
+      true,
+    );
+  });
+
+  it("states the rule when file access is disabled", async () => {
+    vol.fromJSON({ "/srv/docs/readme.md": "hello" });
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({ fileAccess: { mode: "disabled" } }),
+    );
+
+    await expect(policy.resolveFileAccess("file:///srv/docs/readme.md")).rejects.toThrow(
+      /disabled by the scraper security policy.*configuration\.md/s,
+    );
+  });
+
+  it("states the rule when a symlink blocks access", async () => {
+    vol.fromJSON({ "/srv/allowed/real.md": "hello" });
+    await vol.promises.symlink("/srv/allowed/real.md", "/srv/allowed/link.md");
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        fileAccess: { mode: "allowedRoots", allowedRoots: ["/srv/allowed"] },
+      }),
+    );
+
+    await expect(policy.resolveFileAccess("file:///srv/allowed/link.md")).rejects.toThrow(
+      /resolves through a symlink.*configuration\.md/s,
+    );
+  });
+
+  it("states the rule when a hidden segment blocks access", async () => {
+    vol.fromJSON({ "/srv/allowed/.private/readme.md": "hello" });
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        fileAccess: { mode: "allowedRoots", allowedRoots: ["/srv/allowed"] },
+      }),
+    );
+
+    await expect(
+      policy.resolveFileAccess("file:///srv/allowed/.private/readme.md"),
+    ).rejects.toThrow(/hidden path segment.*configuration\.md/s);
+  });
+
+  it("does not warn about internal bypass roots that do not resolve", async () => {
+    vol.fromJSON({ "/srv/allowed/readme.md": "hello" });
+    const policy = new ScraperAccessPolicy(
+      createSecurityConfig({
+        fileAccess: { mode: "allowedRoots", allowedRoots: ["/srv/allowed"] },
+      }),
+    );
+
+    await expect(
+      policy.resolveFileAccess("file:///srv/allowed/readme.md", ["$DOWNLOADS"]),
+    ).resolves.toMatchObject({ filePath: "/srv/allowed/readme.md" });
+    expect(warn.mock.calls.some(([message]) => message.includes("$DOWNLOADS"))).toBe(
+      false,
+    );
   });
 });
 

--- a/src/utils/accessPolicy.ts
+++ b/src/utils/accessPolicy.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { matchesAnyHostPattern } from "../scraper/utils/patternMatcher";
 import type { AppConfig } from "./config";
 import { AccessPolicyError } from "./errors";
+import { logger } from "./logger";
 
 const SPECIAL_USE_IPV4_CIDRS = [
   "0.0.0.0/8",
@@ -28,6 +29,19 @@ const SPECIAL_USE_IPV6_CIDRS = ["::/128", "::1/128", "fc00::/7", "fe80::/10", "f
 
 const ARCHIVE_EXTENSIONS = new Set([".zip", ".tar", ".gz", ".tgz"]);
 
+/**
+ * Where users go to change file access decisions.
+ *
+ * Rejections state which rule blocked the path and point here, rather than
+ * naming individual settings and environment variables. Every setting named in
+ * an error is one more thing a rename can silently invalidate, and the docs
+ * carry the full picture — config file, env vars, and tokens — in one place
+ * that is already maintained. Deep-linked without an anchor on purpose: a stale
+ * anchor fails quietly.
+ */
+const FILE_ACCESS_DOCS =
+  "https://github.com/arabold/docs-mcp-server/blob/main/docs/setup/configuration.md";
+
 type ScraperSecurityConfig = AppConfig["scraper"]["security"];
 
 export interface ResolvedFileAccess {
@@ -43,6 +57,10 @@ export class ScraperAccessPolicy {
   private readonly allowedCidrs = new net.BlockList();
   private readonly specialUseCidrs = new net.BlockList();
   private readonly allowedHosts: string[];
+  /** Roots already reported as unresolvable, so each is warned about once. */
+  private readonly warnedUnresolvedRoots = new Set<string>();
+  private hasWarnedUnavailableAllowlist = false;
+  private hasLoggedConfiguredRoots = false;
 
   constructor(private readonly security: ScraperSecurityConfig) {
     this.allowedHosts = security.network.allowedHosts;
@@ -146,6 +164,15 @@ export class ScraperAccessPolicy {
 
   /**
    * Resolves and validates a file URL against the configured file access policy.
+   *
+   * Rejections name the specific policy rule that blocked the path and link to
+   * the configuration documentation rather than naming individual settings.
+   * Filesystem paths — configured or resolved — stay out of the thrown message
+   * because it reaches MCP clients and the web UI; they are logged instead,
+   * where only the operator sees them. Root tokens such as `$DOCUMENTS` are
+   * named in the message: they are runtime state rather than host detail, and
+   * warn-level logs are suppressed on the non-interactive runs where an
+   * unresolvable token is most likely.
    */
   async resolveFileAccess(
     url: string,
@@ -164,16 +191,24 @@ export class ScraperAccessPolicy {
     let matchedRoot: string | null = matchedBypassRoot;
 
     if (this.security.fileAccess.mode === "disabled" && !matchedBypassRoot) {
-      throw new AccessPolicyError(`Security policy blocked local file access for ${url}`);
+      throw new AccessPolicyError(
+        `Local file access is disabled by the scraper security policy, so ${url} cannot be indexed. ` +
+          `See ${FILE_ACCESS_DOCS} to configure local file access.`,
+      );
     }
 
     if (this.security.fileAccess.mode === "allowedRoots" && !matchedBypassRoot) {
       const configuredRoots = await this.expandRoots(
         this.security.fileAccess.allowedRoots,
+        true,
       );
       if (configuredRoots.length === 0) {
+        this.warnUnavailableAllowlist();
         throw new AccessPolicyError(
-          `Security policy blocked local file access for ${url}`,
+          `Local file access is limited to configured roots, but ${describeUnavailableRoots(
+            this.security.fileAccess.allowedRoots,
+          )}, so ${url} cannot be indexed. ` +
+            `See ${FILE_ACCESS_DOCS} to configure the allowed roots.`,
         );
       }
 
@@ -183,8 +218,10 @@ export class ScraperAccessPolicy {
         this.security.fileAccess.followSymlinks,
       );
       if (!matchedRoot) {
+        this.logConfiguredRoots(configuredRoots);
         throw new AccessPolicyError(
-          `Security policy blocked local file access for ${url}`,
+          `${url} is outside the configured allowed roots, so it cannot be indexed. ` +
+            `See ${FILE_ACCESS_DOCS} to allow this folder.`,
         );
       }
     }
@@ -192,7 +229,10 @@ export class ScraperAccessPolicy {
     if (!this.security.fileAccess.followSymlinks && !matchedBypassRoot) {
       const symlinkPath = await findSymlinkInPath(accessPath);
       if (symlinkPath) {
-        throw new AccessPolicyError(`Security policy blocked symlink access for ${url}`);
+        throw new AccessPolicyError(
+          `${url} resolves through a symlink, which the security policy blocks by default, so it cannot be indexed. ` +
+            `See ${FILE_ACCESS_DOCS} to allow symlinked paths.`,
+        );
       }
     }
 
@@ -205,7 +245,8 @@ export class ScraperAccessPolicy {
       // the full absolute path.
       if (hasHiddenSegmentBelowRoot(filePath, matchedRoot)) {
         throw new AccessPolicyError(
-          `Security policy blocked hidden file access for ${url}`,
+          `${url} contains a hidden path segment (a name starting with "."), which the security policy blocks by default, ` +
+            `so it cannot be indexed. See ${FILE_ACCESS_DOCS} to allow hidden files and folders.`,
         );
       }
       if (
@@ -213,7 +254,8 @@ export class ScraperAccessPolicy {
         hasHiddenArchiveSegment(resolved.virtualArchivePath)
       ) {
         throw new AccessPolicyError(
-          `Security policy blocked hidden archive entry access for ${url}`,
+          `The archive entry requested by ${url} is hidden (a name starting with "."), which the security policy blocks by default. ` +
+            `See ${FILE_ACCESS_DOCS} to allow hidden archive entries.`,
         );
       }
     }
@@ -262,15 +304,63 @@ export class ScraperAccessPolicy {
     );
   }
 
-  private async expandRoots(roots: string[]): Promise<string[]> {
+  /**
+   * Expands configured root entries into concrete paths, dropping those that do
+   * not resolve on this system. With `warnOnUnresolved`, every dropped entry is
+   * reported once — silently discarding them makes `allowedRoots` look active
+   * when it grants nothing.
+   */
+  private async expandRoots(
+    roots: string[],
+    warnOnUnresolved = false,
+  ): Promise<string[]> {
     const expanded: string[] = [];
     for (const root of roots) {
       const value = await expandConfiguredRoot(root);
       if (value) {
         expanded.push(value);
+        continue;
+      }
+      if (warnOnUnresolved && !this.warnedUnresolvedRoots.has(root)) {
+        this.warnedUnresolvedRoots.add(root);
+        logger.warn(
+          `⚠️  Ignoring allowed file root "${root}": it does not resolve to an existing directory on this system.`,
+        );
       }
     }
     return expanded;
+  }
+
+  /**
+   * Warns that `allowedRoots` mode is active but grants nothing, which blocks
+   * all local file access. Emitted once per policy instance.
+   */
+  private warnUnavailableAllowlist(): void {
+    if (this.hasWarnedUnavailableAllowlist) return;
+    this.hasWarnedUnavailableAllowlist = true;
+
+    // Operator-facing log: naming the configured entries is safe here and is
+    // the fastest way to see why the allowlist came up empty.
+    const configured = this.security.fileAccess.allowedRoots;
+    const cause =
+      configured.length === 0
+        ? "no roots are configured"
+        : `none of the configured roots (${configured.join(", ")}) exist on this system`;
+    logger.warn(
+      `⚠️  Local file access is limited to configured roots, but ${cause}, so all file:// indexing is blocked. ` +
+        `See ${FILE_ACCESS_DOCS} to configure the allowed roots.`,
+    );
+  }
+
+  /**
+   * Logs the roots that local file access is limited to. Emitted once per policy
+   * instance, alongside the first out-of-root rejection.
+   */
+  private logConfiguredRoots(roots: string[]): void {
+    if (this.hasLoggedConfiguredRoots) return;
+    this.hasLoggedConfiguredRoots = true;
+
+    logger.warn(`⚠️  Local file access is limited to: ${roots.join(", ")}`);
   }
 
   private async findContainingRoot(
@@ -345,6 +435,38 @@ const USER_DIR_TOKENS: Record<string, string> = {
   $DOWNLOADS: "Downloads",
   $DESKTOP: "Desktop",
 };
+
+const ROOT_TOKENS = new Set(["$HOME", "$CWD", ...Object.keys(USER_DIR_TOKENS)]);
+
+/**
+ * Describes why an `allowedRoots` allowlist grants no access, for an error that
+ * also reaches MCP clients and the web UI.
+ *
+ * Configured tokens are named because they are fixed vocabulary that says
+ * nothing about the host. Literal paths are only counted: even a path that does
+ * not exist reveals the layout an operator intended, so `/mnt/acme-secrets/docs`
+ * must not travel back to a caller.
+ *
+ * Today `expandConfiguredRoot` resolves literal paths unconditionally, so only
+ * tokens reach this function and the count stays at zero. The branch guards the
+ * day that changes — validating literal roots must not start leaking them.
+ */
+function describeUnavailableRoots(configured: string[]): string {
+  if (configured.length === 0) {
+    return "no roots are configured";
+  }
+
+  const tokens = configured.filter((root) => ROOT_TOKENS.has(root));
+  const literalCount = configured.length - tokens.length;
+  const parts: string[] = [];
+  if (tokens.length > 0) {
+    parts.push(`${tokens.join(", ")} did not resolve`);
+  }
+  if (literalCount > 0) {
+    parts.push(`${literalCount} configured path(s) do not exist`);
+  }
+  return `none of its entries are available on this system (${parts.join("; ")})`;
+}
 
 /**
  * Expands user-facing configured root tokens into concrete filesystem paths.


### PR DESCRIPTION
Closes #462. Diagnoses the failure reported in #459.

## Problem

Every local file rejection threw the same opaque string:

```
AccessPolicyError: Security policy blocked local file access for file:///home/ubuntu/
```

Four distinct causes collapsed into one message that named neither the active mode, nor the allowed roots, nor where to look.

Worse, `$DOCUMENTS`, `$DOWNLOADS`, and `$DESKTOP` resolve to `null` when the directory does not exist, and `expandRoots` dropped them silently. With the default `allowedRoots: ["$DOCUMENTS"]` on a headless host or container — where `~/Documents` usually does not exist — the allowlist expands to zero roots and blocks *every* `file://` path, with nothing in the output to say so. That is what #459 hit.

## Changes

**Cause-specific errors.** Each rejection states the rule that blocked the path and links to the configuration documentation: mode disabled, allowlist grants nothing, path outside roots, symlink, hidden segment, hidden archive entry.

Before:

```
Security policy blocked local file access for file:///srv/docs/
```

After:

```
Local file access is limited to configured roots, but none of its entries are available on this system ($DOCUMENTS did not resolve), so file:///srv/docs/ cannot be indexed. See https://github.com/arabold/docs-mcp-server/blob/main/docs/setup/configuration.md to configure the allowed roots.
```

**Warnings for unresolved roots.** Each configured root that fails to resolve is warned about once, and an `allowedRoots` mode that ends up granting nothing reports itself rather than failing silently.

## What a reviewer should look at

**Messages point at docs, not settings.** An earlier revision named the specific config key and env var per rejection. That is more maintenance than it is worth — every named setting is one a rename can silently invalidate, in text whose only job is telling users what to change. Errors now carry the rule plus one docs link, and the documentation holds the config file, env vars, and tokens in one maintained place.

The one exception is the unresolved root token (`$DOCUMENTS did not resolve`). It reads like a config reference but is runtime state: no rename can invalidate it, and it is the diagnosis the docs cannot give, since it depends on the user's machine.

**Where paths appear.** The error reaches MCP clients and the web UI, so filesystem paths stay out of it and are logged at warn level instead, where only the operator sees them. Unresolvable *configured* paths are counted rather than named — a missing path still describes an intended layout. Naming tokens is safe by the same reasoning as above.

Worth knowing: that path-disclosure branch is not reachable today. `expandConfiguredRoot` resolves literal paths unconditionally via `path.resolve`, so only tokens can land there. The guard exists so that validating literal roots later does not silently start leaking them.

**Out of scope, deliberately.** The default `allowedRoots` is unchanged, and CLI-provided paths get no implicit allowance. Granting the same URL via CLI but denying it via MCP would make the policy harder to reason about; if we revisit it, it should be its own change.

## Testing

- 10 new tests in `src/utils/accessPolicy.test.ts` covering each rejection cause, the warn-once behaviour, that configured paths stay out of errors, and that internal temp-archive bypass roots never trigger root warnings.
- Verified against the real CLI: unresolvable `$DOCUMENTS`, out-of-root path, and `mode: disabled` each print the intended message.
- Full suite green (1884 tests), including Docker E2E in CI.

Note: `npm run lint` and `npm run typecheck` report pre-existing failures on this base (5 format, 3 TS) in files this PR does not touch; the touched files are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
