### PR TITLE
feat(mcp): add include/exclude pattern support to scrape_docs

### DIFF
--- a/src/mcp/mcpServer.test.ts
+++ b/src/mcp/mcpServer.test.ts
@@ -132,7 +132,7 @@ describe("MCP Server Read-Only Mode", () => {
     const args = scrapeTool.inputSchema.parse({
       url: "https://example.com",
       library: "example-lib",
-      includePatterns: "/version-v0.3/",
+      includePatterns: "/version-v0.3/, /versioned_docs/version-v0.3/",
       excludePatterns: ["/exclude/"],
     });
     await scrapeTool.handler(args);
@@ -140,10 +140,45 @@ describe("MCP Server Read-Only Mode", () => {
     expect(mockTools.scrape.execute).toHaveBeenCalledWith(
       expect.objectContaining({
         options: expect.objectContaining({
-          includePatterns: ["/version-v0.3/"],
+          includePatterns: ["/version-v0.3/", "/versioned_docs/version-v0.3/"],
           excludePatterns: ["/exclude/"],
         }),
       }),
     );
+  });
+
+  it("should split comma-separated pattern strings without breaking regex constructs", () => {
+    const server = createMcpServerInstance(mockTools, mockConfig);
+    const scrapeTool = (server as any)._registeredTools.scrape_docs;
+    const parse = (includePatterns: string) =>
+      scrapeTool.inputSchema.parse({
+        url: "https://example.com",
+        library: "example-lib",
+        includePatterns,
+      }).includePatterns;
+
+    // Comma inside a regex quantifier is preserved
+    expect(parse("/\\/v\\d{1,3}\\//")).toEqual(["/\\/v\\d{1,3}\\//"]);
+
+    // Comma inside glob brace expansion is preserved
+    expect(parse("**/*.{js,ts}")).toEqual(["**/*.{js,ts}"]);
+
+    // Comma inside a character class is preserved
+    expect(parse("/docs/[a-z,0-9]+/")).toEqual(["/docs/[a-z,0-9]+/"]);
+
+    // Top-level commas split into multiple patterns
+    expect(parse("/version-v0.3/, /versioned_docs/version-v0.3/")).toEqual([
+      "/version-v0.3/",
+      "/versioned_docs/version-v0.3/",
+    ]);
+
+    // Escaped commas are treated as literal commas, not separators
+    expect(parse("/docs/v1\\,2/")).toEqual(["/docs/v1\\,2/"]);
+
+    // Empty segments are dropped
+    expect(parse("/version-v0.3/, , /version-v0.2/")).toEqual([
+      "/version-v0.3/",
+      "/version-v0.2/",
+    ]);
   });
 });

--- a/src/mcp/mcpServer.test.ts
+++ b/src/mcp/mcpServer.test.ts
@@ -104,4 +104,46 @@ describe("MCP Server Read-Only Mode", () => {
       }),
     );
   });
