### PR TITLE
fix(scraper): don't abort scrape when only an llms.txt-seeded url 404s

### DIFF
--- a/src/scraper/strategies/BaseScraperStrategy.test.ts
+++ b/src/scraper/strategies/BaseScraperStrategy.test.ts
@@ -159,6 +159,44 @@ describe("BaseScraperStrategy", () => {
     );
   });
 
+  it("should not abort the scrape when only an llms.txt-seeded url returns NOT_FOUND", async () => {
+    // The real requested root succeeds and seeds a depth-0 llms.txt URL that
+    // 404s. A dead llms.txt entry must not abort a scrape whose actual root
+    // resolved fine.
+    const options: ScraperOptions = {
+      url: "https://example.com/",
+      library: "test",
+      version: "1.0.0",
+      maxPages: 5,
+      maxDepth: 1,
+    };
+    const progressCallback = vi.fn<ProgressCallback<ScraperProgressEvent>>();
+
+    strategy.processItem
+      .mockResolvedValueOnce({
+        content: {
+          textContent: "root content",
+          metadata: {},
+          links: [],
+          errors: [],
+          chunks: [],
+        },
+        links: [],
+        status: FetchStatus.SUCCESS,
+        queueItems: [
+          { url: "https://example.com/llms-seed", depth: 0, fromLlmsTxt: true },
+        ],
+      })
+      .mockResolvedValueOnce({
+        url: "https://example.com/llms-seed",
+        links: [],
+        status: FetchStatus.NOT_FOUND,
+      });
+
+    await expect(strategy.scrape(options, progressCallback)).resolves.not.toThrow();
+    expect(strategy.processItem).toHaveBeenCalledTimes(2);
+  });
+
   it("should treat a tracked root page returning NOT_FOUND during refresh as a deletion", async () => {
     const options: ScraperOptions = {
       url: "https://example.com/",

--- a/src/scraper/strategies/BaseScraperStrategy.ts
+++ b/src/scraper/strategies/BaseScraperStrategy.ts
@@ -294,7 +294,17 @@ export abstract class BaseScraperStrategy implements ScraperStrategy {
                 ),
             );
 
-            if (item.depth === 0 && !isRefreshDeletion && !hasNewFallbackQueueItem) {
+            // Only the user's actual requested root should be fatal on 404 — an
+            // llms.txt-seeded depth-0 item is just one of several discovery seeds
+            // and a dead entry there shouldn't abort a scrape whose real root URL
+            // resolved fine (see llmstxt-discovery spec: llms.txt link failures
+            // are not supposed to fail the overall scrape).
+            if (
+              item.depth === 0 &&
+              !item.fromLlmsTxt &&
+              !isRefreshDeletion &&
+              !hasNewFallbackQueueItem
+            ) {
               throw new ScraperError(`Root page not found: ${item.url}`, false);
             }
 


### PR DESCRIPTION
## Summary

Fixes #478 — a dead `llms.txt` entry can abort an otherwise-successful scrape, even when the actual requested root URL resolves fine.

`llms.txt`-seeded URLs are enqueued at `depth: 0` alongside the user's real input URL (`fromLlmsTxt: true`, per the `llmstxt-discovery` spec). The fail-fast root check in `BaseScraperStrategy.ts` ran for *every* depth-0 item without distinguishing them, so a single dead llms.txt entry threw inside the batch's `Promise.all` and killed the whole job — even though the user's actual root succeeded in that same batch.

This contradicts the `llmstxt-discovery` spec's own stated intent that llms.txt link failures shouldn't fail the overall scrape.

## Repro

`https://docs.litellm.ai/llms.txt` contains a stale entry (leftover Docusaurus boilerplate) pointing at a page that no longer exists:

```
- [Docusaurus Setup Guide](https://docs.litellm.ai/intro): ...
```

Before this fix, scraping *any* URL on that domain failed identically with `Root page not found: https://docs.litellm.ai/intro`, even when the given URL was a real, valid `200` page.

## Fix

Exempt `fromLlmsTxt` items from the fatal root-not-found check — only the user's actual requested root aborts the scrape on 404.

## Test plan

- [x] Added a test confirming a scrape completes when only an llms.txt-seeded URL 404s and the real root succeeds
- [x] Existing test confirming a genuine root 404 (non-llms.txt) still throws continues to pass, unchanged
- [x] `npm run lint`, `npm run typecheck`, `npx vitest run src/scraper/strategies/BaseScraperStrategy.test.ts` all pass
- [x] Verified live against `docs.litellm.ai` with a local build — the site now indexes successfully (500+ pages) instead of failing outright
