### PR TITLE
fix(embeddings): request float encoding for OpenAI-compatible providers

### DIFF
--- a/src/store/embeddings/EmbeddingFactory.test.ts
+++ b/src/store/embeddings/EmbeddingFactory.test.ts
@@ -191,6 +191,16 @@ describe("createEmbeddingModel", () => {
     });
   });
 
+  test("should request float encoding for OpenAI-compatible providers", () => {
+    // Regression guard for #469: without an explicit encodingFormat the OpenAI SDK
+    // sends `encoding_format: "base64"` and then base64-decodes the reply. Providers
+    // that ignore the parameter return JSON floats, which decode into an all-zero
+    // vector a quarter of the native length.
+    const model = createEmbeddingModel("openai:mistral-embed", runtimeConfig);
+    expect(model).toBeInstanceOf(OpenAIEmbeddings);
+    expect(model).toMatchObject({ encodingFormat: "float" });
+  });
+
   describe("OPENAI_API_BASE handling", () => {
     test("should use sanitized OPENAI_API_BASE values", () => {
       const env = {

--- a/src/store/embeddings/EmbeddingFactory.test.ts
+++ b/src/store/embeddings/EmbeddingFactory.test.ts
@@ -1,3 +1,5 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { BedrockEmbeddings } from "@langchain/aws";
 import { GoogleGenerativeAIEmbeddings } from "@langchain/google-genai";
 import { VertexAIEmbeddings } from "@langchain/google-vertexai";
@@ -199,6 +201,78 @@ describe("createEmbeddingModel", () => {
     const model = createEmbeddingModel("openai:mistral-embed", runtimeConfig);
     expect(model).toBeInstanceOf(OpenAIEmbeddings);
     expect(model).toMatchObject({ encodingFormat: "float" });
+  });
+
+  describe("providers that ignore encoding_format", () => {
+    /**
+     * Stands in for Mistral / LM Studio / Ollama: accepts `encoding_format` and
+     * then ignores it, always replying with JSON float arrays. Reproduces #469
+     * without needing an API key or a paid provider.
+     */
+    function startProvider(nativeDimension: number) {
+      const received: Array<string | undefined> = [];
+      const server = createServer((req, res) => {
+        let body = "";
+        req.on("data", (chunk) => {
+          body += chunk;
+        });
+        req.on("end", () => {
+          received.push(JSON.parse(body || "{}").encoding_format);
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              object: "list",
+              model: "mistral-embed",
+              data: [
+                {
+                  object: "embedding",
+                  index: 0,
+                  embedding: Array.from(
+                    { length: nativeDimension },
+                    (_, i) => Math.sin(i + 1) * 0.05,
+                  ),
+                },
+              ],
+              usage: { prompt_tokens: 1, total_tokens: 1 },
+            }),
+          );
+        });
+      });
+      return { server, received };
+    }
+
+    test("should store full-length non-zero vectors from a float-only provider", async () => {
+      const nativeDimension = 1024;
+      const { server, received } = startProvider(nativeDimension);
+      await new Promise<void>((resolve) =>
+        server.listen(0, "127.0.0.1", () => resolve()),
+      );
+      const { port } = server.address() as AddressInfo;
+
+      try {
+        vi.stubGlobal("process", {
+          env: {
+            OPENAI_API_KEY: "test-openai-key",
+            OPENAI_API_BASE: `http://127.0.0.1:${port}/v1`,
+          },
+        });
+
+        const model = createEmbeddingModel("openai:mistral-embed", {
+          vectorDimension: nativeDimension,
+        });
+        const vector = await model.embedQuery("test");
+
+        // Pre-fix, the OpenAI SDK sent `encoding_format: "base64"` and then
+        // base64-decoded the JSON floats, yielding 256 zeros instead of 1024
+        // values — silently, with no error raised.
+        expect(received).toEqual(["float"]);
+        expect(vector).toHaveLength(nativeDimension);
+        expect(vector.every((value) => value === 0)).toBe(false);
+        expect(vector.filter((value) => value !== 0)).toHaveLength(nativeDimension);
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    });
   });
 
   describe("OPENAI_API_BASE handling", () => {

--- a/src/store/embeddings/EmbeddingFactory.ts
+++ b/src/store/embeddings/EmbeddingFactory.ts
@@ -153,6 +153,13 @@ export function createEmbeddingModel(
           modelName: model,
           batchSize: 512, // OpenAI supports large batches
           timeout: requestTimeoutMs,
+          // Request plain float arrays instead of letting the OpenAI SDK pick its
+          // default. Without this the SDK sends `encoding_format: "base64"` and then
+          // unconditionally base64-decodes the response. OpenAI-compatible providers
+          // that ignore the parameter (Mistral, LM Studio, Ollama, ...) return JSON
+          // floats, which the decoder mangles into a silently corrupted vector of a
+          // quarter the length and every element zero.
+          encodingFormat: "float",
         };
       // Add custom base URL if specified
       const baseURL = process.env.OPENAI_API_BASE;


### PR DESCRIPTION
## Problem

`OpenAIEmbeddings` was constructed without `encodingFormat`, so `@langchain/openai` omitted `encoding_format` from the request. The underlying `openai` SDK then **silently defaults to `base64`** and unconditionally base64-decodes the response:

```js
// node_modules/openai/resources/embeddings.js:27
let encoding_format = hasUserProvidedEncodingFormat ? body.encoding_format : 'base64';
```

OpenAI-compatible providers that ignore the parameter (Mistral, LM Studio, Ollama, …) return JSON float arrays instead. `toFloat32Array` then runs `Buffer.from(floatArray, 'base64')`, where Node ignores the encoding and coerces each element to a byte. Embedding values lie in `[-1, 1]`, so **every byte becomes zero** — producing a vector a quarter of the native length with every element zero, and no error raised.

## Root cause of two reported issues — neither a v3.0.0 regression

**#469 — all-zero stored vectors.** `padVector` pads the corrupt 256-dim vector back to the configured 1024, so the stored embedding is all-zero at the correct length. Cosine similarity becomes meaningless and RRF scores collapse to a uniform ~0.03, degrading search to full-text fallback.

**#429 — the "exact 1/4 dimension truncation"** (1024 → 256, 768 → 192). That issue hypothesised a `testEmbedding.length / 4` in the code. There is no division by four anywhere; the ratio is bytes-per-float. `detectEmbeddingDimension` returned `testVector.length` of an *already-corrupted* probe vector. #431 aligned the database dimension with that corrupt probe rather than fixing the decode, so the underlying defect survived.

`api.openai.com` honors `encoding_format` and was never affected, which is why this went unnoticed for so long.

## Fix

Set `encodingFormat: "float"` when constructing `OpenAIEmbeddings`, making the request explicit so the SDK returns the provider's floats untouched.

Scoped deliberately to the `openai` provider. Azure honors the parameter, so forcing it in `AzureOpenAIEmbeddings` would add risk for older `AZURE_OPENAI_API_VERSION` values with no reported benefit.

## Verification

Measured against a local OpenAI-compatible server that accepts `encoding_format` and then ignores it, always returning JSON floats — exactly Mistral's behaviour, with a native dimension of 1024:

| | `encoding_format` sent | Dimensions | Non-zero | Verdict |
|---|---|---|---|---|
| Before fix | `base64` | 256 | 0 (0.0%) | ❌ corrupted |
| After fix | `float` | 1024 | 1024 (100.0%) | ✅ correct |

This is now committed as an integration test, so it runs in CI with no API key and no paid provider.

**Note on verifying with a real OpenAI key:** it cannot catch this bug. Checked against `api.openai.com` with `text-embedding-3-small`, both the pre-fix and post-fix code paths return 1536 dimensions with 100% non-zero values — identical results, because OpenAI honors `encoding_format`. Only a provider that ignores the parameter exposes the defect.

- Full suite on Node 22: **132 files, 1918 tests passing**. Typecheck and lint clean.
- Both new tests verified to fail without the fix and pass with it.
- `npm run test:docker`: 6 tests passing (image builds and runs; does not exercise this code path).

## Upgrade notes for maintainers

Two things worth deciding on separately from this PR:

1. **Affected users must fully re-scrape.** `refresh_version` only reprocesses changed pages and will not regenerate stored embeddings, so the all-zero vectors persist until a full re-scrape.

2. **Users who never set `DOCS_MCP_EMBEDDINGS_VECTOR_DIMENSION` explicitly will hit a hard error** (the #429 / LM Studio case). Their database was created at the corrupt 256d. After this fix the probe correctly returns 1024, `DocumentStore.ts:744` restores `dbDimension = 256` from metadata, and `padVector` throws `Vector dimension 1024 exceeds database dimension 256`. The model spec is unchanged, so model-change detection does not catch it. Users who *did* set the dimension explicitly (as in #469) are unaffected beyond needing the re-scrape.

A follow-up guarding against all-zero embeddings would catch this whole class of silent corruption for other providers; left out here to keep the fix reviewable.

Fixes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)