+
+  it("should normalize includePatterns/excludePatterns to string arrays", async () => {
+    const server = createMcpServerInstance(mockTools, mockConfig);
+    const scrapeTool = (server as any)._registeredTools.scrape_docs;
+
+    // Single pattern passed as a string stays whole, commas preserved
+    const single = scrapeTool.inputSchema.parse({
+      url: "https://example.com",
+      library: "example-lib",
+      includePatterns: "/\\/v\\d{1,3}\\//",
+    });
+    expect(single.includePatterns).toEqual(["/\\/v\\d{1,3}\\//"]);
+
+    // Multiple patterns passed as an array are kept as-is
+    const multiple = scrapeTool.inputSchema.parse({
+      url: "https://example.com",
+      library: "example-lib",
+      includePatterns: ["/version-v0.3/", "/versioned_docs/version-v0.3/"],
+    });
+    expect(multiple.includePatterns).toEqual([
+      "/version-v0.3/",
+      "/versioned_docs/version-v0.3/",
+    ]);
+
+    // The handler receives the normalized array and propagates it to the scraper
+    const args = scrapeTool.inputSchema.parse({
+      url: "https://example.com",
+      library: "example-lib",
+      includePatterns: "/version-v0.3/",
+      excludePatterns: ["/exclude/"],
+    });
+    await scrapeTool.handler(args);
+
+    expect(mockTools.scrape.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          includePatterns: ["/version-v0.3/"],
+          excludePatterns: ["/exclude/"],
+        }),
+      }),
+    );
+  });
 });

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -10,6 +10,22 @@ import type { McpServerTools } from "./tools";
 import { createError, createResponse } from "./utils";
 
 /**
+ * Splits a comma-separated pattern string into an array of trimmed, non-empty
+ * patterns. MCP tool arguments arrive as a single string; the scraper expects
+ * an array.
+ * @param patterns The raw comma-separated pattern string.
+ * @returns An array of patterns, or undefined if no patterns were provided.
+ */
+function splitPatterns(patterns: string | undefined): string[] | undefined {
+  if (patterns === undefined) return undefined;
+  const items = patterns
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean);
+  return items.length > 0 ? items : undefined;
+}
+
+/**
  * Creates and configures an instance of the MCP server with registered tools and resources.
  * @param tools The shared tool instances to use for server operations.
  * @param config The application configuration.
@@ -71,6 +87,18 @@ export function createMcpServerInstance(
           .boolean()
           .optional()
           .describe("Preserve hash fragments for hash-routed SPA documentation sites."),
+        includePatterns: z
+          .string()
+          .optional()
+          .describe(
+            "Comma-separated patterns for including URLs during scraping. Regex patterns must be wrapped in slashes, e.g. /pattern/. If not set, all are included by default.",
+          ),
+        excludePatterns: z
+          .string()
+          .optional()
+          .describe(
+            "Comma-separated patterns for excluding URLs during scraping. Exclude takes precedence over include. Regex patterns must be wrapped in slashes, e.g. /pattern/.",
+          ),
       },
       {
         title: "Scrape New Library Documentation",
@@ -86,6 +114,8 @@ export function createMcpServerInstance(
         scope,
         followRedirects,
         preserveHashes,
+        includePatterns,
+        excludePatterns,
       }) => {
         // Track MCP tool usage
         telemetry.track(TelemetryEvent.TOOL_USED, {
@@ -113,6 +143,8 @@ export function createMcpServerInstance(
               scope,
               followRedirects,
               preserveHashes,
+              includePatterns: splitPatterns(includePatterns),
+              excludePatterns: splitPatterns(excludePatterns),
             },
           });
 

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -10,15 +10,59 @@ import type { McpServerTools } from "./tools";
 import { createError, createResponse } from "./utils";
 
 /**
+ * Splits a comma-separated pattern string into an array of patterns. Commas
+ * inside `{}`, `[]`, or `()` (regex quantifiers, glob brace expansion,
+ * character classes) and escaped commas (`\,`) are preserved so that a single
+ * regex or glob pattern is never torn apart. This keeps the argument
+ * renderable as one string for MCP clients that only display primitive tool
+ * arguments.
+ * @param value The raw pattern string.
+ * @returns An array of trimmed, non-empty patterns.
+ */
+function splitPatterns(value: string): string[] {
+  const patterns: string[] = [];
+  let current = "";
+  let braces = 0;
+  let brackets = 0;
+  let parens = 0;
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    if (ch === "\\") {
+      if (i + 1 < value.length) {
+        current += ch + value[i + 1];
+        i++;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+    if (ch === "{") braces++;
+    else if (ch === "}") braces = Math.max(0, braces - 1);
+    else if (ch === "[") brackets++;
+    else if (ch === "]") brackets = Math.max(0, brackets - 1);
+    else if (ch === "(") parens++;
+    else if (ch === ")") parens = Math.max(0, parens - 1);
+    if (ch === "," && braces === 0 && brackets === 0 && parens === 0) {
+      patterns.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  patterns.push(current.trim());
+  return patterns.filter(Boolean);
+}
+
+/**
  * Schema for URL pattern arguments. Accepts a single pattern as a string or
  * multiple patterns as an array of strings, and normalizes both to an array
- * of trimmed, non-empty patterns. Strings are kept whole so that commas inside
- * a single pattern (e.g. regex quantifiers or glob brace expansion) are
- * preserved.
+ * of trimmed, non-empty patterns. A string is split on top-level commas while
+ * commas inside `{}`, `[]`, or `()` are preserved, so regex quantifiers and
+ * glob brace expansion survive.
  */
 const patternsSchema = z.union([z.string(), z.array(z.string())]).transform((value) => {
-  const patterns = typeof value === "string" ? [value] : value;
-  return patterns.map((p) => p.trim()).filter(Boolean);
+  if (typeof value === "string") return splitPatterns(value);
+  return value.map((p) => p.trim()).filter(Boolean);
 });
 
 /**
@@ -86,12 +130,12 @@ export function createMcpServerInstance(
         includePatterns: patternsSchema
           .optional()
           .describe(
-            "Patterns for including URLs during scraping. Pass a single pattern as a string or multiple patterns as an array. Regex patterns must be wrapped in slashes, e.g. /pattern/. If not set, all are included by default.",
+            "Patterns for including URLs during scraping. Pass one or more patterns as a comma-separated string or as an array. Commas inside { }, [ ] or ( ) are preserved; escape a literal comma with a backslash. Regex patterns must be wrapped in slashes, e.g. /pattern/. If not set, all are included by default.",
           ),
         excludePatterns: patternsSchema
           .optional()
           .describe(
-            "Patterns for excluding URLs during scraping. Pass a single pattern as a string or multiple patterns as an array. Exclude takes precedence over include. Regex patterns must be wrapped in slashes, e.g. /pattern/.",
+            "Patterns for excluding URLs during scraping. Pass one or more patterns as a comma-separated string or as an array. Commas inside { }, [ ] or ( ) are preserved; escape a literal comma with a backslash. Exclude takes precedence over include. Regex patterns must be wrapped in slashes, e.g. /pattern/.",
           ),
       },
       {

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -10,20 +10,16 @@ import type { McpServerTools } from "./tools";
 import { createError, createResponse } from "./utils";
 
 /**
- * Splits a comma-separated pattern string into an array of trimmed, non-empty
- * patterns. MCP tool arguments arrive as a single string; the scraper expects
- * an array.
- * @param patterns The raw comma-separated pattern string.
- * @returns An array of patterns, or undefined if no patterns were provided.
+ * Schema for URL pattern arguments. Accepts a single pattern as a string or
+ * multiple patterns as an array of strings, and normalizes both to an array
+ * of trimmed, non-empty patterns. Strings are kept whole so that commas inside
+ * a single pattern (e.g. regex quantifiers or glob brace expansion) are
+ * preserved.
  */
-function splitPatterns(patterns: string | undefined): string[] | undefined {
-  if (patterns === undefined) return undefined;
-  const items = patterns
-    .split(",")
-    .map((p) => p.trim())
-    .filter(Boolean);
-  return items.length > 0 ? items : undefined;
-}
+const patternsSchema = z.union([z.string(), z.array(z.string())]).transform((value) => {
+  const patterns = typeof value === "string" ? [value] : value;
+  return patterns.map((p) => p.trim()).filter(Boolean);
+});
 
 /**
  * Creates and configures an instance of the MCP server with registered tools and resources.
@@ -87,17 +83,15 @@ export function createMcpServerInstance(
           .boolean()
           .optional()
           .describe("Preserve hash fragments for hash-routed SPA documentation sites."),
-        includePatterns: z
-          .string()
+        includePatterns: patternsSchema
           .optional()
           .describe(
-            "Comma-separated patterns for including URLs during scraping. Regex patterns must be wrapped in slashes, e.g. /pattern/. If not set, all are included by default.",
+            "Patterns for including URLs during scraping. Pass a single pattern as a string or multiple patterns as an array. Regex patterns must be wrapped in slashes, e.g. /pattern/. If not set, all are included by default.",
           ),
-        excludePatterns: z
-          .string()
+        excludePatterns: patternsSchema
           .optional()
           .describe(
-            "Comma-separated patterns for excluding URLs during scraping. Exclude takes precedence over include. Regex patterns must be wrapped in slashes, e.g. /pattern/.",
+            "Patterns for excluding URLs during scraping. Pass a single pattern as a string or multiple patterns as an array. Exclude takes precedence over include. Regex patterns must be wrapped in slashes, e.g. /pattern/.",
           ),
       },
       {
@@ -143,8 +137,8 @@ export function createMcpServerInstance(
               scope,
               followRedirects,
               preserveHashes,
-              includePatterns: splitPatterns(includePatterns),
-              excludePatterns: splitPatterns(excludePatterns),
+              includePatterns,
+              excludePatterns,
             },
           });
 


### PR DESCRIPTION
Adds `includePatterns`/`excludePatterns` support to the MCP `scrape_docs` tool.

## Changes

`src/mcp/mcpServer.ts` (+32):
- Exposes `includePatterns` and `excludePatterns` on the `scrape_docs` tool schema as comma-separated **strings** (regex patterns wrapped in slashes, e.g. `/pattern/`).
- Strings are used instead of arrays so MCP client tool-call renderers (e.g. opencode TUI) display them inline — they silently drop array arguments.
- `splitPatterns()` helper splits the comma-separated string into trimmed, non-empty `string[]` before passing to the scraper (which keeps receiving arrays as before).

The underlying scraper already supported these options; this PR exposes them through the MCP interface.